### PR TITLE
YT-CPPGL-12: Create the adjacency_matrix graph implementation

### DIFF
--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -92,7 +92,7 @@ public:
         return *this->_vertices.first == *this->_vertices.second;
     }
 
-    properties_type properties = {};
+    [[no_unique_address]] properties_type properties = {};
 
 private:
     types::homogeneous_pair<vertex_ptr_type> _vertices;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -99,7 +99,7 @@ public:
     }
 
     [[nodiscard]] inline types::iterator_range<vertex_const_iterator_type> vertex_crange() const {
-        return make_iterator_range(this->_vertices.cbegin(), this->_vertices.cend());
+        return make_const_iterator_range(this->_vertices);
     }
 
     [[nodiscard]] inline types::iterator_range<vertex_reverse_iterator_type> vertex_rrange() {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -57,12 +57,12 @@ public:
         this->_list.push_back(edge_set_type{});
     }
 
-    inline void remove_vertex(const vertex_ptr_type& vertex) {
-        specialized::remove_vertex(*this, vertex);
-    }
-
     inline void add_edge(edge_ptr_type edge) {
         specialized::add_edge(*this, std::move(edge));
+    }
+
+    inline void remove_vertex(const vertex_ptr_type& vertex) {
+        specialized::remove_vertex(*this, vertex);
     }
 
     inline void remove_edge(const edge_ptr_type& edge) {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -6,7 +6,6 @@
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_list.hpp"
 
-#include <algorithm>
 #include <vector>
 
 namespace gl::impl {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -21,8 +21,8 @@ public:
     using edge_directional_tag = type_traits::edge_directional_tag<GraphTraits>;
 
     using edge_set_type = std::vector<edge_ptr_type>;
-    using edge_iterator_type = typename edge_set_type::iterator;
-    using edge_const_iterator_type = typename edge_set_type::const_iterator;
+    using edge_iterator_type = type_traits::iterator_type<edge_set_type>;
+    using edge_const_iterator_type = type_traits::const_iterator_type<edge_set_type>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -78,8 +78,7 @@ public:
     [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
         const types::id_type vertex_id
     ) const {
-        const auto& adjacent_edges = this->_list.at(vertex_id);
-        return make_iterator_range(adjacent_edges.cbegin(), adjacent_edges.cend());
+        return make_const_iterator_range(this->_list.at(vertex_id));
     }
 
 private:

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -120,11 +120,14 @@ public:
     requires(type_traits::is_undirected_v<edge_type>)
     {
         const auto edge_addr = edge.get();
-        auto& adj_edges_first = this->_list.at(edge->first()->id());
-        auto& adj_edges_second = this->_list.at(edge->second()->id());
+        auto& adjacent_edges_first = this->_list.at(edge->first()->id());
+        auto& adjacent_edges_second = this->_list.at(edge->second()->id());
 
-        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge_addr, address_projection{}));
-        adj_edges_second.erase(std::ranges::find(adj_edges_second, edge_addr, address_projection{})
+        adj_edges_first.erase(
+            std::ranges::find(adjacent_edges_first, edge_addr, address_projection{})
+        );
+        adj_edges_second.erase(
+            std::ranges::find(adjacent_edges_second, edge_addr, address_projection{})
         );
         this->_no_unique_edges--;
     }
@@ -133,6 +136,13 @@ public:
         const types::id_type vertex_id
     ) {
         return make_iterator_range(this->_list.at(vertex_id));
+    }
+
+    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
+        const types::id_type vertex_id
+    ) const {
+        const auto& adjacent_edges = this->_list.at(vertex_id);
+        return make_iterator_range(adjacent_edges.cbegin(), adjacent_edges.cend());
     }
 
 private:

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -66,7 +66,7 @@ public:
     }
 
     inline void remove_edge(const edge_ptr_type& edge) {
-        specialized::template remove_edge<address_projection>(*this, edge);
+        specialized::remove_edge(*this, edge);
     }
 
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -78,7 +78,7 @@ public:
     }
 
     inline void remove_edge(const edge_ptr_type& edge) {
-        // specialized::template remove_edge<address_projection>(*this, edge);
+        specialized::remove_edge(*this, edge);
     }
 
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -21,8 +21,8 @@ public:
     using edge_directional_tag = type_traits::edge_directional_tag<GraphTraits>;
 
     using edge_set_type = std::vector<edge_ptr_type>;
-    using edge_iterator_type = typename edge_set_type::iterator;
-    using edge_const_iterator_type = typename edge_set_type::const_iterator;
+    using edge_iterator_type = type_traits::iterator_type<edge_set_type>;
+    using edge_const_iterator_type = type_traits::const_iterator_type<edge_set_type>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -53,6 +53,18 @@ public:
 
     [[nodiscard]] inline types::size_type no_unique_edges() const {
         return this->_no_unique_edges;
+    }
+
+    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
+        const types::id_type vertex_id
+    ) {
+        return make_iterator_range(this->_list.at(vertex_id));
+    }
+
+    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
+        const types::id_type vertex_id
+    ) const {
+        return make_const_iterator_range(this->_list.at(vertex_id));
     }
 
 private:

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -74,7 +74,7 @@ public:
     }
 
     inline void remove_vertex(const vertex_ptr_type& vertex) {
-        // specialized::remove_vertex(*this, vertex);
+        specialized::remove_vertex(*this, vertex);
     }
 
     inline void remove_edge(const edge_ptr_type& edge) {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -68,19 +68,17 @@ public:
         std::generate_n(std::back_inserter(new_row), this->no_vertices(), _make_null_edge);
     }
 
-    /*
-    inline void remove_vertex(const vertex_ptr_type& vertex) {
-        specialized::remove_vertex(*this, vertex);
-    }
-
     inline void add_edge(edge_ptr_type edge) {
         specialized::add_edge(*this, std::move(edge));
     }
 
-    inline void remove_edge(const edge_ptr_type& edge) {
-        specialized::template remove_edge<address_projection>(*this, edge);
+    inline void remove_vertex(const vertex_ptr_type& vertex) {
+        // specialized::remove_vertex(*this, vertex);
     }
-    */
+
+    inline void remove_edge(const edge_ptr_type& edge) {
+        // specialized::template remove_edge<address_projection>(*this, edge);
+    }
 
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -33,8 +33,13 @@ public:
 
     adjacency_matrix() = default;
 
-    adjacency_matrix(const types::size_type no_vertices)
-    : _matrix(no_vertices, edge_set_type(no_vertices)) {}
+    adjacency_matrix(const types::size_type no_vertices) : _matrix(no_vertices) {
+        constexpr auto make_null_edge = []() { return nullptr; };
+        for (auto& matrix_row : this->_matrix) {
+            matrix_row.reserve(no_vertices);
+            std::generate_n(std::back_inserter(matrix_row), no_vertices, make_null_edge);
+        }
+    }
 
     adjacency_matrix(adjacency_matrix&&) = default;
     adjacency_matrix& operator=(adjacency_matrix&&) = default;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "gl/graph_traits.hpp"
+#include "gl/types/iterator_range.hpp"
+#include "gl/types/type_traits.hpp"
+#include "gl/types/types.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace gl::impl {
+
+template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+class adjacency_matrix {
+public:
+    using vertex_type = type_traits::vertex_type<GraphTraits>;
+    using vertex_ptr_type = type_traits::vertex_ptr_type<GraphTraits>;
+
+    using edge_type = type_traits::edge_type<GraphTraits>;
+    using edge_ptr_type = type_traits::edge_ptr_type<GraphTraits>;
+    using edge_directional_tag = type_traits::edge_directional_tag<GraphTraits>;
+
+    using edge_set_type = std::vector<edge_ptr_type>;
+    using edge_iterator_type = typename edge_set_type::iterator;
+    using edge_const_iterator_type = typename edge_set_type::const_iterator;
+
+    // TODO: reverese iterators should be available for bidirectional ranges
+
+    using type = std::vector<edge_set_type>;
+
+    adjacency_matrix(const adjacency_matrix&) = delete;
+    adjacency_matrix& operator=(const adjacency_matrix&) = delete;
+
+    adjacency_matrix() = default;
+
+    adjacency_matrix(const types::size_type no_vertices)
+    : _matrix(no_vertices, edge_set_type(no_vertices)) {}
+
+    adjacency_matrix(adjacency_matrix&&) = default;
+    adjacency_matrix& operator=(adjacency_matrix&&) = default;
+
+    ~adjacency_matrix() = default;
+
+    [[nodiscard]] inline types::size_type no_vertices() const {
+        return this->_matrix.size();
+    }
+
+    [[nodiscard]] inline types::size_type no_unique_edges() const {
+        return this->_no_unique_edges;
+    }
+
+private:
+    type _matrix = {};
+    types::size_type _no_unique_edges = 0ull;
+};
+
+} // namespace gl::impl

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -4,8 +4,8 @@
 #include "gl/types/iterator_range.hpp"
 #include "gl/types/type_traits.hpp"
 #include "gl/types/types.hpp"
