### PR TITLE
YT-CPPGL-16: Add distance caching to iterator_range

### DIFF
--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -6,7 +6,6 @@
 #include "types/types.hpp"
 
 #include <algorithm>
-#include <iostream>
 
 #ifdef GL_TESTING
 
@@ -31,9 +30,7 @@ public:
     using vertex_iterator_type = type_traits::iterator_type<vertex_set_type>;
     using vertex_const_iterator_type = type_traits::const_iterator_type<vertex_set_type>;
 
-    // TODO: reverese iterators should be available only for bidirectional ranges
-    using vertex_reverse_iterator_type = typename vertex_set_type::reverse_iterator;
-    using vertex_const_reverse_iterator_type = typename vertex_set_type::const_reverse_iterator;
+    // TODO: reverese iterators should be available for bidirectional ranges
 
     using edge_type = type_traits::edge_type<traits_type>;
     using edge_ptr_type = type_traits::edge_ptr_type<traits_type>;
@@ -94,21 +91,12 @@ public:
         );
     }
 
-    [[nodiscard]] inline types::iterator_range<vertex_iterator_type> vertex_range() {
+    [[nodiscard]] inline types::iterator_range<vertex_iterator_type> vertices() {
         return make_iterator_range(this->_vertices);
     }
 
-    [[nodiscard]] inline types::iterator_range<vertex_const_iterator_type> vertex_crange() const {
+    [[nodiscard]] inline types::iterator_range<vertex_const_iterator_type> c_vertices() const {
         return make_const_iterator_range(this->_vertices);
-    }
-
-    [[nodiscard]] inline types::iterator_range<vertex_reverse_iterator_type> vertex_rrange() {
-        return make_iterator_range(this->_vertices.rbegin(), this->_vertices.rend());
-    }
-
-    [[nodiscard]] inline types::iterator_range<vertex_const_reverse_iterator_type> vertex_crrange(
-    ) const {
-        return make_iterator_range(this->_vertices.crbegin(), this->_vertices.crend());
     }
 
 private:

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -19,22 +19,24 @@ using it_range_cache = types::iterator_range_cache_type;
 } // namespace gl
 
 #ifdef GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_EAGER
-    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::eager
+#define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::eager
 #elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_LAZY)
-    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
+#define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
 #elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_NONE)
-    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::none
+#define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::none
 #endif
 
 #ifndef _GL_IT_RANGE_DEFAULT_CACHE_TYPE
-    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
+#define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
 #endif
 
 namespace gl {
 
 namespace types {
 
-template <std::forward_iterator Iterator, iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+template <
+    std::forward_iterator Iterator,
+    iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 class iterator_range {
 public:
     using iterator = Iterator;
@@ -49,19 +51,22 @@ public:
     iterator_range() = delete;
 
     iterator_range(iterator begin, iterator end)
-    requires(cache_type == iterator_range_cache_type::eager) {
+    requires(cache_type == iterator_range_cache_type::eager)
+    {
         this->_distance = std::ranges::distance(begin, end);
         this->_range = std::make_pair(begin, end);
     }
 
     iterator_range(iterator begin, iterator end)
-    requires(cache_type == iterator_range_cache_type::lazy) {
+    requires(cache_type == iterator_range_cache_type::lazy)
+    {
         this->_range = std::make_pair(begin, end);
         this->_distance = _invalid_distance;
     }
 
     iterator_range(iterator begin, iterator end)
-    requires(cache_type == iterator_range_cache_type::none) {
+    requires(cache_type == iterator_range_cache_type::none)
+    {
         this->_range = std::make_pair(begin, end);
     }
 
@@ -94,19 +99,22 @@ public:
 #endif
 
     [[nodiscard]] inline distance_type distance() const
-    requires(cache_type == iterator_range_cache_type::eager) {
+    requires(cache_type == iterator_range_cache_type::eager)
+    {
         return this->_distance;
     }
 
     [[nodiscard]] inline distance_type distance() const
-    requires(cache_type == iterator_range_cache_type::lazy) {
+    requires(cache_type == iterator_range_cache_type::lazy)
+    {
         if (this->_is_distance_uninitialized())
             this->_distance = std::ranges::distance(this->begin(), this->end());
         return this->_distance;
     }
 
     [[nodiscard]] inline distance_type distance() const
-    requires(cache_type == iterator_range_cache_type::none) {
+    requires(cache_type == iterator_range_cache_type::none)
+    {
         return std::ranges::distance(this->begin(), this->end());
     }
 
@@ -137,10 +145,9 @@ private:
 
     homogeneous_pair<iterator> _range;
 
-    [[no_unique_address]] mutable std::conditional_t<
-        cache_type == iterator_range_cache_type::none,
-        std::monostate,
-        distance_type> _distance;
+    [[no_unique_address]] mutable std::
+        conditional_t<cache_type == iterator_range_cache_type::none, std::monostate, distance_type>
+            _distance;
 
     static constexpr distance_type _invalid_distance = -1;
     static constexpr distance_type _default_n = 1;
@@ -148,21 +155,26 @@ private:
 
 } // namespace types
 
-template <std::forward_iterator Iterator, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+template <
+    std::forward_iterator Iterator,
+    types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 [[nodiscard]] inline types::iterator_range<Iterator, CacheType> make_iterator_range(
     Iterator begin, Iterator end
 ) {
     return {begin, end};
 }
 
-template <type_traits::c_range Range, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
-[[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>, CacheType> make_iterator_range(
-    Range& range
-) {
+template <
+    type_traits::c_range Range,
+    types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+[[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>, CacheType>
+make_iterator_range(Range& range) {
     return {std::ranges::begin(range), std::ranges::end(range)};
 }
 
-template <type_traits::c_range Range, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+template <
+    type_traits::c_range Range,
+    types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 [[nodiscard]] inline types::iterator_range<type_traits::const_iterator_type<Range>, CacheType>
 make_const_iterator_range(const Range& range) {
     return {std::ranges::cbegin(range), std::ranges::cend(range)};

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -50,21 +50,21 @@ public:
 
     iterator_range() = delete;
 
-    iterator_range(iterator begin, iterator end)
+    explicit iterator_range(iterator begin, iterator end)
     requires(cache_type == iterator_range_cache_type::eager)
     {
         this->_distance = std::ranges::distance(begin, end);
         this->_range = std::make_pair(begin, end);
     }
 
-    iterator_range(iterator begin, iterator end)
+    explicit iterator_range(iterator begin, iterator end)
     requires(cache_type == iterator_range_cache_type::lazy)
     {
         this->_range = std::make_pair(begin, end);
         this->_distance = _invalid_distance;
     }
 
-    iterator_range(iterator begin, iterator end)
+    explicit iterator_range(iterator begin, iterator end)
     requires(cache_type == iterator_range_cache_type::none)
     {
         this->_range = std::make_pair(begin, end);
@@ -161,7 +161,7 @@ template <
 [[nodiscard]] inline types::iterator_range<Iterator, CacheType> make_iterator_range(
     Iterator begin, Iterator end
 ) {
-    return {begin, end};
+    return types::iterator_range<Iterator, CacheType>{begin, end};
 }
 
 template <
@@ -169,7 +169,9 @@ template <
     types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 [[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>, CacheType>
 make_iterator_range(Range& range) {
-    return {std::ranges::begin(range), std::ranges::end(range)};
+    return types::iterator_range<type_traits::iterator_type<Range>, CacheType>{
+        std::ranges::begin(range), std::ranges::end(range)
+    };
 }
 
 template <
@@ -177,7 +179,9 @@ template <
     types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 [[nodiscard]] inline types::iterator_range<type_traits::const_iterator_type<Range>, CacheType>
 make_const_iterator_range(const Range& range) {
-    return {std::ranges::cbegin(range), std::ranges::cend(range)};
+    return types::iterator_range<type_traits::const_iterator_type<Range>, CacheType>{
+        std::ranges::cbegin(range), std::ranges::cend(range)
+    };
 }
 
 } // namespace gl

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -10,23 +10,60 @@ namespace gl {
 
 namespace types {
 
-template <std::forward_iterator Iterator>
+enum class iterator_range_cache_type { none, lazy, eager };
+
+} // namespace types
+
+using it_range_cache = types::iterator_range_cache_type;
+
+} // namespace gl
+
+#ifdef GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_EAGER
+    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::eager
+#elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_LAZY)
+    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
+#elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_TYPE_NONE)
+    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::none
+#endif
+
+#ifndef _GL_IT_RANGE_DEFAULT_CACHE_TYPE
+    #define _GL_IT_RANGE_DEFAULT_CACHE_TYPE gl::types::iterator_range_cache_type::lazy
+#endif
+
+namespace gl {
+
+namespace types {
+
+template <std::forward_iterator Iterator, iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
 class iterator_range {
 public:
     using iterator = Iterator;
 #if __cplusplus >= 202302L
     using const_iterator = std::const_iterator<Iterator>;
 #endif
-    using difference_type = std::ptrdiff_t;
+    using distance_type = std::ptrdiff_t;
     using value_type = std::remove_reference_t<typename iterator::value_type>;
+
+    static constexpr iterator_range_cache_type cache_type = CacheType;
 
     iterator_range() = delete;
 
-    explicit iterator_range(iterator begin, iterator end) : _range(begin, end) {}
+    iterator_range(iterator begin, iterator end)
+    requires(cache_type == iterator_range_cache_type::eager) {
+        this->_distance = std::ranges::distance(begin, end);
+        this->_range = std::make_pair(begin, end);
+    }
 
-    template <type_traits::c_range Range>
-    explicit iterator_range(Range& range)
-    : _range(std::ranges::begin(range), std::ranges::end(range)) {}
+    iterator_range(iterator begin, iterator end)
+    requires(cache_type == iterator_range_cache_type::lazy) {
+        this->_range = std::make_pair(begin, end);
+        this->_distance = _invalid_distance;
+    }
+
+    iterator_range(iterator begin, iterator end)
+    requires(cache_type == iterator_range_cache_type::none) {
+        this->_range = std::make_pair(begin, end);
+    }
 
     iterator_range(const iterator_range&) = default;
     iterator_range(iterator_range&&) = default;
@@ -56,66 +93,79 @@ public:
     }
 #endif
 
-    [[nodiscard]] inline difference_type distance() const {
-        // TODO: keep the current distance as a member
+    [[nodiscard]] inline distance_type distance() const
+    requires(cache_type == iterator_range_cache_type::eager) {
+        return this->_distance;
+    }
+
+    [[nodiscard]] inline distance_type distance() const
+    requires(cache_type == iterator_range_cache_type::lazy) {
+        if (this->_is_distance_uninitialized())
+            this->_distance = std::ranges::distance(this->begin(), this->end());
+        return this->_distance;
+    }
+
+    [[nodiscard]] inline distance_type distance() const
+    requires(cache_type == iterator_range_cache_type::none) {
         return std::ranges::distance(this->begin(), this->end());
     }
 
-    [[nodiscard]] value_type& element_at(types::size_type n) {
-        const auto distance = this->distance();
-        if (not (n < this->distance()))
-            throw std::out_of_range(
-                std::format("Position index {} out of range [0, {}]", n, this->distance())
-            );
-        return *std::ranges::next(this->begin(), n);
+    [[nodiscard]] inline value_type& element_at(types::size_type position) {
+        this->_validate_element_position(position);
+        return *std::ranges::next(this->begin(), position);
     }
 
-    [[nodiscard]] const value_type& element_at(types::size_type n) const {
-        const auto distance = this->distance();
-        if (not (n < this->distance()))
-            throw std::out_of_range(
-                std::format("Position index {} out of range [0, {}]", n, this->distance())
-            );
-        return *std::ranges::next(this->begin(), n);
-    }
-
-    // TODO: validate begin <(=?) end
-    // If validated, use size_type instead of ptrdiff_t
-
-    inline void advance_begin(difference_type n = _default_n) {
-        std::ranges::advance(this->_range.first, n);
-    }
-
-    inline void advance_end(difference_type n = _default_n) {
-        std::ranges::advance(this->_range.second, n);
+    [[nodiscard]] inline const value_type& element_at(types::size_type position) const {
+        this->_validate_element_position(position);
+        return *std::ranges::next(this->begin(), position);
     }
 
 private:
+    [[nodiscard]] inline bool _is_distance_uninitialized() const
+    requires(cache_type == iterator_range_cache_type::lazy)
+    {
+        return this->_distance == _invalid_distance;
+    }
+
+    void _validate_element_position(const types::size_type position) const {
+        const auto current_distance = this->distance();
+        if (position >= current_distance)
+            throw std::out_of_range(
+                std::format("Position index {} out of range [0, {}]", position, current_distance)
+            );
+    }
+
     homogeneous_pair<iterator> _range;
 
-    static constexpr difference_type _default_n = 1;
+    [[no_unique_address]] mutable std::conditional_t<
+        cache_type == iterator_range_cache_type::none,
+        std::monostate,
+        distance_type> _distance;
+
+    static constexpr distance_type _invalid_distance = -1;
+    static constexpr distance_type _default_n = 1;
 };
 
 } // namespace types
 
-template <std::forward_iterator Iterator>
-[[nodiscard]] inline types::iterator_range<Iterator> make_iterator_range(
+template <std::forward_iterator Iterator, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+[[nodiscard]] inline types::iterator_range<Iterator, CacheType> make_iterator_range(
     Iterator begin, Iterator end
 ) {
-    return types::iterator_range{begin, end};
+    return {begin, end};
 }
 
-template <type_traits::c_range Range>
-[[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>> make_iterator_range(
+template <type_traits::c_range Range, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+[[nodiscard]] inline types::iterator_range<type_traits::iterator_type<Range>, CacheType> make_iterator_range(
     Range& range
 ) {
-    return types::iterator_range{std::ranges::begin(range), std::ranges::end(range)};
+    return {std::ranges::begin(range), std::ranges::end(range)};
 }
 
-template <type_traits::c_range Range>
-[[nodiscard]] inline types::iterator_range<type_traits::const_iterator_type<Range>>
-make_const_iterator_range(Range& range) {
-    return types::iterator_range{std::ranges::cbegin(range), std::ranges::cend(range)};
+template <type_traits::c_range Range, types::iterator_range_cache_type CacheType = _GL_IT_RANGE_DEFAULT_CACHE_TYPE>
+[[nodiscard]] inline types::iterator_range<type_traits::const_iterator_type<Range>, CacheType>
+make_const_iterator_range(const Range& range) {
+    return {std::ranges::cbegin(range), std::ranges::cend(range)};
 }
 
 } // namespace gl

--- a/include/gl/types/traits/cache_mode.hpp
+++ b/include/gl/types/traits/cache_mode.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace gl::type_traits {
+
+enum class cache_mode { none, lazy, eager };
+
+} // namespace gl::type_traits

--- a/include/gl/types/type_traits.hpp
+++ b/include/gl/types/type_traits.hpp
@@ -1,4 +1,5 @@
 #pragma once
 
+#include "traits/cache_mode.hpp"
 #include "traits/concepts.hpp"
 #include "traits/iterator_traits.hpp"

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -33,7 +33,7 @@ TEST_CASE("graph constructed with no_vertices parameter should properly initiali
     default_sut_type sut{constants::no_elements};
 
     REQUIRE(std::ranges::equal(
-        sut.vertex_crange() | std::views::transform(transforms::extract_vertex_id<>),
+        sut.c_vertices() | std::views::transform(transforms::extract_vertex_id<>),
         constants::vertex_id_view
     ));
 
@@ -76,24 +76,12 @@ TEST_CASE_FIXTURE(test_graph, "get_vertex should return a vertex with the given 
     CHECK_EQ(*sut.get_vertex(added_vertex->id()), *added_vertex);
 }
 
-TEST_CASE_FIXTURE(
-    test_graph, "vertex_(c)range should return the correct vertex list iterator range"
-) {
-    const auto v_range = sut.vertex_range();
+TEST_CASE_FIXTURE(test_graph, "(c_)vertices should return the correct vertex list iterator range") {
+    const auto v_range = sut.vertices();
     CHECK(std::ranges::equal(v_range, get_vertex_list(sut)));
 
-    const auto v_crange = sut.vertex_crange();
+    const auto v_crange = sut.c_vertices();
     CHECK(std::ranges::equal(v_crange, get_vertex_list(sut)));
-}
-
-TEST_CASE_FIXTURE(
-    test_graph, "vertex_(c)rrange should return the correct vertex list reverse iterator range"
-) {
-    const auto v_rrange = sut.vertex_rrange();
-    CHECK(std::ranges::equal(v_rrange, get_vertex_list(sut)));
-
-    const auto v_crrange = sut.vertex_crrange();
-    CHECK(std::ranges::equal(v_crrange, get_vertex_list(sut)));
 }
 
 TEST_CASE("remove_vertex should remove the given vertex and align ids of remaining vertices") {
@@ -106,7 +94,7 @@ TEST_CASE("remove_vertex should remove the given vertex and align ids of remaini
         constants::no_elements - constants::one_element;
 
     REQUIRE(std::ranges::equal(
-        sut.vertex_range() | std::views::transform(transforms::extract_vertex_id<>),
+        sut.c_vertices() | std::views::transform(transforms::extract_vertex_id<>),
         std::views::iota(constants::vertex_id_1, no_vertices_after_remove)
     ));
 

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -14,17 +14,17 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_iterator_range");
 
-template <typename Container, lib::it_range_cache CacheType>
+template <typename Container, lib_tt::cache_mode CacheMode>
 struct test_iterator_range_type_params {
     using container_type = Container;
-    static constexpr lib::it_range_cache cache_type = CacheType;
+    static constexpr lib_tt::cache_mode cache_mode = CacheMode;
 };
 
 template <typename TypeParams>
 struct test_iterator_range {
     using container_type = typename TypeParams::container_type;
     using iterator_type = lib_tt::iterator_type<container_type>;
-    using sut_type = lib_t::iterator_range<iterator_type, TypeParams::cache_type>;
+    using sut_type = lib_t::iterator_range<iterator_type, TypeParams::cache_mode>;
 
     test_iterator_range() : container(size), sut(container.begin(), container.end()) {
         std::iota(container.begin(), container.end(), first_element);
@@ -42,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
     using container_type = typename fixture_type::container_type;
     using iterator_type = typename fixture_type::iterator_type;
     using sut_type = typename fixture_type::sut_type;
-    constexpr lib::it_range_cache cache_type = sut_type::cache_type;
+    constexpr lib_tt::cache_mode cache_mode = sut_type::cache_mode;
 
     fixture_type fixture;
 
@@ -61,7 +61,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
 
     SUBCASE("should properly initialize the begin and end iterator for a range constructor") {
         sut_type range_constructed_sut =
-            lib::make_iterator_range<container_type, cache_type>(container);
+            lib::make_iterator_range<container_type, cache_mode>(container);
 
         CHECK_EQ(range_constructed_sut.begin(), std::ranges::begin(container));
         CHECK_EQ(range_constructed_sut.end(), std::ranges::end(container));
@@ -120,55 +120,55 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
 
     SUBCASE("make_iterator_range should return a properly initialized iterator_range") {
         const auto range =
-            lib::make_iterator_range<iterator_type, cache_type>(container.begin(), container.end());
+            lib::make_iterator_range<iterator_type, cache_mode>(container.begin(), container.end());
         CHECK(std::ranges::equal(range, container));
     }
 
     SUBCASE("make_iterator_range should return an iterator_range properly initialized with the "
             "container") {
-        const auto range = lib::make_iterator_range<container_type, cache_type>(container);
+        const auto range = lib::make_iterator_range<container_type, cache_mode>(container);
         CHECK(std::ranges::equal(range, container));
     }
 
     SUBCASE("make_const_iterator_range should return an iterator_range properly initialized with "
             "the container") {
-        const auto range = lib::make_const_iterator_range<container_type, cache_type>(container);
+        const auto range = lib::make_const_iterator_range<container_type, cache_mode>(container);
         CHECK(std::ranges::equal(range, container));
     }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     type_params_template,
-    // cache_type::none
+    // cache_mode::none
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib::it_range_cache::none>, // random access iterator
+        lib_tt::cache_mode::none>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib::it_range_cache::none>, // bidirectional iterator
+        lib_tt::cache_mode::none>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib::it_range_cache::none>, // forward iterator
-    // cache_type::lazy
+        lib_tt::cache_mode::none>, // forward iterator
+    // cache_mode::lazy
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib::it_range_cache::lazy>, // random access iterator
+        lib_tt::cache_mode::lazy>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib::it_range_cache::lazy>, // bidirectional iterator
+        lib_tt::cache_mode::lazy>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib::it_range_cache::lazy>, // forward iterator
-    // cache_type::eager
+        lib_tt::cache_mode::lazy>, // forward iterator
+    // cache_mode::eager
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib::it_range_cache::eager>, // random access iterator
+        lib_tt::cache_mode::eager>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib::it_range_cache::eager>, // bidirectional iterator
+        lib_tt::cache_mode::eager>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib::it_range_cache::eager> // forward iterator
+        lib_tt::cache_mode::eager> // forward iterator
 );
 
 TEST_SUITE_END(); // test_iterator_range

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -60,7 +60,8 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
     }
 
     SUBCASE("should properly initialize the begin and end iterator for a range constructor") {
-        sut_type range_constructed_sut = lib::make_iterator_range<container_type, cache_type>(container);
+        sut_type range_constructed_sut =
+            lib::make_iterator_range<container_type, cache_type>(container);
 
         CHECK_EQ(range_constructed_sut.begin(), std::ranges::begin(container));
         CHECK_EQ(range_constructed_sut.end(), std::ranges::end(container));
@@ -78,9 +79,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
         range = sut_type{std::next(sut.begin()), sut.end()};
         CHECK_NE(sut, range);
 
-        range = sut_type{
-            sut.begin(), std::next(sut.begin(), sut.distance() - 1)
-        };
+        range = sut_type{sut.begin(), std::next(sut.begin(), sut.distance() - 1)};
         CHECK_NE(sut, range);
     }
 
@@ -120,7 +119,8 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
     }
 
     SUBCASE("make_iterator_range should return a properly initialized iterator_range") {
-        const auto range = lib::make_iterator_range<iterator_type, cache_type>(container.begin(), container.end());
+        const auto range =
+            lib::make_iterator_range<iterator_type, cache_type>(container.begin(), container.end());
         CHECK(std::ranges::equal(range, container));
     }
 
@@ -130,7 +130,8 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
         CHECK(std::ranges::equal(range, container));
     }
 
-    SUBCASE("make_const_iterator_range should return an iterator_range properly initialized with the container") {
+    SUBCASE("make_const_iterator_range should return an iterator_range properly initialized with "
+            "the container") {
         const auto range = lib::make_const_iterator_range<container_type, cache_type>(container);
         CHECK(std::ranges::equal(range, container));
     }
@@ -139,17 +140,35 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
 TEST_CASE_TEMPLATE_INSTANTIATE(
     type_params_template,
     // cache_type::none
-    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::none>, // random access iterator
-    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::none>, // bidirectional iterator
-    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::none>, // forward iterator
+    test_iterator_range_type_params<
+        std::vector<std::size_t>,
+        lib::it_range_cache::none>, // random access iterator
+    test_iterator_range_type_params<
+        std::list<std::size_t>,
+        lib::it_range_cache::none>, // bidirectional iterator
+    test_iterator_range_type_params<
+        std::forward_list<std::size_t>,
+        lib::it_range_cache::none>, // forward iterator
     // cache_type::lazy
-    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::lazy>, // random access iterator
-    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::lazy>, // bidirectional iterator
-    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::lazy>, // forward iterator
+    test_iterator_range_type_params<
+        std::vector<std::size_t>,
+        lib::it_range_cache::lazy>, // random access iterator
+    test_iterator_range_type_params<
+        std::list<std::size_t>,
+        lib::it_range_cache::lazy>, // bidirectional iterator
+    test_iterator_range_type_params<
+        std::forward_list<std::size_t>,
+        lib::it_range_cache::lazy>, // forward iterator
     // cache_type::eager
-    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::eager>, // random access iterator
-    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::eager>, // bidirectional iterator
-    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::eager> // forward iterator
+    test_iterator_range_type_params<
+        std::vector<std::size_t>,
+        lib::it_range_cache::eager>, // random access iterator
+    test_iterator_range_type_params<
+        std::list<std::size_t>,
+        lib::it_range_cache::eager>, // bidirectional iterator
+    test_iterator_range_type_params<
+        std::forward_list<std::size_t>,
+        lib::it_range_cache::eager> // forward iterator
 );
 
 TEST_SUITE_END(); // test_iterator_range

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -14,10 +14,17 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_iterator_range");
 
-template <typename Container>
-struct test_iterator_range {
+template <typename Container, lib::it_range_cache CacheType>
+struct test_iterator_range_type_params {
     using container_type = Container;
+    static constexpr lib::it_range_cache cache_type = CacheType;
+};
+
+template <typename TypeParams>
+struct test_iterator_range {
+    using container_type = typename TypeParams::container_type;
     using iterator_type = lib_tt::iterator_type<container_type>;
+    using sut_type = lib_t::iterator_range<iterator_type, TypeParams::cache_type>;
 
     test_iterator_range() : container(size), sut(container.begin(), container.end()) {
         std::iota(container.begin(), container.end(), first_element);
@@ -27,13 +34,15 @@ struct test_iterator_range {
     static constexpr std::size_t first_element = 0ull;
     container_type container;
 
-    lib_t::iterator_range<iterator_type> sut;
+    sut_type sut;
 };
 
-TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", ContainerType, container_type_template) {
-    using container_type = ContainerType;
-    using fixture_type = test_iterator_range<container_type>;
+TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_template) {
+    using fixture_type = test_iterator_range<TypeParams>;
+    using container_type = typename fixture_type::container_type;
     using iterator_type = typename fixture_type::iterator_type;
+    using sut_type = typename fixture_type::sut_type;
+    constexpr lib::it_range_cache cache_type = sut_type::cache_type;
 
     fixture_type fixture;
 
@@ -51,7 +60,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", ContainerType, container_type_
     }
 
     SUBCASE("should properly initialize the begin and end iterator for a range constructor") {
-        lib_t::iterator_range<iterator_type> range_constructed_sut{container};
+        sut_type range_constructed_sut = lib::make_iterator_range<container_type, cache_type>(container);
 
         CHECK_EQ(range_constructed_sut.begin(), std::ranges::begin(container));
         CHECK_EQ(range_constructed_sut.end(), std::ranges::end(container));
@@ -63,13 +72,13 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", ContainerType, container_type_
     }
 
     SUBCASE("equality operator should return true only when both iterators are equal") {
-        lib_t::iterator_range<iterator_type> range{sut};
+        sut_type range{sut};
         REQUIRE_EQ(sut, range);
 
-        range = lib_t::iterator_range<iterator_type>{std::next(sut.begin()), sut.end()};
+        range = sut_type{std::next(sut.begin()), sut.end()};
         CHECK_NE(sut, range);
 
-        range = lib_t::iterator_range<iterator_type>{
+        range = sut_type{
             sut.begin(), std::next(sut.begin(), sut.distance() - 1)
         };
         CHECK_NE(sut, range);
@@ -110,79 +119,37 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", ContainerType, container_type_
             CHECK_EQ(std::addressof(sut.element_at(n)), std::addressof(*it++));
     }
 
-    SUBCASE("advance_begin should move the begin iterator by the the specified offset") {
-        for (std::ptrdiff_t n = 0ull; n < static_cast<std::ptrdiff_t>(fixture_type::size); n++) {
-            SUBCASE(("n = " + std::to_string(n)).c_str()) {
-                iterator_type it = std::ranges::next(container.begin(), n);
-
-                sut.advance_begin(n);
-                CHECK_EQ(sut.distance(), std::ranges::distance(it, container.end()));
-                CHECK_EQ(std::addressof(*sut.begin()), std::addressof(*it));
-            }
-        }
-    }
-
-    SUBCASE("advance_begin should move the begin iterator by the the specified offset for negative "
-            "difference") {
-        lib_t::iterator_range<iterator_type> narrow_range{container.end(), container.end()};
-
-        for (std::ptrdiff_t n = 0ull; n < static_cast<std::ptrdiff_t>(fixture_type::size); n++) {
-            const auto neg_n = -n;
-            SUBCASE(("n = " + std::to_string(neg_n)).c_str()) {
-                iterator_type it = std::ranges::next(container.end(), neg_n);
-
-                narrow_range.advance_begin(neg_n);
-                CHECK_EQ(narrow_range.distance(), std::ranges::distance(it, container.end()));
-                CHECK_EQ(std::addressof(*narrow_range.begin()), std::addressof(*it));
-            }
-        }
-    }
-
-    SUBCASE("advance_end should move the end iterator by the specified offset") {
-        lib_t::iterator_range<iterator_type> narrow_range{container.begin(), container.begin()};
-
-        for (std::ptrdiff_t n = 0ull; n < static_cast<std::ptrdiff_t>(fixture_type::size); n++) {
-            SUBCASE(("n = " + std::to_string(n)).c_str()) {
-                iterator_type it = std::ranges::next(container.begin(), n);
-
-                narrow_range.advance_end(n);
-                CHECK_EQ(narrow_range.distance(), std::ranges::distance(container.begin(), it));
-                CHECK_EQ(std::addressof(*narrow_range.end()), std::addressof(*it));
-            }
-        }
-    }
-
-    SUBCASE("advance_end should move the begin iterator by the the specified offset for negative "
-            "difference") {
-        for (std::ptrdiff_t n = 0ull; n < static_cast<std::ptrdiff_t>(fixture_type::size); n++) {
-            const auto neg_n = -n;
-            SUBCASE(("n = " + std::to_string(neg_n)).c_str()) {
-                iterator_type it = std::ranges::next(container.end(), neg_n);
-
-                sut.advance_end(neg_n);
-                CHECK_EQ(sut.distance(), std::ranges::distance(container.begin(), it));
-                CHECK_EQ(std::addressof(*sut.end()), std::addressof(*it));
-            }
-        }
-    }
-
     SUBCASE("make_iterator_range should return a properly initialized iterator_range") {
-        const auto range = lib::make_iterator_range(container.begin(), container.end());
-        CHECK_EQ(range, sut);
+        const auto range = lib::make_iterator_range<iterator_type, cache_type>(container.begin(), container.end());
+        CHECK(std::ranges::equal(range, container));
     }
 
     SUBCASE("make_iterator_range should return an iterator_range properly initialized with the "
             "container") {
-        const auto range = lib::make_iterator_range(container);
-        CHECK_EQ(range, sut);
+        const auto range = lib::make_iterator_range<container_type, cache_type>(container);
+        CHECK(std::ranges::equal(range, container));
+    }
+
+    SUBCASE("make_const_iterator_range should return an iterator_range properly initialized with the container") {
+        const auto range = lib::make_const_iterator_range<container_type, cache_type>(container);
+        CHECK(std::ranges::equal(range, container));
     }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    container_type_template,
-    std::vector<std::size_t>, // random access iterator
-    std::list<std::size_t>, // bidirectional iterator
-    std::forward_list<std::size_t> // forward iterator
+    type_params_template,
+    // cache_type::none
+    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::none>, // random access iterator
+    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::none>, // bidirectional iterator
+    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::none>, // forward iterator
+    // cache_type::lazy
+    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::lazy>, // random access iterator
+    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::lazy>, // bidirectional iterator
+    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::lazy>, // forward iterator
+    // cache_type::eager
+    test_iterator_range_type_params<std::vector<std::size_t>, lib::it_range_cache::eager>, // random access iterator
+    test_iterator_range_type_params<std::list<std::size_t>, lib::it_range_cache::eager>, // bidirectional iterator
+    test_iterator_range_type_params<std::forward_list<std::size_t>, lib::it_range_cache::eager> // forward iterator
 );
 
 TEST_SUITE_END(); // test_iterator_range


### PR DESCRIPTION
Added a distance caching option (eager, lazy or none) to the `iterator_range` class and aligned the the class to properly handle distance calculation