### PR TITLE
YT-CPPGL-10: Extend the graph class with a vertex_range methods

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -174,8 +174,8 @@ IntegerLiteralSeparator:
   Binary:           4
   BinaryMinDigits:  6
   Decimal:          3
-  DecimalMinDigits: 5
-  Hex:              2
+  DecimalMinDigits: 7
+  Hex:              4
   HexMinDigits:     6
 
 Cpp11BracedListStyle: true

--- a/.github/workflows/gpp.yaml
+++ b/.github/workflows/gpp.yaml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Prepare
         env:
-          CC:  gcc-11
-          CXX: g++-11
+          CC:  gcc-12
+          CXX: g++-12
         run: |
           cmake -B build -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,15 @@ project(cpp-gl
 
 option(BUILD_TESTS "Build project tests" ON)
 
+# Set the proper cxx standard
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+elseif(CMAKE_CXX_STANDARD LESS 20)
+    message(WARNING "The defined C++ standard (${CMAKE_CXX_STANDARD}) is too low - overriding!")
+    set(CMAKE_CXX_STANDARD 20)
+endif()
+message(STATUS "The C++ standard is set to ${CMAKE_CXX_STANDARD}")
+
 # Define the library target
 add_library(cpp-gl INTERFACE)
 target_include_directories(cpp-gl INTERFACE
@@ -23,8 +32,9 @@ target_include_directories(cpp-gl INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 set_target_properties(cpp-gl PROPERTIES
-    CXX_STANDARD 20
+    CXX_STANDARD ${CMAKE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
 )
 
 # Installation configuration

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -28,6 +28,8 @@ public:
     using vertex_list_type = std::vector<vertex_ptr_type>;
     using vertex_iterator_type = typename vertex_list_type::iterator;
     using vertex_const_iterator_type = typename vertex_list_type::const_iterator;
+    using vertex_reverse_iterator_type = typename vertex_list_type::reverse_iterator;
+    using vertex_const_reverse_iterator_type = typename vertex_list_type::const_reverse_iterator;
 
     using edge_directional_tag = traits::edge_directional_tag<traits_type>;
     using edge_type = traits::edge_type<traits_type>;
@@ -81,6 +83,15 @@ public:
 
     [[nodiscard]] inline types::iterator_range<vertex_const_iterator_type> vertex_crange() const {
         return make_iterator_range(this->_vertices.cbegin(), this->_vertices.cend());
+    }
+
+    [[nodiscard]] inline types::iterator_range<vertex_reverse_iterator_type> vertex_rrange() {
+        return make_iterator_range(this->_vertices.rbegin(), this->_vertices.rend());
+    }
+
+    [[nodiscard]] inline types::iterator_range<vertex_const_reverse_iterator_type> vertex_crrange(
+    ) const {
+        return make_iterator_range(this->_vertices.crbegin(), this->_vertices.crend());
     }
 
     void remove_vertex(const vertex_ptr_type& vertex) {

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -19,6 +19,8 @@ public:
     using difference_type = std::ptrdiff_t;
     using value_type = std::remove_reference_t<typename iterator_type::value_type>;
 
+    iterator_range() = delete;
+
     explicit iterator_range(iterator_type begin, iterator_type end) : _range(begin, end) {}
 
     template <std::ranges::range Range>

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -13,6 +13,9 @@ template <std::forward_iterator Iterator>
 class iterator_range {
 public:
     using iterator_type = Iterator;
+#if __cplusplus >= 202302L
+    using const_iterator_type = std::const_iterator<Iterator>;
+#endif
     using difference_type = std::ptrdiff_t;
     using value_type = std::remove_reference_t<typename iterator_type::value_type>;
 
@@ -40,6 +43,16 @@ public:
         return this->_range.second;
     }
 
+#if __cplusplus >= 202302L
+    [[nodiscard]] inline auto cbegin() const {
+        return std::make_const_iterator(this->_range.first);
+    }
+
+    [[nodiscard]] inline auto cend() const {
+        return std::make_const_iterator(this->_range.second);
+    }
+#endif
+
     [[nodiscard]] inline difference_type distance() const {
         return std::ranges::distance(this->begin(), this->end());
     }
@@ -48,16 +61,18 @@ public:
         return *std::ranges::next(this->begin(), n);
     }
 
-    inline void advance_begin(difference_type n) {
+    inline void advance_begin(difference_type n = _default_n) {
         std::ranges::advance(this->_range.first, n);
     }
 
-    inline void advance_end(difference_type n) {
+    inline void advance_end(difference_type n = _default_n) {
         std::ranges::advance(this->_range.second, n);
     }
 
 private:
     homogeneous_pair<iterator_type> _range;
+
+    static constexpr difference_type _default_n = 1;
 };
 
 } // namespace types

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,10 +23,11 @@ endif()
 add_executable(run ${SOURCES})
 set_target_properties(run PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${EXECUTABLE_DIR}"
-    CXX_STANDARD 20
+    CXX_STANDARD ${CMAKE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
 target_include_directories(run PRIVATE ${INCLUDE_DIRS})
 target_compile_options(run PRIVATE ${CMAKE_CXX_FLAGS})
+target_compile_definitions(run PRIVATE GL_TESTING)
 target_link_libraries(run PRIVATE cpp-gl)

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -11,6 +11,11 @@ TEST_SUITE_BEGIN("test_graph");
 
 struct test_graph {
     lib::graph<> sut;
+
+    template <lib_d::c_instantiation_of<lib::graph> GraphType>
+    typename GraphType::vertex_list_type& get_vertex_list(GraphType& graph) {
+        return graph._vertices;
+    }
 };
 
 TEST_CASE_FIXTURE(test_graph, "graph should be initialized with no vertices by default") {
@@ -22,11 +27,9 @@ TEST_CASE("graph constructed with no_vertices parameter should properly initiali
     lib::graph<> sut{constants::no_vertices};
     CHECK_EQ(sut.no_vertices(), constants::no_vertices);
 
-    // TODO: replace with iterator range
-    for (lib_t::id_type v_id = 0ull; v_id < constants::no_vertices; v_id++) {
-        CHECK_NOTHROW(static_cast<void>(sut.get_vertex(v_id)));
-        CHECK_EQ(sut.get_vertex(v_id)->id(), v_id);
-    }
+    lib_t::id_type v_id = constants::vertex_id_1;
+    for (const auto& vertex : sut.vertex_crange())
+        CHECK_EQ(vertex->id(), v_id++);
 }
 
 TEST_CASE_FIXTURE(
@@ -65,20 +68,29 @@ TEST_CASE_FIXTURE(test_graph, "get_vertex should return a vertex with the given 
     CHECK_EQ(*sut.get_vertex(added_vertex->id()), *added_vertex);
 }
 
+TEST_CASE_FIXTURE(test_graph, "vertex_range should return the correct vertex list iterator range") {
+    const auto v_range = sut.vertex_range();
+    CHECK(std::ranges::equal(v_range, get_vertex_list(sut)));
+}
+
 TEST_CASE("remove_vertex should remove the given vertex and align ids of remaining vertices") {
     lib::graph<> sut{constants::no_vertices};
     CHECK_EQ(sut.no_vertices(), constants::no_vertices);
 
     sut.remove_vertex(sut.get_vertex(constants::vertex_id_1));
 
-    constexpr lib_t::id_type last_vertex_id = constants::no_vertices - constants::one_vertex;
-    REQUIRE_THROWS_AS(static_cast<void>(sut.get_vertex(last_vertex_id)), std::out_of_range);
+    constexpr lib_t::id_type no_vertices_after_remove =
+        constants::no_vertices - constants::one_vertex;
 
-    // TODO: replace with iterator range
-    for (lib_t::id_type v_id = constants::vertex_id_1; v_id < last_vertex_id; v_id++) {
-        CHECK_NOTHROW(static_cast<void>(sut.get_vertex(v_id)));
-        CHECK_EQ(sut.get_vertex(v_id)->id(), v_id);
-    }
+    CHECK_EQ(sut.no_vertices(), no_vertices_after_remove);
+    REQUIRE_THROWS_AS(
+        static_cast<void>(sut.get_vertex(no_vertices_after_remove)), std::out_of_range
+    );
+
+    CHECK(std::ranges::equal(
+        sut.vertex_range() | std::views::transform([](const auto& vertex) { return vertex->id(); }),
+        std::views::iota(constants::vertex_id_1, no_vertices_after_remove)
+    ));
 }
 
 TEST_SUITE_END(); // test_graph

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -68,9 +68,24 @@ TEST_CASE_FIXTURE(test_graph, "get_vertex should return a vertex with the given 
     CHECK_EQ(*sut.get_vertex(added_vertex->id()), *added_vertex);
 }
 
-TEST_CASE_FIXTURE(test_graph, "vertex_range should return the correct vertex list iterator range") {
+TEST_CASE_FIXTURE(
+    test_graph, "vertex_(c)range should return the correct vertex list iterator range"
+) {
     const auto v_range = sut.vertex_range();
     CHECK(std::ranges::equal(v_range, get_vertex_list(sut)));
+
+    const auto v_crange = sut.vertex_crange();
+    CHECK(std::ranges::equal(v_crange, get_vertex_list(sut)));
+}
+
+TEST_CASE_FIXTURE(
+    test_graph, "vertex_(c)rrange should return the correct vertex list reverse iterator range"
+) {
+    const auto v_rrange = sut.vertex_rrange();
+    CHECK(std::ranges::equal(v_rrange, get_vertex_list(sut)));
+
+    const auto v_crrange = sut.vertex_crrange();
+    CHECK(std::ranges::equal(v_crrange, get_vertex_list(sut)));
 }
 
 TEST_CASE("remove_vertex should remove the given vertex and align ids of remaining vertices") {

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -2,6 +2,7 @@
 
 #include <doctest.h>
 
+#include <algorithm>
 #include <forward_list>
 #include <list>
 #include <numeric>
@@ -40,6 +41,11 @@ TEST_CASE_TEMPLATE_DEFINE("common iterator_range tests", ContainerType, containe
     SUBCASE("should properly initialze the begin and end iterators") {
         CHECK_EQ(sut.begin(), container.begin());
         CHECK_EQ(sut.end(), container.end());
+
+#if __cplusplus >= 202302L
+        CHECK_EQ(sut.cbegin(), container.cbegin());
+        CHECK_EQ(sut.cend(), container.cend());
+#endif
     }
 
     SUBCASE("should properly initialize the begin and end iterator for a range constructor") {
@@ -47,6 +53,11 @@ TEST_CASE_TEMPLATE_DEFINE("common iterator_range tests", ContainerType, containe
 
         CHECK_EQ(range_constructed_sut.begin(), std::ranges::begin(container));
         CHECK_EQ(range_constructed_sut.end(), std::ranges::end(container));
+
+#if __cplusplus >= 202302L
+        CHECK_EQ(range_constructed_sut.cbegin(), std::ranges::cbegin(container));
+        CHECK_EQ(range_constructed_sut.cend(), std::ranges::cend(container));
+#endif
     }
 
     SUBCASE("equality operator should return true only when both iterators are equal") {
@@ -67,6 +78,18 @@ TEST_CASE_TEMPLATE_DEFINE("common iterator_range tests", ContainerType, containe
 
         for (const std::size_t range_element : sut)
             CHECK_EQ(range_element, element++);
+    }
+
+    SUBCASE("should be compatible with std functions") {
+        CHECK(std::equal(std::begin(sut), std::end(sut), container.begin()));
+
+#if __cplusplus >= 202302L
+        CHECK(std::equal(std::cbegin(sut), std::cend(sut), container.cbegin()));
+#endif
+    }
+
+    SUBCASE("should be compatible with std::ranges functions") {
+        CHECK(std::ranges::equal(sut, container));
     }
 
     SUBCASE("distance should return the distance between begin and end iterators") {


### PR DESCRIPTION
- Added the cbegin and cend methods to the iterator_range class (C++23 required)
- Added the vertex_(c)(r)range methods which return the respective vertex range types
- Modified the gpp workflow to use g++-12