+#include "specialized/adjacency_matrix.hpp"
 
-#include <algorithm>
 #include <vector>
 
 namespace gl::impl {
@@ -28,17 +28,18 @@ public:
 
     using type = std::vector<edge_set_type>;
 
+private:
+    using specialized = specialized::impl_type<adjacency_matrix>;
+    friend specialized;
+
+public:
     adjacency_matrix(const adjacency_matrix&) = delete;
     adjacency_matrix& operator=(const adjacency_matrix&) = delete;
 
     adjacency_matrix() = default;
 
     adjacency_matrix(const types::size_type no_vertices) : _matrix(no_vertices) {
-        constexpr auto make_null_edge = []() { return nullptr; };
-        for (auto& matrix_row : this->_matrix) {
-            matrix_row.reserve(no_vertices);
-            std::generate_n(std::back_inserter(matrix_row), no_vertices, make_null_edge);
-        }
+        specialized::construct(*this, no_vertices);
     }
 
     adjacency_matrix(adjacency_matrix&&) = default;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -5,6 +5,7 @@
 #include "gl/types/type_traits.hpp"
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_matrix.hpp"
+#include "gl/types/non_null_iterator.hpp"
 
 #include <vector>
 
@@ -21,8 +22,8 @@ public:
     using edge_directional_tag = type_traits::edge_directional_tag<GraphTraits>;
 
     using edge_set_type = std::vector<edge_ptr_type>;
-    using edge_iterator_type = type_traits::iterator_type<edge_set_type>;
-    using edge_const_iterator_type = type_traits::const_iterator_type<edge_set_type>;
+    using edge_iterator_type = types::non_null_iterator<type_traits::iterator_type<edge_set_type>>;
+    using edge_const_iterator_type = types::non_null_iterator<type_traits::const_iterator_type<edge_set_type>>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -39,7 +40,11 @@ public:
     adjacency_matrix() = default;
 
     adjacency_matrix(const types::size_type no_vertices) : _matrix(no_vertices) {
-        specialized::construct(*this, no_vertices);
+        // initialize a full n x n matrix with null elements
+        for (auto& row : this->_matrix) {
+            row.reserve(no_vertices);
+            std::generate_n(std::back_inserter(row), no_vertices, _make_null_edge);
+        }
     }
 
     adjacency_matrix(adjacency_matrix&&) = default;
@@ -55,19 +60,47 @@ public:
         return this->_no_unique_edges;
     }
 
+    void add_vertex() {
+        for (auto& row : this->_matrix)
+            row.push_back(_make_null_edge());
+        auto& new_row = this->_matrix.emplace_back();
+        new_row.reserve(this->no_vertices());
+        std::generate_n(std::back_inserter(new_row), this->no_vertices(), _make_null_edge);
+    }
+
+    /*
+    inline void remove_vertex(const vertex_ptr_type& vertex) {
+        specialized::remove_vertex(*this, vertex);
+    }
+
+    inline void add_edge(edge_ptr_type edge) {
+        specialized::add_edge(*this, std::move(edge));
+    }
+
+    inline void remove_edge(const edge_ptr_type& edge) {
+        specialized::template remove_edge<address_projection>(*this, edge);
+    }
+    */
+
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) {
-        return make_iterator_range(this->_list.at(vertex_id));
+        auto& row = this->_matrix.at(vertex_id);
+        return make_iterator_range(non_null_begin(row), non_null_end(row));
     }
 
     [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
         const types::id_type vertex_id
     ) const {
-        return make_const_iterator_range(this->_list.at(vertex_id));
+        const auto& row = this->_matrix.at(vertex_id);
+        return make_iterator_range(non_null_cbegin(row), non_null_cend(row));
     }
 
 private:
+    static constexpr edge_ptr_type _make_null_edge() {
+        return nullptr;
+    }
+
     type _matrix = {};
     types::size_type _no_unique_edges = 0ull;
 };

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -2,10 +2,10 @@
 
 #include "gl/graph_traits.hpp"
 #include "gl/types/iterator_range.hpp"
+#include "gl/types/non_null_iterator.hpp"
 #include "gl/types/type_traits.hpp"
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_matrix.hpp"
-#include "gl/types/non_null_iterator.hpp"
 
 #include <vector>
 
@@ -23,7 +23,8 @@ public:
 
     using edge_set_type = std::vector<edge_ptr_type>;
     using edge_iterator_type = types::non_null_iterator<type_traits::iterator_type<edge_set_type>>;
-    using edge_const_iterator_type = types::non_null_iterator<type_traits::const_iterator_type<edge_set_type>>;
+    using edge_const_iterator_type =
+        types::non_null_iterator<type_traits::const_iterator_type<edge_set_type>>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -12,14 +12,12 @@ class adjacency_list;
 
 namespace specialized {
 
-// directed adjacency_list
-
 template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
 requires(type_traits::is_directed_v<typename AdjacencyList::edge_type>)
 struct directed_adjacency_list {
     using impl_type = AdjacencyList;
 
-    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+    static inline void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
         self._list.at(edge->first()->id()).push_back(std::move(edge));
         self._no_unique_edges++;
     }

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "gl/graph_traits.hpp"
+#include "gl/types/type_traits.hpp"
+
+#include <algorithm>
+
+namespace gl::impl {
+
+template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+class adjacency_list;
+
+namespace specialized {
+
+// directed adjacency_list
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+requires(type_traits::is_directed_v<typename AdjacencyList::edge_type>)
+struct directed_adjacency_list {
+    using impl_type = AdjacencyList;
+
+    static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
+        for (auto& adj_edges : self._list) {
+            const auto rem_subrange = std::ranges::remove_if(
+                adj_edges, [&vertex](const auto& edge) { return edge->is_incident_with(vertex); }
+            );
+            self._no_unique_edges -=
+                std::ranges::distance(rem_subrange.begin(), rem_subrange.end());
+            adj_edges.erase(rem_subrange.begin(), rem_subrange.end());
+        }
+        self._list.erase(std::next(std::begin(self._list), vertex->id()));
+    }
+
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        self._list.at(edge->first()->id()).push_back(std::move(edge));
+        self._no_unique_edges++;
+    }
+
+    template <typename IdProjection>
+    static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
+        auto& adj_edges = self._list.at(edge->first()->id());
+        adj_edges.erase(std::ranges::find(adj_edges, edge.get(), IdProjection{}));
+        self._no_unique_edges--;
+    }
+};
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+requires(type_traits::is_undirected_v<typename AdjacencyList::edge_type>)
+struct undirected_adjacency_list {
+    using impl_type = AdjacencyList;
+
+    static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
+        // TODO: optimize for multiedges
+        // * the edges adjacent to incident_vertex should be processed once
+
+        const auto vertex_id = vertex->id();
+
+        for (const auto& edge : self._list.at(vertex_id)) {
+            const auto incident_vertex = edge->incident_vertex(vertex);
+            if (*incident_vertex == *vertex)
+                continue; // loop: will be removed with the vertex's list
+
+            auto& adj_edges = self._list.at(incident_vertex->id());
+            const auto rem_subrange = std::ranges::remove_if(
+                adj_edges, [&vertex](const auto& edge) { return edge->is_incident_with(vertex); }
+            );
+            adj_edges.erase(rem_subrange.begin(), rem_subrange.end());
+        }
+
+        self._no_unique_edges -= self._list.at(vertex_id).size();
+        self._list.erase(std::next(std::begin(self._list), vertex_id));
+    }
+
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        self._list.at(edge->first()->id()).push_back(edge);
+        if (not edge->is_loop())
+            self._list.at(edge->second()->id()).push_back(edge);
+        self._no_unique_edges++;
+    }
+
+    template <typename IdProjection>
+    static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
+        const auto edge_addr = edge.get();
+        auto& adj_edges_first = self._list.at(edge->first()->id());
+        auto& adj_edges_second = self._list.at(edge->second()->id());
+
+        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge_addr, IdProjection{}));
+        adj_edges_second.erase(std::ranges::find(adj_edges_second, edge_addr, IdProjection{}));
+        self._no_unique_edges--;
+    }
+};
+
+// common utility
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+struct list_impl_traits {
+    using specialized_type = void;
+};
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+requires(type_traits::is_directed_v<typename AdjacencyList::edge_type>)
+struct list_impl_traits<AdjacencyList> {
+    using specialized_type = directed_adjacency_list<AdjacencyList>;
+};
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+requires(type_traits::is_undirected_v<typename AdjacencyList::edge_type>)
+struct list_impl_traits<AdjacencyList> {
+    using specialized_type = undirected_adjacency_list<AdjacencyList>;
+};
+
+template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
+using impl_type = typename list_impl_traits<AdjacencyList>::specialized_type;
+
+} // namespace specialized
+
+} // namespace gl::impl

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -19,6 +19,11 @@ requires(type_traits::is_directed_v<typename AdjacencyList::edge_type>)
 struct directed_adjacency_list {
     using impl_type = AdjacencyList;
 
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        self._list.at(edge->first()->id()).push_back(std::move(edge));
+        self._no_unique_edges++;
+    }
+
     static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
         for (auto& adj_edges : self._list) {
             const auto rem_subrange = std::ranges::remove_if(
@@ -29,11 +34,6 @@ struct directed_adjacency_list {
             adj_edges.erase(rem_subrange.begin(), rem_subrange.end());
         }
         self._list.erase(std::next(std::begin(self._list), vertex->id()));
-    }
-
-    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
-        self._list.at(edge->first()->id()).push_back(std::move(edge));
-        self._no_unique_edges++;
     }
 
     template <typename IdProjection>
