### PR TITLE
YT-CPPGL-4: Create the vertex descriptor class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -178,7 +178,7 @@ IntegerLiteralSeparator:
   Hex:              2
   HexMinDigits:     6
 
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 
 ReflowComments: false
 

--- a/include/gl/detail/concepts.hpp
+++ b/include/gl/detail/concepts.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <concepts>
+
+namespace gl::detail {
+
+template <typename T>
+concept c_properties =
+    std::default_initializable<T> and std::copy_constructible<T> and std::move_constructible<T>;
+
+} // namespace gl::detail

--- a/include/gl/detail/concepts.hpp
+++ b/include/gl/detail/concepts.hpp
@@ -6,6 +6,7 @@ namespace gl::detail {
 
 template <typename T>
 concept c_properties =
-    std::default_initializable<T> and std::copy_constructible<T> and std::move_constructible<T>;
+    std::default_initializable<T> and std::copy_constructible<T> and std::move_constructible<T>
+    and std::assignable_from<T&, const T&>;
 
 } // namespace gl::detail

--- a/include/gl/detail/default_types.hpp
+++ b/include/gl/detail/default_types.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace gl::detail {
+
+struct empty_properties {};
+
+} // namespace gl::detail

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -1,10 +1,20 @@
 #pragma once
 
 #include "detail/concepts.hpp"
+#include "detail/default_types.hpp"
 
 namespace gl {
 
-template <detail::c_properties Properties>
+/*
+TODO: define the properties member only when Properties is not void
+Possible solutions:
+- Template specialization
+- std::enable_if_t ?
+Requires:
+- Modification of the c_properties concept to be a valid type or void
+*/
+
+template <detail::c_properties Properties = detail::empty_properties>
 class vertex_descriptor {
 public:
     using properties_type = Properties;
@@ -14,7 +24,8 @@ public:
     vertex_descriptor(const std::size_t id) : _id(id) {}
 
     vertex_descriptor(const std::size_t id, const properties_type& properties)
-    : _list_id(id), _properties(properties) {}
+    requires(not std::is_same_v<properties_type, detail::empty_properties>)
+    : _id(id), properties(properties) {}
 
     vertex_descriptor(const vertex_descriptor&) = default;
     vertex_descriptor(vertex_descriptor&&) = default;

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "detail/concepts.hpp"
+
+namespace gl {
+
+template <detail::c_properties Properties>
+class vertex_descriptor {
+public:
+    using properties_type = Properties;
+
+    vertex_descriptor() = delete;
+
+    vertex_descriptor(const std::size_t id) : _id(id) {}
+
+    vertex_descriptor(const std::size_t id, const properties_type& properties)
+    : _list_id(id), _properties(properties) {}
+
+    vertex_descriptor(const vertex_descriptor&) = default;
+    vertex_descriptor(vertex_descriptor&&) = default;
+
+    vertex_descriptor& operator=(const vertex_descriptor&) = default;
+    vertex_descriptor& operator=(vertex_descriptor&&) = default;
+
+    ~vertex_descriptor() = default;
+
+    [[nodiscard]] inline std::size_t id() const {
+        return this->_id;
+    }
+
+    properties_type properties = properties_type{};
+
+private:
+    std::size_t _id;
+};
+
+} // namespace gl

--- a/tests/source/test_extarnal_libs_config.cpp
+++ b/tests/source/test_extarnal_libs_config.cpp
@@ -36,7 +36,7 @@ int divide(const int numerator, const int denominator) {
 TEST_CASE("addition of integers") {
     int a = 5;
     int b = 10;
-    REQUIRE(add(a, b) == 15);
+    CHECK(add(a, b) == 15);
 }
 
 TEST_CASE("multiplication of floats") {
@@ -97,7 +97,7 @@ TEST_CASE("mock should perform actions correctly") {
     When(Method(config_test_mock, bar).Using(foo_value)).AlwaysReturn(bar_value);
 
     const auto& config_mock_instance = config_test_mock.get();
-    const TestClass test_object{ config_mock_instance };
+    const TestClass test_object{config_mock_instance};
 
     CHECK_EQ(test_object.get_foo(), foo_value);
     CHECK_EQ(test_object.get_bar(foo_value), bar_value);

--- a/tests/source/test_vertex_descriptor.cpp
+++ b/tests/source/test_vertex_descriptor.cpp
@@ -1,0 +1,36 @@
+#include <doctest.h>
+#include <gl/vertex_descriptor.hpp>
+
+#include <type_traits>
+
+using namespace gl;
+
+namespace {
+constexpr std::size_t id = 1234ull;
+} // namespace
+
+namespace gl_testing {
+
+TEST_SUITE_BEGIN("test_vertex_descriptor");
+
+TEST_CASE("id() should return the correct vertex id") {
+    const vertex_descriptor sut{id};
+    CHECK_EQ(sut.id(), id);
+}
+
+TEST_CASE("properties should be properly initialized") {
+    struct visited_property {
+        bool operator==(const visited_property&) const = default;
+
+        bool visited = false;
+    };
+
+    const visited_property visited{true};
+    const vertex_descriptor<visited_property> sut{id, visited};
+
+    CHECK_EQ(sut.properties, visited);
+}
+
+TEST_SUITE_END(); // test_vertex_descriptor
+
+} // namespace gl_testing


### PR DESCRIPTION
Added the `vertex_descriptor` class with the `c_properties` concept and unit tests