@@ -48,6 +48,13 @@ template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
 requires(type_traits::is_undirected_v<typename AdjacencyList::edge_type>)
 struct undirected_adjacency_list {
     using impl_type = AdjacencyList;
+
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        self._list.at(edge->first()->id()).push_back(edge);
+        if (not edge->is_loop())
+            self._list.at(edge->second()->id()).push_back(edge);
+        self._no_unique_edges++;
+    }
 
     static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
         // TODO: optimize for multiedges
@@ -69,13 +76,6 @@ struct undirected_adjacency_list {
 
         self._no_unique_edges -= self._list.at(vertex_id).size();
         self._list.erase(std::next(std::begin(self._list), vertex_id));
-    }
-
-    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
-        self._list.at(edge->first()->id()).push_back(edge);
-        if (not edge->is_loop())
-            self._list.at(edge->second()->id()).push_back(edge);
-        self._no_unique_edges++;
     }
 
     template <typename IdProjection>

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -36,10 +36,11 @@ struct directed_adjacency_list {
         self._list.erase(std::next(std::begin(self._list), vertex->id()));
     }
 
-    template <typename IdProjection>
     static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
+        using id_projection = typename impl_type::address_projection;
+
         auto& adj_edges = self._list.at(edge->first()->id());
-        adj_edges.erase(std::ranges::find(adj_edges, edge.get(), IdProjection{}));
+        adj_edges.erase(std::ranges::find(adj_edges, edge.get(), id_projection{}));
         self._no_unique_edges--;
     }
 };
@@ -78,14 +79,16 @@ struct undirected_adjacency_list {
         self._list.erase(std::next(std::begin(self._list), vertex_id));
     }
 
-    template <typename IdProjection>
     static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
+        using id_projection = typename impl_type::address_projection;
+
         const auto edge_addr = edge.get();
         auto& adj_edges_first = self._list.at(edge->first()->id());
         auto& adj_edges_second = self._list.at(edge->second()->id());
 
-        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge_addr, IdProjection{}));
-        adj_edges_second.erase(std::ranges::find(adj_edges_second, edge_addr, IdProjection{}));
+        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge_addr, id_projection{}));
+        if (not edge->is_loop())
+            adj_edges_second.erase(std::ranges::find(adj_edges_second, edge_addr, id_projection{}));
         self._no_unique_edges--;
     }
 };

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "gl/graph_traits.hpp"
+#include "gl/types/type_traits.hpp"
+
+#include <algorithm>
+
+namespace gl::impl {
+
+template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+class adjacency_matrix;
+
+namespace specialized {
+
+namespace detail {
+
+constexpr auto make_null_edge = []() { return nullptr; };
+
+} // namespace detail
+
+// directed adjacency_matrix
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+requires(type_traits::is_directed_v<typename AdjacencyMatrix::edge_type>)
+struct directed_adjacency_list {
+    using impl_type = AdjacencyMatrix;
+
+    static void construct(impl_type& self, const types::size_type no_vertices) {
+        // initialize a full n x n matrix
+        for (auto& row : self._matrix) {
+            row.reserve(no_vertices);
+            std::generate_n(std::back_inserter(row), no_vertices, detail::make_null_edge);
+        }
+    }
+};
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+requires(type_traits::is_undirected_v<typename AdjacencyMatrix::edge_type>)
+struct undirected_adjacency_list {
+    using impl_type = AdjacencyMatrix;
+
+    static void construct(impl_type& self, const types::size_type no_vertices) {
+        // initialize a (lower) triangular n x n matrix
+        for (types::size_type row_idx = 0ull; row_idx < no_vertices; row_idx++) {
+            auto& row = self._matrix[row_idx];
+            const auto row_size = row_idx + 1ull;
+
+            row.reserve(row_size);
+            std::generate_n(std::back_inserter(row), row_size, detail::make_null_edge);
+        }
+    }
+};
+
+// common utility
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+struct matrix_impl_traits {
+    using specialized_type = void;
+};
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+requires(type_traits::is_directed_v<typename AdjacencyMatrix::edge_type>)
+struct matrix_impl_traits<AdjacencyMatrix> {
+    using specialized_type = directed_adjacency_list<AdjacencyMatrix>;
+};
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+requires(type_traits::is_undirected_v<typename AdjacencyMatrix::edge_type>)
+struct matrix_impl_traits<AdjacencyMatrix> {
+    using specialized_type = undirected_adjacency_list<AdjacencyMatrix>;
+};
+
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+using impl_type = typename matrix_impl_traits<AdjacencyMatrix>::specialized_type;
+
+} // namespace specialized
+
+} // namespace gl::impl

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -18,12 +18,27 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(type_traits::is_directed_v<typename AdjacencyMatrix::edge_type>)
 struct directed_adjacency_list {
     using impl_type = AdjacencyMatrix;
+
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        self._matrix.at(edge->first()->id()).at(edge->second()->id()) = std::move(edge);
+        self._no_unique_edges++;
+    }
 };
 
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(type_traits::is_undirected_v<typename AdjacencyMatrix::edge_type>)
 struct undirected_adjacency_list {
     using impl_type = AdjacencyMatrix;
+
+    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+        const auto first_id = edge->first()->id();
+        const auto second_id = edge->second()->id();
+
+        self._matrix.at(first_id).at(second_id) = edge;
+        if (not edge->is_loop())
+            self._matrix.at(second_id).at(first_id) = edge;
+        self._no_unique_edges++;
+    }
 };
 
 // common utility

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -12,43 +12,18 @@ class adjacency_matrix;
 
 namespace specialized {
 
-namespace detail {
-
-constexpr auto make_null_edge = []() { return nullptr; };
-
-} // namespace detail
-
 // directed adjacency_matrix
 
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(type_traits::is_directed_v<typename AdjacencyMatrix::edge_type>)
 struct directed_adjacency_list {
     using impl_type = AdjacencyMatrix;
-
-    static void construct(impl_type& self, const types::size_type no_vertices) {
-        // initialize a full n x n matrix
-        for (auto& row : self._matrix) {
-            row.reserve(no_vertices);
-            std::generate_n(std::back_inserter(row), no_vertices, detail::make_null_edge);
-        }
-    }
 };
 
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(type_traits::is_undirected_v<typename AdjacencyMatrix::edge_type>)
 struct undirected_adjacency_list {
     using impl_type = AdjacencyMatrix;
-
-    static void construct(impl_type& self, const types::size_type no_vertices) {
-        // initialize a (lower) triangular n x n matrix
-        for (types::size_type row_idx = 0ull; row_idx < no_vertices; row_idx++) {
-            auto& row = self._matrix[row_idx];
-            const auto row_size = row_idx + 1ull;
-
-            row.reserve(row_size);
-            std::generate_n(std::back_inserter(row), row_size, detail::make_null_edge);
-        }
-    }
 };
 
 // common utility

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -24,6 +24,19 @@ struct directed_adjacency_matrix {
         self._no_unique_edges++;
     }
 
+    static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
+        const auto vertex_id = vertex->id();
+
+        self._no_unique_edges -= self.adjacent_edges_c(vertex_id).distance();
+        self._matrix.erase(std::next(std::begin(self._matrix), vertex->id()));
+
+        for (auto& row : self._matrix) {
+            const auto vertex_it = std::next(std::begin(row), vertex_id);
+            self._no_unique_edges -= static_cast<types::size_type>(*vertex_it != nullptr);
+            row.erase(vertex_it);
+        }
+    }
+
     static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
         self._matrix.at(edge->first()->id()).at(edge->second()->id()) = nullptr;
         self._no_unique_edges--;
@@ -43,6 +56,16 @@ struct undirected_adjacency_matrix {
         if (not edge->is_loop())
             self._matrix.at(second_id).at(first_id) = edge;
         self._no_unique_edges++;
+    }
+
+    static void remove_vertex(impl_type& self, const typename impl_type::vertex_ptr_type& vertex) {
+        const auto vertex_id = vertex->id();
+
+        self._no_unique_edges -= self.adjacent_edges_c(vertex_id).distance();
+        self._matrix.erase(std::next(std::begin(self._matrix), vertex->id()));
+
+        for (auto& row : self._matrix)
+            row.erase(std::next(std::begin(row), vertex_id));
     }
 
     static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -12,14 +12,12 @@ class adjacency_matrix;
 
 namespace specialized {
 
-// directed adjacency_matrix
-
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(type_traits::is_directed_v<typename AdjacencyMatrix::edge_type>)
 struct directed_adjacency_matrix {
     using impl_type = AdjacencyMatrix;
 
-    static void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
+    static inline void add_edge(impl_type& self, typename impl_type::edge_ptr_type edge) {
         self._matrix.at(edge->first()->id()).at(edge->second()->id()) = std::move(edge);
         self._no_unique_edges++;
     }
@@ -37,7 +35,7 @@ struct directed_adjacency_matrix {
         }
     }
 
-    static void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
+    static inline void remove_edge(impl_type& self, const typename impl_type::edge_ptr_type& edge) {
         self._matrix.at(edge->first()->id()).at(edge->second()->id()) = nullptr;
         self._no_unique_edges--;
     }

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -57,6 +57,7 @@ public:
 #endif
 
     [[nodiscard]] inline difference_type distance() const {
+        // TODO: keep the current distance as a member
         return std::ranges::distance(this->begin(), this->end());
     }
 

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -60,7 +60,16 @@ public:
         return std::ranges::distance(this->begin(), this->end());
     }
 
-    [[nodiscard]] value_type& element_at(types::size_type n) const {
+    [[nodiscard]] value_type& element_at(types::size_type n) {
+        const auto distance = this->distance();
+        if (not (n < this->distance()))
+            throw std::out_of_range(
+                std::format("Position index {} out of range [0, {}]", n, this->distance())
+            );
+        return *std::ranges::next(this->begin(), n);
+    }
+
+    [[nodiscard]] const value_type& element_at(types::size_type n) const {
         const auto distance = this->distance();
         if (not (n < this->distance()))
             throw std::out_of_range(

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "type_traits.hpp"
 #include "types.hpp"
 
 #include <format>
 #include <iterator>
-#include <ranges>
 
 namespace gl {
 
@@ -24,7 +24,7 @@ public:
 
     explicit iterator_range(iterator begin, iterator end) : _range(begin, end) {}
 
-    template <std::ranges::range Range>
+    template <type_traits::c_range Range>
     explicit iterator_range(Range& range)
     : _range(std::ranges::begin(range), std::ranges::end(range)) {}
 
@@ -95,11 +95,17 @@ template <std::forward_iterator Iterator>
     return types::iterator_range{begin, end};
 }
 
-template <std::ranges::range Range>
-[[nodiscard]] inline types::iterator_range<typename Range::iterator> make_iterator_range(
+template <type_traits::c_range Range>
+[[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>> make_iterator_range(
     Range& range
 ) {
     return types::iterator_range{std::ranges::begin(range), std::ranges::end(range)};
+}
+
+template <type_traits::c_range Range>
+[[nodiscard]] inline types::iterator_range<type_traits::const_iterator_type<Range>>
+make_const_iterator_range(Range& range) {
+    return types::iterator_range{std::ranges::cbegin(range), std::ranges::cend(range)};
 }
 
 } // namespace gl

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -75,14 +75,24 @@ private:
 
 } // namespace types
 
-template <std::ranges::range Range>
+template <type_traits::c_range Range>
 [[nodiscard]] auto non_null_begin(Range& range) {
     return types::non_null_iterator(std::ranges::begin(range), std::ranges::end(range));
 }
 
-template <std::ranges::range Range>
+template <type_traits::c_range Range>
 [[nodiscard]] auto non_null_end(Range& range) {
     return types::non_null_iterator(std::ranges::end(range), std::ranges::end(range));
+}
+
+template <type_traits::c_const_range Range>
+[[nodiscard]] auto non_null_cbegin(Range& range) {
+    return types::non_null_iterator(std::ranges::cbegin(range), std::ranges::cend(range));
+}
+
+template <type_traits::c_const_range Range>
+[[nodiscard]] auto non_null_cend(Range& range) {
+    return types::non_null_iterator(std::ranges::cend(range), std::ranges::cend(range));
 }
 
 } // namespace gl

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "type_traits.hpp"
+
+#include <algorithm>
+
+namespace gl {
+
+namespace types {
+
+template <std::forward_iterator Iterator>
+requires(type_traits::c_strong_smart_ptr<typename Iterator::value_type>)
+class non_null_iterator {
+public:
+    using iterator_type = Iterator;
+    using value_type = typename std::iterator_traits<iterator_type>::value_type;
+    using reference = typename std::iterator_traits<iterator_type>::reference;
+    using pointer = typename std::iterator_traits<iterator_type>::pointer;
+    using difference_type = typename std::iterator_traits<iterator_type>::difference_type;
+    using iterator_category = typename std::iterator_traits<iterator_type>::iterator_category;
+
+    non_null_iterator() = default;
+
+    non_null_iterator(iterator_type current, iterator_type end) : _current(current), _end(end) {
+        if (this->_current != this->_end and not *this->_current)
+            this->_skip_null_elements();
+    }
+
+    non_null_iterator(const non_null_iterator&) = default;
+    non_null_iterator(non_null_iterator&&) = default;
+
+    non_null_iterator& operator=(const non_null_iterator&) = default;
+    non_null_iterator& operator=(non_null_iterator&&) = default;
+
+    [[nodiscard]] reference operator*() const {
+        return *this->_current;
+    }
+
+    [[nodiscard]] pointer operator->() const {
+        return &(*this->_current);
+    }
+
+    non_null_iterator& operator++() {
+        this->_skip_null_elements();
+        return *this;
+    }
+
+    non_null_iterator operator++(int) {
+        non_null_iterator tmp = *this;
+        this->_skip_null_elements();
+        return tmp;
+    }
+
+    [[nodiscard]] bool operator==(const non_null_iterator& other) const {
+        return this->_current == other._current;
+    }
+
+    [[nodiscard]] bool operator!=(const non_null_iterator& other) const {
+        return this->_current != other._current;
+    }
+
+private:
+    void _skip_null_elements() {
+        constexpr auto is_null = [](const reference& ptr) { return ptr == nullptr; };
+
+        if (this->_current == this->_end)
+            return;
+
+        this->_current = std::find_if_not(++this->_current, this->_end, is_null);
+    }
+
+    iterator_type _current;
+    iterator_type _end;
+};
+
+} // namespace types
+
+template <std::ranges::range Range>
+[[nodiscard]] auto non_null_begin(Range& range) {
+    return types::non_null_iterator(std::ranges::begin(range), std::ranges::end(range));
+}
+
+template <std::ranges::range Range>
+[[nodiscard]] auto non_null_end(Range& range) {
+    return types::non_null_iterator(std::ranges::end(range), std::ranges::end(range));
+}
+
+} // namespace gl

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <concepts>
+#include <memory>
 #include <ranges>
 #include <type_traits>
 
@@ -36,5 +37,9 @@ concept c_reverse_range = requires(T& t) {
     std::ranges::rbegin(t);
     std::ranges::rend(t);
 };
+
+template <typename T>
+concept c_strong_smart_ptr =
+    c_instantiation_of<T, std::unique_ptr> or c_instantiation_of<T, std::shared_ptr>;
 
 } // namespace gl::type_traits

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -32,10 +32,19 @@ inline constexpr bool is_one_of_v = is_one_of<T, Types...>::value;
 template <typename T, typename... Types>
 concept c_one_of = is_one_of_v<T, Types...>;
 
-template <typename T>
-concept c_reverse_range = requires(T& t) {
-    std::ranges::rbegin(t);
-    std::ranges::rend(t);
+template <typename R>
+concept c_range = std::ranges::range<R>;
+
+template <typename R>
+concept c_const_range = requires(R& r) {
+    std::ranges::cbegin(r);
+    std::ranges::cend(r);
+};
+
+template <typename R>
+concept c_reverse_range = requires(R& r) {
+    std::ranges::rbegin(r);
+    std::ranges::rend(r);
 };
 
 template <typename T>

--- a/include/gl/types/traits/iterator_traits.hpp
+++ b/include/gl/types/traits/iterator_traits.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
+#include "concepts.hpp"
+
 #include <iterator>
 
 namespace gl::type_traits {
 
-template <std::ranges::range Range>
+template <type_traits::c_range Range>
 using iterator_type = typename Range::iterator;
 
-template <std::ranges::range Range>
+template <type_traits::c_const_range Range>
 using const_iterator_type = typename Range::const_iterator;
 
 // TODO: reverse iterator types (requires reverse_range concept)

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -54,7 +54,7 @@ public:
         return this->_id;
     }
 
-    properties_type properties = properties_type{};
+    [[no_unique_address]] properties_type properties = properties_type{};
 
 private:
     types::id_type _id;

--- a/tests/include/namespaces.hpp
+++ b/tests/include/namespaces.hpp
@@ -3,19 +3,19 @@
 // required for the type alias
 namespace gl {
 
+namespace impl {} // namespace impl
+
 namespace types {} // namespace types
 
 namespace type_traits {} // namespace type_traits
-
-namespace impl {} // namespace impl
 
 } // namespace gl
 
 namespace gl_testing {
 
 namespace lib = gl;
+namespace lib_i = lib::impl;
 namespace lib_t = lib::types;
 namespace lib_tt = lib::type_traits;
-namespace lib_i = lib::impl;
 
 } // namespace gl_testing

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -32,7 +32,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         std::ranges::for_each(
             std::views::iota(constants::vertex_id_1, constants::no_elements),
             [&sut](const lib_t::id_type vertex_id) {
-                CHECK_EQ(sut.adjacent_edges(vertex_id).distance(), constants::zero_elements);
+                CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
             }
         );
     }
@@ -106,8 +106,8 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
 
-    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_1).distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
+    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
+    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
 }
 
 TEST_CASE_FIXTURE(
@@ -160,7 +160,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(no_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);
@@ -210,8 +210,8 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
 
-    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_1).distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::one_element);
+    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
+    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::one_element);
 }
 
 TEST_CASE_FIXTURE(
@@ -221,7 +221,7 @@ TEST_CASE_FIXTURE(
     add_edge(constants::vertex_id_1, constants::vertex_id_1);
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_1).distance(), constants::one_element);
+    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
 }
 
 TEST_CASE_FIXTURE(
@@ -261,7 +261,7 @@ TEST_CASE_FIXTURE(
         adjacent_edges_first.end()
     );
 
-    const auto adjacent_edges_second = sut.adjacent_edges(second_id);
+    const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
     REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
     // validate that the adjacent edges vector has been properly aligned
     CHECK_EQ(
@@ -292,7 +292,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(no_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -106,8 +106,13 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
 
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
+    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
+
+    const auto& new_edge = adjacent_edges_1.element_at(constants::first_element_idx);
+    CHECK(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
+    CHECK(new_edge->is_incident_to(vertices[constants::vertex_id_2]));
 }
 
 TEST_CASE_FIXTURE(
@@ -210,8 +215,18 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
 
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::one_element);
+    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+
+    REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
+    REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
+
+    const auto& new_edge_1 = adjacent_edges_1.element_at(constants::first_element_idx);
+    CHECK(new_edge_1->is_incident_from(vertices[constants::vertex_id_1]));
+    CHECK(new_edge_1->is_incident_to(vertices[constants::vertex_id_2]));
+
+    const auto& new_edge_2 = adjacent_edges_2.element_at(constants::first_element_idx);
+    CHECK_EQ(new_edge_1.get(), new_edge_2.get());
 }
 
 TEST_CASE_FIXTURE(
@@ -221,7 +236,11 @@ TEST_CASE_FIXTURE(
     add_edge(constants::vertex_id_1, constants::vertex_id_1);
 
     REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_1).distance(), constants::one_element);
+
+    const auto adjacent_edges = sut.adjacent_edges_c(constants::vertex_id_1);
+    REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
+
+    CHECK(adjacent_edges.element_at(constants::first_element_idx)->is_loop());
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -30,7 +30,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.no_unique_edges(), constants::zero_elements);
 
         std::ranges::for_each(
-            std::views::iota(constants::vertex_id_1, constants::no_elements),
+            constants::vertex_id_view,
             [&sut](const lib_t::id_type vertex_id) {
                 CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
             }
@@ -41,7 +41,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         SutType sut{};
         constexpr lib_t::size_type target_no_vertices = constants::no_elements;
 
-        for (lib_t::id_type no_vertices = constants::one_element; no_vertices <= target_no_vertices;
+        for (lib_t::size_type no_vertices = constants::one_element; no_vertices <= target_no_vertices;
              no_vertices++) {
             sut.add_vertex();
             CHECK_EQ(sut.no_vertices(), no_vertices);

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -12,6 +12,8 @@
 
 namespace gl_testing {
 
+TEST_SUITE_BEGIN("test_adjacency_list");
+
 TEST_CASE_TEMPLATE_DEFINE(
     "directional_tag-independent tests", SutType, edge_directional_tag_sut_template
 ) {
@@ -297,5 +299,7 @@ TEST_CASE_FIXTURE(
         }));
     }
 }
+
+TEST_SUITE_END(); // test_adjacency_list
 
 } // namespace gl_testing

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -119,8 +119,8 @@ TEST_CASE_FIXTURE(
     fully_connect_vertex(constants::vertex_id_1);
 
     auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
-    REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex);
+    REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_for_fully_connected_vertex);
 
     const auto& edge_to_remove = adjacent_edges.element_at(constants::first_element_idx);
     const auto edge_to_remove_addr = edge_to_remove.get();
@@ -135,7 +135,7 @@ TEST_CASE_FIXTURE(
         adjacent_edges.distance(),
         no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
-    // validate that the adjacent edges vector has been properly aligned
+    // validate that the adjacent edges list has been properly aligned
     CHECK_EQ(edge_to_remove.get(), adjacent_edges.element_at(constants::first_element_idx).get());
     CHECK_EQ(
         std::ranges::find(
@@ -255,19 +255,19 @@ TEST_CASE_FIXTURE(
     const auto edge_to_remove_addr = edge_to_remove.get();
 
     const auto second_id = edge_to_remove->second()->id();
-    REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges_c(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
         sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
 
+    // validate that the first adjacent edges list has been properly aligned
     adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
-    // validate that the adjacent edges vector has been properly aligned
     CHECK_EQ(
         edge_to_remove.get(), adjacent_edges_first.element_at(constants::first_element_idx).get()
     );
@@ -278,9 +278,9 @@ TEST_CASE_FIXTURE(
         adjacent_edges_first.end()
     );
 
+    // validate that the second adjacent edges list has been properly aligned
     const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
     REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
-    // validate that the adjacent edges vector has been properly aligned
     CHECK_EQ(
         std::ranges::find(
             adjacent_edges_second, edge_to_remove_addr, transforms::address_projection<edge_type>{}

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -29,19 +29,17 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.no_vertices(), constants::no_elements);
         REQUIRE_EQ(sut.no_unique_edges(), constants::zero_elements);
 
-        std::ranges::for_each(
-            constants::vertex_id_view,
-            [&sut](const lib_t::id_type vertex_id) {
-                CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
-            }
-        );
+        std::ranges::for_each(constants::vertex_id_view, [&sut](const lib_t::id_type vertex_id) {
+            CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
+        });
     }
 
     SUBCASE("add_vertex should properly extend the current adjacency list") {
         SutType sut{};
         constexpr lib_t::size_type target_no_vertices = constants::no_elements;
 
-        for (lib_t::size_type no_vertices = constants::one_element; no_vertices <= target_no_vertices;
+        for (lib_t::size_type no_vertices = constants::one_element;
+             no_vertices <= target_no_vertices;
              no_vertices++) {
             sut.add_vertex();
             CHECK_EQ(sut.no_vertices(), no_vertices);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -1,0 +1,35 @@
+#include "constants.hpp"
+#include "functional.hpp"
+#include "transforms.hpp"
+#include "utility.hpp"
+
+#include <gl/impl/adjacency_matrix.hpp>
+
+#include <doctest.h>
+
+#include <algorithm>
+#include <functional>
+
+namespace gl_testing {
+
+TEST_SUITE_BEGIN("test_adjacency_matrix");
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "directional_tag-independent tests", SutType, edge_directional_tag_sut_template
+) {
+    SUBCASE("should be initialized with no vertices and no edges by default") {
+        SutType sut{};
+        CHECK_EQ(sut.no_vertices(), constants::zero_elements);
+        CHECK_EQ(sut.no_unique_edges(), constants::zero_elements);
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    edge_directional_tag_sut_template,
+    lib_i::adjacency_matrix<lib::graph_traits<lib::directed_t>>, // directed adj list
+    lib_i::adjacency_matrix<lib::graph_traits<lib::undirected_t>> // undirected adj list
+);
+
+TEST_SUITE_END(); // test_adjacency_matrix
+
+} // namespace gl_testing

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -145,7 +145,6 @@ TEST_CASE_FIXTURE(
     );
 }
 
-/*
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
@@ -171,7 +170,6 @@ TEST_CASE_FIXTURE(
         }));
     }
 }
-*/
 
 struct test_undirected_adjacency_matrix {
     using vertex_type = lib::vertex_descriptor<>;
@@ -288,7 +286,6 @@ TEST_CASE_FIXTURE(
     );
 }
 
-/*
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
@@ -316,7 +313,6 @@ TEST_CASE_FIXTURE(
         }));
     }
 }
-*/
 
 TEST_SUITE_END(); // test_adjacency_matrix
 

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -58,6 +58,271 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib_i::adjacency_matrix<lib::graph_traits<lib::undirected_t>> // undirected adj list
 );
 
+namespace {
+
+constexpr lib_t::size_type no_incident_edges_for_fully_connected_vertex =
+    constants::no_elements - constants::one_element;
+
+} // namespace
+
+struct test_directed_adjacency_matrix {
+    using vertex_type = lib::vertex_descriptor<>;
+    using edge_type = lib::directed_edge<vertex_type>;
+    using sut_type = lib_i::adjacency_matrix<lib::graph_traits<lib::directed_t>>;
+
+    test_directed_adjacency_matrix() {
+        for (const auto id : constants::vertex_id_view)
+            vertices.push_back(util::make_vertex<vertex_type>(id));
+    }
+
+    void add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
+        sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+    }
+
+    void fully_connect_vertex(const lib_t::id_type first_id) {
+        for (const auto second_id : constants::vertex_id_view)
+            if (second_id != first_id)
+                add_edge(first_id, second_id);
+    }
+
+    void prepare_full_graph() {
+        for (const auto first_id : constants::vertex_id_view)
+            fully_connect_vertex(first_id);
+
+        REQUIRE_EQ(sut.no_unique_edges(), no_unique_edges_in_full_graph);
+    }
+
+    sut_type sut{constants::no_elements};
+    std::vector<std::shared_ptr<vertex_type>> vertices;
+
+    static constexpr lib_t::size_type no_unique_edges_in_full_graph =
+        no_incident_edges_for_fully_connected_vertex * constants::no_elements;
+};
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "add_edge should add the edge only to the source vertex list"
+) {
+    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
+
+    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
+
+    const auto& new_edge = adjacent_edges_1.element_at(constants::first_element_idx);
+    CHECK(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
+    CHECK(new_edge->is_incident_to(vertices[constants::vertex_id_2]));
+}
+
+/*
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "remove_edge should remove the edge from the source vertex's list"
+) {
+    fully_connect_vertex(constants::vertex_id_1);
+
+    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_for_fully_connected_vertex);
+    REQUIRE_EQ(sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex);
+
+    const auto& edge_to_remove = adjacent_edges.element_at(constants::first_element_idx);
+    const auto edge_to_remove_addr = edge_to_remove.get();
+
+    sut.remove_edge(edge_to_remove);
+    REQUIRE_EQ(
+        sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex - constants::one_element
+    );
+
+    adjacent_edges = sut.adjacent_edges(constants::first_element_idx);
+    REQUIRE_EQ(
+        adjacent_edges.distance(),
+        no_incident_edges_for_fully_connected_vertex - constants::one_element
+    );
+    // validate that the adjacent edges vector has been properly aligned
+    CHECK_EQ(edge_to_remove.get(), adjacent_edges.element_at(constants::first_element_idx).get());
+    CHECK_EQ(
+        std::ranges::find(
+            adjacent_edges, edge_to_remove_addr, transforms::address_projection<edge_type>{}
+        ),
+        adjacent_edges.end()
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix,
+    "remove_vertex should remove the given vertex and all edges incident with it"
+) {
+    prepare_full_graph();
+
+    const auto& removed_vertex = vertices[constants::first_element_idx];
+    sut.remove_vertex(removed_vertex);
+
+    constexpr auto no_vertices_after_remove = constants::no_elements - constants::one_element;
+    constexpr auto no_incident_edges_after_remove =
+        no_incident_edges_for_fully_connected_vertex - constants::one_element;
+
+    REQUIRE_EQ(sut.no_vertices(), no_vertices_after_remove);
+    REQUIRE_EQ(sut.no_unique_edges(), no_vertices_after_remove * no_incident_edges_after_remove);
+
+    for (const auto vertex_id :
+         constants::vertex_id_view | std::views::take(no_vertices_after_remove)) {
+        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_after_remove);
+        CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
+            return edge->is_incident_with(removed_vertex);
+        }));
+    }
+}
+*/
+
+struct test_undirected_adjacency_matrix {
+    using vertex_type = lib::vertex_descriptor<>;
+    using edge_type = lib::undirected_edge<vertex_type>;
+    using sut_type = lib_i::adjacency_matrix<lib::graph_traits<lib::undirected_t>>;
+
+    test_undirected_adjacency_matrix() {
+        for (const auto id : constants::vertex_id_view)
+            vertices.push_back(util::make_vertex<vertex_type>(id));
+    }
+
+    void add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
+        sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+    }
+
+    void fully_connect_vertex(const lib_t::id_type first_id) {
+        for (const auto second_id : constants::vertex_id_view)
+            if (second_id != first_id)
+                add_edge(first_id, second_id);
+    }
+
+    void prepare_full_graph() {
+        for (const auto first_id : constants::vertex_id_view)
+            for (const auto second_id : std::views::iota(constants::vertex_id_1, first_id))
+                add_edge(first_id, second_id);
+
+        REQUIRE_EQ(sut.no_unique_edges(), no_unique_edges_in_full_graph);
+    }
+
+    sut_type sut{constants::no_elements};
+    std::vector<std::shared_ptr<vertex_type>> vertices;
+
+    static constexpr lib_t::size_type no_unique_edges_in_full_graph =
+        (no_incident_edges_for_fully_connected_vertex * constants::no_elements) / 2;
+};
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix, "add_edge should add the edge to the lists of both vertices"
+) {
+    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
+
+    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+
+    REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
+    REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
+
+    const auto& new_edge_1 = adjacent_edges_1.element_at(constants::first_element_idx);
+    CHECK(new_edge_1->is_incident_from(vertices[constants::vertex_id_1]));
+    CHECK(new_edge_1->is_incident_to(vertices[constants::vertex_id_2]));
+
+    const auto& new_edge_2 = adjacent_edges_2.element_at(constants::first_element_idx);
+    CHECK_EQ(new_edge_1.get(), new_edge_2.get());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "add_edge should add the edge once to the vertex list if the edge is a loop"
+) {
+    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+
+    REQUIRE_EQ(sut.no_unique_edges(), constants::one_element);
+
+    const auto adjacent_edges = sut.adjacent_edges_c(constants::vertex_id_1);
+    REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
+
+    CHECK(adjacent_edges.element_at(constants::first_element_idx)->is_loop());
+}
+
+/*
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "remove_edge should remove the edge from both the first and second vertices' list"
+) {
+    fully_connect_vertex(constants::vertex_id_1);
+
+    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    REQUIRE_EQ(sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex);
+    REQUIRE_EQ(adjacent_edges_first.distance(), no_incident_edges_for_fully_connected_vertex);
+
+    const auto& edge_to_remove = adjacent_edges_first.element_at(constants::first_element_idx);
+    const auto edge_to_remove_addr = edge_to_remove.get();
+
+    const auto second_id = edge_to_remove->second()->id();
+    REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
+
+    sut.remove_edge(edge_to_remove);
+    REQUIRE_EQ(
+        sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex - constants::one_element
+    );
+
+    adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
+    REQUIRE_EQ(
+        adjacent_edges_first.distance(),
+        no_incident_edges_for_fully_connected_vertex - constants::one_element
+    );
+    // validate that the adjacent edges vector has been properly aligned
+    CHECK_EQ(
+        edge_to_remove.get(), adjacent_edges_first.element_at(constants::first_element_idx).get()
+    );
+    CHECK_EQ(
+        std::ranges::find(
+            adjacent_edges_first, edge_to_remove_addr, transforms::address_projection<edge_type>{}
+        ),
+        adjacent_edges_first.end()
+    );
+
+    const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
+    REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
+    // validate that the adjacent edges vector has been properly aligned
+    CHECK_EQ(
+        std::ranges::find(
+            adjacent_edges_second, edge_to_remove_addr, transforms::address_projection<edge_type>{}
+        ),
+        adjacent_edges_second.end()
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "remove_vertex should remove the given vertex and all edges incident with it"
+) {
+    prepare_full_graph();
+
+    const auto& removed_vertex = vertices[constants::first_element_idx];
+    sut.remove_vertex(removed_vertex);
+
+    constexpr auto no_vertices_after_remove = constants::no_elements - constants::one_element;
+    constexpr auto no_incident_edges_after_remove =
+        no_incident_edges_for_fully_connected_vertex - constants::one_element;
+
+    REQUIRE_EQ(sut.no_vertices(), no_vertices_after_remove);
+    REQUIRE_EQ(
+        sut.no_unique_edges(), (no_vertices_after_remove * no_incident_edges_after_remove) / 2
+    );
+
+    for (const auto vertex_id :
+         constants::vertex_id_view | std::views::take(no_vertices_after_remove)) {
+        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_after_remove);
+        CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
+            return edge->is_incident_with(removed_vertex);
+        }));
+    }
+}
+*/
+
 TEST_SUITE_END(); // test_adjacency_matrix
 
 } // namespace gl_testing

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -113,15 +113,15 @@ TEST_CASE_FIXTURE(
     CHECK(new_edge->is_incident_to(vertices[constants::vertex_id_2]));
 }
 
-/*
 TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix, "remove_edge should remove the edge from the source vertex's list"
+    test_directed_adjacency_matrix,
+    "remove_edge should remove the edge from the source vertex's list"
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
     auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
-    REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex);
+    REQUIRE_EQ(adjacent_edges.distance(), no_incident_edges_for_fully_connected_vertex);
 
     const auto& edge_to_remove = adjacent_edges.element_at(constants::first_element_idx);
     const auto edge_to_remove_addr = edge_to_remove.get();
@@ -131,13 +131,12 @@ TEST_CASE_FIXTURE(
         sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
 
-    adjacent_edges = sut.adjacent_edges(constants::first_element_idx);
+    // validate that the adjacent edges list has been properly aligned
+    adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges.distance(),
         no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
-    // validate that the adjacent edges vector has been properly aligned
-    CHECK_EQ(edge_to_remove.get(), adjacent_edges.element_at(constants::first_element_idx).get());
     CHECK_EQ(
         std::ranges::find(
             adjacent_edges, edge_to_remove_addr, transforms::address_projection<edge_type>{}
@@ -146,6 +145,7 @@ TEST_CASE_FIXTURE(
     );
 }
 
+/*
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
@@ -243,7 +243,6 @@ TEST_CASE_FIXTURE(
     CHECK(adjacent_edges.element_at(constants::first_element_idx)->is_loop());
 }
 
-/*
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_edge should remove the edge from both the first and second vertices' list"
@@ -258,21 +257,18 @@ TEST_CASE_FIXTURE(
     const auto edge_to_remove_addr = edge_to_remove.get();
 
     const auto second_id = edge_to_remove->second()->id();
-    REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges_c(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
         sut.no_unique_edges(), no_incident_edges_for_fully_connected_vertex - constants::one_element
     );
 
-    adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
+    // validate that the first adjacent edges list has been properly aligned
+    adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         no_incident_edges_for_fully_connected_vertex - constants::one_element
-    );
-    // validate that the adjacent edges vector has been properly aligned
-    CHECK_EQ(
-        edge_to_remove.get(), adjacent_edges_first.element_at(constants::first_element_idx).get()
     );
     CHECK_EQ(
         std::ranges::find(
@@ -281,9 +277,9 @@ TEST_CASE_FIXTURE(
         adjacent_edges_first.end()
     );
 
+    // validate that the second adjacent edges list has been properly aligned
     const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
     REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
-    // validate that the adjacent edges vector has been properly aligned
     CHECK_EQ(
         std::ranges::find(
             adjacent_edges_second, edge_to_remove_addr, transforms::address_projection<edge_type>{}
@@ -292,6 +288,7 @@ TEST_CASE_FIXTURE(
     );
 }
 
+/*
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -29,19 +29,17 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.no_vertices(), constants::no_elements);
         REQUIRE_EQ(sut.no_unique_edges(), constants::zero_elements);
 
-        std::ranges::for_each(
-            constants::vertex_id_view,
-            [&sut](const lib_t::id_type vertex_id) {
-                CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
-            }
-        );
+        std::ranges::for_each(constants::vertex_id_view, [&sut](const lib_t::id_type vertex_id) {
+            CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
+        });
     }
 
     SUBCASE("add_vertex should properly extend the current adjacency matrix") {
         SutType sut{};
         constexpr lib_t::size_type target_no_vertices = constants::no_elements;
 
-        for (lib_t::size_type no_vertices = constants::one_element; no_vertices <= target_no_vertices;
+        for (lib_t::size_type no_vertices = constants::one_element;
+             no_vertices <= target_no_vertices;
              no_vertices++) {
             sut.add_vertex();
             CHECK_EQ(sut.no_vertices(), no_vertices);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -22,6 +22,15 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.no_vertices(), constants::zero_elements);
         CHECK_EQ(sut.no_unique_edges(), constants::zero_elements);
     }
+
+    SUBCASE("constructed with the no_vertices parameter should properly initialize the adjacency "
+            "matrix") {
+        SutType sut{constants::no_elements};
+        REQUIRE_EQ(sut.no_vertices(), constants::no_elements);
+        REQUIRE_EQ(sut.no_unique_edges(), constants::zero_elements);
+
+        // TODO: check that there are no edges added
+    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -29,7 +29,26 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.no_vertices(), constants::no_elements);
         REQUIRE_EQ(sut.no_unique_edges(), constants::zero_elements);
 
-        // TODO: check that there are no edges added
+        std::ranges::for_each(
+            constants::vertex_id_view,
+            [&sut](const lib_t::id_type vertex_id) {
+                CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
+            }
+        );
+    }
+
+    SUBCASE("add_vertex should properly extend the current adjacency matrix") {
+        SutType sut{};
+        constexpr lib_t::size_type target_no_vertices = constants::no_elements;
+
+        for (lib_t::size_type no_vertices = constants::one_element; no_vertices <= target_no_vertices;
+             no_vertices++) {
+            sut.add_vertex();
+            CHECK_EQ(sut.no_vertices(), no_vertices);
+        }
+
+        CHECK_EQ(sut.no_vertices(), target_no_vertices);
+        CHECK_EQ(sut.no_unique_edges(), constants::zero_elements);
     }
 }
 

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -34,7 +34,7 @@ TEST_CASE("graph constructed with no_vertices parameter should properly initiali
 
     REQUIRE(std::ranges::equal(
         sut.vertex_crange() | std::views::transform(transforms::extract_vertex_id<>),
-        std::views::iota(constants::vertex_id_1, constants::no_elements)
+        constants::vertex_id_view
     ));
 
     CHECK_THROWS_AS(static_cast<void>(sut.get_vertex(constants::no_elements)), std::out_of_range);

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -15,11 +15,11 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_iterator_range");
 
 template <typename Container>
-struct test_iterator_range_common {
+struct test_iterator_range {
     using container_type = Container;
     using iterator_type = typename container_type::iterator;
 
-    test_iterator_range_common() : container(size), sut(container.begin(), container.end()) {
+    test_iterator_range() : container(size), sut(container.begin(), container.end()) {
         std::iota(container.begin(), container.end(), first_element);
     }
 
@@ -30,9 +30,9 @@ struct test_iterator_range_common {
     lib_t::iterator_range<iterator_type> sut;
 };
 
-TEST_CASE_TEMPLATE_DEFINE("common iterator_range tests", ContainerType, container_type_template) {
+TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", ContainerType, container_type_template) {
     using container_type = ContainerType;
-    using fixture_type = test_iterator_range_common<container_type>;
+    using fixture_type = test_iterator_range<container_type>;
     using iterator_type = typename fixture_type::iterator_type;
 
     fixture_type fixture;

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -17,7 +17,7 @@ TEST_SUITE_BEGIN("test_iterator_range");
 template <typename Container>
 struct test_iterator_range {
     using container_type = Container;
-    using iterator_type = typename container_type::iterator;
+    using iterator_type = lib_tt::iterator_type<container_type>;
 
     test_iterator_range() : container(size), sut(container.begin(), container.end()) {
         std::iota(container.begin(), container.end(), first_element);

--- a/tests/source/test_non_null_iterator.cpp
+++ b/tests/source/test_non_null_iterator.cpp
@@ -29,7 +29,7 @@ template <typename Container>
 struct test_non_null_iterator {
     using container_type = Container;
     using data_ptr_type = typename container_type::value_type;
-    using sut_type = lib_t::non_null_iterator<typename container_type::iterator>;
+    using sut_type = lib_t::non_null_iterator<lib_tt::iterator_type<container_type>>;
 
     struct reference_projection {
         auto operator()(const data_ptr_type& data_ptr) {

--- a/tests/source/test_non_null_iterator.cpp
+++ b/tests/source/test_non_null_iterator.cpp
@@ -1,0 +1,103 @@
+#include "constants.hpp"
+#include "functional.hpp"
+
+#include <gl/types/iterator_range.hpp>
+#include <gl/types/non_null_iterator.hpp>
+
+#include <doctest.h>
+
+#include <algorithm>
+#include <deque>
+#include <forward_list>
+#include <list>
+
+namespace gl_testing {
+
+TEST_SUITE_BEGIN("test_non_null_iterator");
+
+struct data {
+    lib_t::id_type id;
+    std::string str;
+
+    friend bool operator==(const data&, const data&) = default;
+};
+
+using data_uptr = std::unique_ptr<data>;
+using data_sptr = std::shared_ptr<data>;
+
+template <typename Container>
+struct test_non_null_iterator {
+    using container_type = Container;
+    using data_ptr_type = typename container_type::value_type;
+    using sut_type = lib_t::non_null_iterator<typename container_type::iterator>;
+
+    struct reference_projection {
+        auto operator()(const data_ptr_type& data_ptr) {
+            return *data_ptr;
+        }
+    };
+
+    test_non_null_iterator() {
+        for (auto i = constants::first_element_idx; i < constants::no_elements; i++) {
+            container.push_front(nullptr);
+            container.push_front(data_ptr_type{
+                new data{i, std::to_string(i)}
+            });
+            container.push_front(nullptr);
+
+            non_null_container.push_front(data_ptr_type{
+                new data{i, std::to_string(i)}
+            });
+        }
+    }
+
+    static constexpr std::size_t size = 3ull;
+    static constexpr std::size_t first_element = 0ull;
+    container_type container;
+    container_type non_null_container;
+};
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "non_null_iterator should provide an 'equivalent' iterator range as a non null container",
+    ContainerType,
+    container_type_template
+) {
+    using container_type = ContainerType;
+    using fixture_type = test_non_null_iterator<container_type>;
+    using sut_type = typename fixture_type::sut_type;
+    using reference_projection = typename fixture_type::reference_projection;
+
+    static_assert(std::forward_iterator<sut_type>);
+
+    fixture_type fixture;
+
+    const auto sut_begin = lib::non_null_begin(fixture.container);
+    const auto sut_end = lib::non_null_end(fixture.container);
+
+    const auto sut_range = lib::make_iterator_range(sut_begin, sut_end);
+    const auto non_null_range = lib::make_iterator_range(fixture.non_null_container);
+
+    CHECK(std::ranges::equal(
+        sut_range,
+        non_null_range,
+        std::ranges::equal_to{},
+        reference_projection{},
+        reference_projection{}
+    ));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    container_type_template,
+    std::deque<data_uptr>, // random access iterator
+    std::deque<data_sptr>, // random access iterator
+    std::list<data_uptr>, // bidirectional iterator
+    std::list<data_sptr>, // bidirectional iterator
+    std::forward_list<data_uptr>, // bidirectional iterator
+    std::forward_list<data_sptr> // bidirectional iterator
+);
+
+// TODO: add specific tests covering the individual methods
+
+TEST_SUITE_END(); // test_non_null_iterator
+
+} // namespace gl_testing


### PR DESCRIPTION
Added the `impl::adjacency_matrix` class which allows for:
- adding and removing vertices and edges
- getting the edges adjacent to a specific vertex