### PR TITLE
YT-CPPGL-19: Add a force_inline attribute

### DIFF
--- a/include/gl/attributes/force_inline.hpp
+++ b/include/gl/attributes/force_inline.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#ifndef gl_attr_force_inline
+
 #if defined(__clang__)
 #define gl_attr_force_inline [[clang::always_inline]] inline
 #elif defined(__GNUC__)
 #define gl_attr_force_inline [[gnu::always_inline]] inline
-#elif defined(_MSC_VER)
-#define gl_attr_force_inline [[msvc::forceinline]] inline
 #else
 #define gl_attr_force_inline inline
+#endif
+
 #endif

--- a/include/gl/attributes/force_inline.hpp
+++ b/include/gl/attributes/force_inline.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(__clang__)
+#define gl_attr_force_inline [[clang::always_inline]] inline
+#elif defined(__GNUC__)
+#define gl_attr_force_inline [[gnu::always_inline]] inline
+#elif defined(_MSC_VER)
+#define gl_attr_force_inline [[msvc::forceinline]] inline
+#else
+#define gl_attr_force_inline inline
+#endif

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "edge_tags.hpp"
+#include "gl/attributes/force_inline.hpp"
 #include "types/default_types.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
 #include "vertex_descriptor.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <memory>
 #include <type_traits>
@@ -55,7 +55,8 @@ public:
         return type_traits::is_undirected_v<type>;
     }
 
-    [[nodiscard]] gl_attr_force_inline const types::homogeneous_pair<vertex_ptr_type>& incident_vertices() const {
+    [[nodiscard]] const gl_attr_force_inline types::homogeneous_pair<vertex_ptr_type>&
+    incident_vertices() const {
         return this->_vertices;
     }
 

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -55,7 +55,7 @@ public:
         return type_traits::is_undirected_v<type>;
     }
 
-    [[nodiscard]] const gl_attr_force_inline types::homogeneous_pair<vertex_ptr_type>&
+    [[nodiscard]] gl_attr_force_inline const types::homogeneous_pair<vertex_ptr_type>&
     incident_vertices() const {
         return this->_vertices;
     }

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -55,10 +55,15 @@ public:
         return type_traits::is_undirected_v<type>;
     }
 
-    [[nodiscard]] gl_attr_force_inline const types::homogeneous_pair<vertex_ptr_type>&
-    incident_vertices() const {
+    // clang-format off
+    // gl_attr_force_inline misplacement
+
+    [[nodiscard]] gl_attr_force_inline
+    const types::homogeneous_pair<vertex_ptr_type>& incident_vertices() const {
         return this->_vertices;
     }
+
+    // clang-format on
 
     [[nodiscard]] gl_attr_force_inline vertex_ptr_type first() const {
         return this->_vertices.first;

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -5,6 +5,7 @@
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
 #include "vertex_descriptor.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <memory>
 #include <type_traits>
@@ -46,23 +47,23 @@ public:
 
     ~edge_descriptor() = default;
 
-    [[nodiscard]] inline constexpr bool is_directed() const {
+    [[nodiscard]] constexpr bool is_directed() const {
         return type_traits::is_directed_v<type>;
     }
 
-    [[nodiscard]] inline constexpr bool is_undirected() const {
+    [[nodiscard]] constexpr bool is_undirected() const {
         return type_traits::is_undirected_v<type>;
     }
 
-    [[nodiscard]] inline const types::homogeneous_pair<vertex_ptr_type>& incident_vertices() const {
+    [[nodiscard]] gl_attr_force_inline const types::homogeneous_pair<vertex_ptr_type>& incident_vertices() const {
         return this->_vertices;
     }
 
-    [[nodiscard]] inline vertex_ptr_type first() const {
+    [[nodiscard]] gl_attr_force_inline vertex_ptr_type first() const {
         return this->_vertices.first;
     }
 
-    [[nodiscard]] inline vertex_ptr_type second() const {
+    [[nodiscard]] gl_attr_force_inline vertex_ptr_type second() const {
         return this->_vertices.second;
     }
 
@@ -76,19 +77,19 @@ public:
         return nullptr;
     }
 
-    [[nodiscard]] inline bool is_incident_with(const vertex_ptr_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_ptr_type& vertex) const {
         return *vertex == *this->_vertices.first or *vertex == *this->_vertices.second;
     }
 
-    [[nodiscard]] inline bool is_incident_from(const vertex_ptr_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline bool is_incident_from(const vertex_ptr_type& vertex) const {
         return directional_tag::is_incident_from(*this, vertex);
     }
 
-    [[nodiscard]] inline bool is_incident_to(const vertex_ptr_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline bool is_incident_to(const vertex_ptr_type& vertex) const {
         return directional_tag::is_incident_to(*this, vertex);
     }
 
-    [[nodiscard]] inline bool is_loop() const {
+    [[nodiscard]] gl_attr_force_inline bool is_loop() const {
         return *this->_vertices.first == *this->_vertices.second;
     }
 

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "types/default_types.hpp"
 #include "types/type_traits.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <memory>
 
@@ -127,19 +127,23 @@ struct undirected_t {
 };
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
-[[nodiscard]] gl_attr_force_inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
-    const typename EdgeType::vertex_ptr_type& first,
-    const typename EdgeType::vertex_ptr_type& second
-) {
+[[nodiscard]] gl_attr_force_inline
+    typename EdgeType::directional_tag::template edge_ptr_type<EdgeType>
+    make_edge(
+        const typename EdgeType::vertex_ptr_type& first,
+        const typename EdgeType::vertex_ptr_type& second
+    ) {
     return EdgeType::directional_tag::template make<EdgeType>(first, second);
 }
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
-[[nodiscard]] gl_attr_force_inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
-    const typename EdgeType::vertex_ptr_type& first,
-    const typename EdgeType::vertex_ptr_type& second,
-    const typename EdgeType::properties_type& properties
-) {
+[[nodiscard]] gl_attr_force_inline
+    typename EdgeType::directional_tag::template edge_ptr_type<EdgeType>
+    make_edge(
+        const typename EdgeType::vertex_ptr_type& first,
+        const typename EdgeType::vertex_ptr_type& second,
+        const typename EdgeType::properties_type& properties
+    ) {
     return EdgeType::directional_tag::template make<EdgeType>(first, second, properties);
 }
 

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -2,6 +2,7 @@
 
 #include "types/default_types.hpp"
 #include "types/type_traits.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <memory>
 
@@ -48,7 +49,7 @@ struct directed_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
-    [[nodiscard]] static inline edge_ptr_type<EdgeType> make(
+    [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
         const typename EdgeType::vertex_ptr_type& first,
         const typename EdgeType::vertex_ptr_type& second
     ) {
@@ -57,7 +58,7 @@ struct directed_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
-    [[nodiscard]] static inline edge_ptr_type<EdgeType> make(
+    [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
         const typename EdgeType::vertex_ptr_type& first,
         const typename EdgeType::vertex_ptr_type& second,
         const typename EdgeType::properties_type& properties
@@ -67,7 +68,7 @@ struct directed_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
-    static inline bool is_incident_from(
+    [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
         return *vertex == *edge._vertices.first;
@@ -75,7 +76,7 @@ struct directed_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
-    static inline bool is_incident_to(
+    [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
         return *vertex == *edge._vertices.second;
@@ -91,7 +92,7 @@ struct undirected_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
-    [[nodiscard]] static inline edge_ptr_type<EdgeType> make(
+    [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
         const typename EdgeType::vertex_ptr_type& first,
         const typename EdgeType::vertex_ptr_type& second
     ) {
@@ -100,7 +101,7 @@ struct undirected_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
-    [[nodiscard]] static inline edge_ptr_type<EdgeType> make(
+    [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
         const typename EdgeType::vertex_ptr_type& first,
         const typename EdgeType::vertex_ptr_type& second,
         const typename EdgeType::properties_type& properties
@@ -110,7 +111,7 @@ struct undirected_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
-    static inline bool is_incident_from(
+    [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
         return edge.is_incident_with(vertex);
@@ -118,7 +119,7 @@ struct undirected_t {
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
-    static inline bool is_incident_to(
+    [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
         return edge.is_incident_with(vertex);
@@ -126,7 +127,7 @@ struct undirected_t {
 };
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
-[[nodiscard]] inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
+[[nodiscard]] gl_attr_force_inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
     const typename EdgeType::vertex_ptr_type& first,
     const typename EdgeType::vertex_ptr_type& second
 ) {
@@ -134,7 +135,7 @@ template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
 }
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
-[[nodiscard]] inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
+[[nodiscard]] gl_attr_force_inline typename EdgeType::directional_tag::template edge_ptr_type<EdgeType> make_edge(
     const typename EdgeType::vertex_ptr_type& first,
     const typename EdgeType::vertex_ptr_type& second,
     const typename EdgeType::properties_type& properties

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "graph_traits.hpp"
 #include "impl/impl_tags.hpp"
 #include "types/formatter.hpp"
 #include "types/iterator_range.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <algorithm>
 
@@ -91,7 +91,9 @@ public:
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& get_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] const gl_attr_force_inline vertex_ptr_type& get_vertex(
+        const types::id_type vertex_id
+    ) const {
         return this->_vertices.at(vertex_id);
     }
 
@@ -108,11 +110,12 @@ public:
         return make_iterator_range(this->_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices_c() const {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices_c(
+    ) const {
         return make_const_iterator_range(this->_vertices);
     }
 
-    gl_attr_force_inline const edge_ptr_type& add_edge(
+    const gl_attr_force_inline edge_ptr_type& add_edge(
         const types::id_type first_id, const types::id_type second_id
     ) {
         return this->_impl.add_edge(
@@ -120,7 +123,7 @@ public:
         );
     }
 
-    gl_attr_force_inline const edge_ptr_type& add_edge(
+    const gl_attr_force_inline edge_ptr_type& add_edge(
         const types::id_type first_id,
         const types::id_type second_id,
         const edge_properties_type& properties
@@ -160,9 +163,8 @@ public:
         return this->_impl.adjacent_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
-        const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
+    adjacent_edges_c(const types::id_type vertex_id) const {
         return this->_impl.adjacent_edges_c(vertex_id);
     }
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -91,11 +91,16 @@ public:
         );
     }
 
+    // clang-format off
+    // gl_attr_force_inline misplacement
+
     [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& get_vertex(
         const types::id_type vertex_id
     ) const {
         return this->_vertices.at(vertex_id);
     }
+
+    // clang-format on
 
     gl_attr_force_inline void remove_vertex(const types::size_type vertex_id) {
         this->_remove_vertex_impl(this->get_vertex(vertex_id));
@@ -114,6 +119,9 @@ public:
     ) const {
         return make_const_iterator_range(this->_vertices);
     }
+
+    // clang-format off
+    // gl_attr_force_inline misplacement
 
     gl_attr_force_inline const edge_ptr_type& add_edge(
         const types::id_type first_id, const types::id_type second_id
@@ -134,6 +142,8 @@ public:
             this->get_vertex(first_id), this->get_vertex(second_id), properties
         ));
     }
+
+    // clang-format on
 
     const edge_ptr_type& add_edge(const vertex_ptr_type& first, const vertex_ptr_type& second) {
         this->_verify_vertex(first);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -6,6 +6,7 @@
 #include "types/iterator_range.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <algorithm>
 
@@ -68,11 +69,11 @@ public:
 
     ~graph() = default;
 
-    [[nodiscard]] inline types::size_type n_vertices() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_vertices() const {
         return this->_vertices.size();
     }
 
-    [[nodiscard]] inline types::size_type n_unique_edges() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_unique_edges() const {
         return this->_impl.n_unique_edges();
     }
 
@@ -90,11 +91,11 @@ public:
         );
     }
 
-    [[nodiscard]] inline const vertex_ptr_type& get_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& get_vertex(const types::id_type vertex_id) const {
         return this->_vertices.at(vertex_id);
     }
 
-    inline void remove_vertex(const types::size_type vertex_id) {
+    gl_attr_force_inline void remove_vertex(const types::size_type vertex_id) {
         this->_remove_vertex_impl(this->get_vertex(vertex_id));
     }
 
@@ -103,15 +104,15 @@ public:
         this->_remove_vertex_impl(vertex);
     }
 
-    [[nodiscard]] inline types::iterator_range<vertex_iterator_type> vertices() {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices() {
         return make_iterator_range(this->_vertices);
     }
 
-    [[nodiscard]] inline types::iterator_range<vertex_const_iterator_type> vertices_c() const {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices_c() const {
         return make_const_iterator_range(this->_vertices);
     }
 
-    inline const edge_ptr_type& add_edge(
+    gl_attr_force_inline const edge_ptr_type& add_edge(
         const types::id_type first_id, const types::id_type second_id
     ) {
         return this->_impl.add_edge(
@@ -119,7 +120,7 @@ public:
         );
     }
 
-    inline const edge_ptr_type& add_edge(
+    gl_attr_force_inline const edge_ptr_type& add_edge(
         const types::id_type first_id,
         const types::id_type second_id,
         const edge_properties_type& properties
@@ -149,17 +150,17 @@ public:
         return this->_impl.add_edge(make_edge<edge_type>(first, second, properties));
     }
 
-    inline void remove_edge(const edge_ptr_type& edge) {
+    gl_attr_force_inline void remove_edge(const edge_ptr_type& edge) {
         this->_impl.remove_edge(edge);
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) {
         return this->_impl.adjacent_edges(vertex_id);
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
         const types::id_type vertex_id
     ) const {
         return this->_impl.adjacent_edges_c(vertex_id);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -91,7 +91,7 @@ public:
         );
     }
 
-    [[nodiscard]] const gl_attr_force_inline vertex_ptr_type& get_vertex(
+    [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& get_vertex(
         const types::id_type vertex_id
     ) const {
         return this->_vertices.at(vertex_id);
@@ -115,7 +115,7 @@ public:
         return make_const_iterator_range(this->_vertices);
     }
 
-    const gl_attr_force_inline edge_ptr_type& add_edge(
+    gl_attr_force_inline const edge_ptr_type& add_edge(
         const types::id_type first_id, const types::id_type second_id
     ) {
         return this->_impl.add_edge(
@@ -123,7 +123,7 @@ public:
         );
     }
 
-    const gl_attr_force_inline edge_ptr_type& add_edge(
+    gl_attr_force_inline const edge_ptr_type& add_edge(
         const types::id_type first_id,
         const types::id_type second_id,
         const edge_properties_type& properties

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "gl/types/iterator_range.hpp"
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_list.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <vector>
 
@@ -51,7 +51,7 @@ public:
         this->_list.push_back(edge_set_type{});
     }
 
-    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
+    const gl_attr_force_inline edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 
@@ -69,9 +69,8 @@ public:
         return make_iterator_range(this->_list.at(vertex_id));
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
-        const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
+    adjacent_edges_c(const types::id_type vertex_id) const {
         return make_const_iterator_range(this->_list.at(vertex_id));
     }
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -3,6 +3,7 @@
 #include "gl/types/iterator_range.hpp"
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_list.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <vector>
 
@@ -38,37 +39,37 @@ public:
 
     ~adjacency_list() = default;
 
-    [[nodiscard]] inline types::size_type n_vertices() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_vertices() const {
         return this->_list.size();
     }
 
-    [[nodiscard]] inline types::size_type n_unique_edges() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_unique_edges() const {
         return this->_n_unique_edges;
     }
 
-    inline void add_vertex() {
+    gl_attr_force_inline void add_vertex() {
         this->_list.push_back(edge_set_type{});
     }
 
-    inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
+    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 
-    inline void remove_vertex(const vertex_ptr_type& vertex) {
+    gl_attr_force_inline void remove_vertex(const vertex_ptr_type& vertex) {
         specialized::remove_vertex(*this, vertex);
     }
 
-    inline void remove_edge(const edge_ptr_type& edge) {
+    gl_attr_force_inline void remove_edge(const edge_ptr_type& edge) {
         specialized::remove_edge(*this, edge);
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) {
         return make_iterator_range(this->_list.at(vertex_id));
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
         const types::id_type vertex_id
     ) const {
         return make_const_iterator_range(this->_list.at(vertex_id));
@@ -79,7 +80,7 @@ private:
     friend specialized;
 
     struct address_projection {
-        auto operator()(const edge_ptr_type& edge) const {
+        gl_attr_force_inline auto operator()(const edge_ptr_type& edge) const {
             return edge.get();
         }
     };

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -51,7 +51,7 @@ public:
         this->_list.push_back(edge_set_type{});
     }
 
-    const gl_attr_force_inline edge_ptr_type& add_edge(edge_ptr_type edge) {
+    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -51,9 +51,14 @@ public:
         this->_list.push_back(edge_set_type{});
     }
 
+    // clang-format off
+    // gl_attr_force_inline misplacement
+
     gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
+
+    // clang-format on
 
     gl_attr_force_inline void remove_vertex(const vertex_ptr_type& vertex) {
         specialized::remove_vertex(*this, vertex);

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -62,9 +62,14 @@ public:
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
     }
 
+    // clang-format off
+    // gl_attr_force_inline misplacement
+
     gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
+
+    // clang-format on
 
     gl_attr_force_inline void remove_vertex(const vertex_ptr_type& vertex) {
         specialized::remove_vertex(*this, vertex);

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -62,7 +62,7 @@ public:
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
     }
 
-    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
+    const gl_attr_force_inline edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -62,7 +62,7 @@ public:
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
     }
 
-    const gl_attr_force_inline edge_ptr_type& add_edge(edge_ptr_type edge) {
+    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -46,11 +46,11 @@ public:
 
     ~adjacency_matrix() = default;
 
-    [[nodiscard]] inline types::size_type n_vertices() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_vertices() const {
         return this->_matrix.size();
     }
 
-    [[nodiscard]] inline types::size_type n_unique_edges() const {
+    [[nodiscard]] gl_attr_force_inline types::size_type n_unique_edges() const {
         return this->_n_unique_edges;
     }
 
@@ -62,15 +62,15 @@ public:
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
     }
 
-    inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
+    gl_attr_force_inline const edge_ptr_type& add_edge(edge_ptr_type edge) {
         return specialized::add_edge(*this, std::move(edge));
     }
 
-    inline void remove_vertex(const vertex_ptr_type& vertex) {
+    gl_attr_force_inline void remove_vertex(const vertex_ptr_type& vertex) {
         specialized::remove_vertex(*this, vertex);
     }
 
-    inline void remove_edge(const edge_ptr_type& edge) {
+    gl_attr_force_inline void remove_edge(const edge_ptr_type& edge) {
         specialized::remove_edge(*this, edge);
     }
 

--- a/include/gl/types/formatter.hpp
+++ b/include/gl/types/formatter.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
+
 #include <type_traits>
 
 namespace gl::types {
 
 template <typename T>
-[[nodiscard]] inline void* formatter(T* ptr) {
+[[nodiscard]] gl_attr_force_inline void* formatter(T* ptr) {
     // std::format is not compatible with all types of ptrs
     return static_cast<void*>(ptr);
 }

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -2,6 +2,7 @@
 
 #include "type_traits.hpp"
 #include "types.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <format>
 #include <iterator>
@@ -68,25 +69,25 @@ public:
 
     bool operator==(const iterator_range&) const = default;
 
-    [[nodiscard]] inline iterator begin() const {
+    [[nodiscard]] gl_attr_force_inline iterator begin() const {
         return this->_range.first;
     }
 
-    [[nodiscard]] inline iterator end() const {
+    [[nodiscard]] gl_attr_force_inline iterator end() const {
         return this->_range.second;
     }
 
 #if __cplusplus >= 202302L
-    [[nodiscard]] inline auto cbegin() const {
+    [[nodiscard]] gl_attr_force_inline auto cbegin() const {
         return std::make_const_iterator(this->_range.first);
     }
 
-    [[nodiscard]] inline auto cend() const {
+    [[nodiscard]] gl_attr_force_inline auto cend() const {
         return std::make_const_iterator(this->_range.second);
     }
 #endif
 
-    [[nodiscard]] inline distance_type distance() const
+    [[nodiscard]] gl_attr_force_inline distance_type distance() const
     requires(cache_mode == type_traits::cache_mode::eager)
     {
         return this->_distance;
@@ -100,7 +101,7 @@ public:
         return this->_distance;
     }
 
-    [[nodiscard]] inline distance_type distance() const
+    [[nodiscard]] gl_attr_force_inline distance_type distance() const
     requires(cache_mode == type_traits::cache_mode::none)
     {
         return std::ranges::distance(this->begin(), this->end());
@@ -119,7 +120,7 @@ public:
     // TODO: add the [] operator
 
 private:
-    [[nodiscard]] inline bool _is_distance_uninitialized() const
+    [[nodiscard]] gl_attr_force_inline bool _is_distance_uninitialized() const
     requires(cache_mode == type_traits::cache_mode::lazy)
     {
         return this->_distance == _invalid_distance;
@@ -148,7 +149,7 @@ private:
 template <
     std::forward_iterator Iterator,
     type_traits::cache_mode CacheMode = _GL_IT_RANGE_DEFAULT_CACHE_MODE>
-[[nodiscard]] inline types::iterator_range<Iterator, CacheMode> make_iterator_range(
+[[nodiscard]] gl_attr_force_inline types::iterator_range<Iterator, CacheMode> make_iterator_range(
     Iterator begin, Iterator end
 ) {
     return types::iterator_range<Iterator, CacheMode>{begin, end};
@@ -157,7 +158,7 @@ template <
 template <
     type_traits::c_range Range,
     type_traits::cache_mode CacheMode = _GL_IT_RANGE_DEFAULT_CACHE_MODE>
-[[nodiscard]] inline types::iterator_range<typename Range::iterator, CacheMode> make_iterator_range(
+[[nodiscard]] gl_attr_force_inline types::iterator_range<typename Range::iterator, CacheMode> make_iterator_range(
     Range& range
 ) {
     return types::iterator_range<typename Range::iterator, CacheMode>{
@@ -168,7 +169,7 @@ template <
 template <
     type_traits::c_range Range,
     type_traits::cache_mode CacheMode = _GL_IT_RANGE_DEFAULT_CACHE_MODE>
-[[nodiscard]] inline types::iterator_range<typename Range::const_iterator, CacheMode>
+[[nodiscard]] gl_attr_force_inline types::iterator_range<typename Range::const_iterator, CacheMode>
 make_const_iterator_range(const Range& range) {
     return types::iterator_range<typename Range::const_iterator, CacheMode>{
         std::ranges::cbegin(range), std::ranges::cend(range)

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "type_traits.hpp"
 #include "types.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <format>
 #include <iterator>
@@ -158,9 +158,8 @@ template <
 template <
     type_traits::c_range Range,
     type_traits::cache_mode CacheMode = _GL_IT_RANGE_DEFAULT_CACHE_MODE>
-[[nodiscard]] gl_attr_force_inline types::iterator_range<typename Range::iterator, CacheMode> make_iterator_range(
-    Range& range
-) {
+[[nodiscard]] gl_attr_force_inline types::iterator_range<typename Range::iterator, CacheMode>
+make_iterator_range(Range& range) {
     return types::iterator_range<typename Range::iterator, CacheMode>{
         std::ranges::begin(range), std::ranges::end(range)
     };

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "type_traits.hpp"
 #include "gl/attributes/force_inline.hpp"
+#include "type_traits.hpp"
 
 #include <algorithm>
 

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "type_traits.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <algorithm>
 
@@ -76,22 +77,22 @@ private:
 } // namespace types
 
 template <type_traits::c_range Range>
-[[nodiscard]] auto non_null_begin(Range& range) {
+[[nodiscard]] gl_attr_force_inline auto non_null_begin(Range& range) {
     return types::non_null_iterator(std::ranges::begin(range), std::ranges::end(range));
 }
 
 template <type_traits::c_range Range>
-[[nodiscard]] auto non_null_end(Range& range) {
+[[nodiscard]] gl_attr_force_inline auto non_null_end(Range& range) {
     return types::non_null_iterator(std::ranges::end(range), std::ranges::end(range));
 }
 
 template <type_traits::c_const_range Range>
-[[nodiscard]] auto non_null_cbegin(Range& range) {
+[[nodiscard]] gl_attr_force_inline auto non_null_cbegin(Range& range) {
     return types::non_null_iterator(std::ranges::cbegin(range), std::ranges::cend(range));
 }
 
 template <type_traits::c_const_range Range>
-[[nodiscard]] auto non_null_cend(Range& range) {
+[[nodiscard]] gl_attr_force_inline auto non_null_cend(Range& range) {
     return types::non_null_iterator(std::ranges::cend(range), std::ranges::cend(range));
 }
 

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -33,30 +33,30 @@ public:
     non_null_iterator& operator=(const non_null_iterator&) = default;
     non_null_iterator& operator=(non_null_iterator&&) = default;
 
-    [[nodiscard]] reference operator*() const {
+    [[nodiscard]] gl_attr_force_inline reference operator*() const {
         return *this->_current;
     }
 
-    [[nodiscard]] pointer operator->() const {
+    [[nodiscard]] gl_attr_force_inline pointer operator->() const {
         return &(*this->_current);
     }
 
-    non_null_iterator& operator++() {
+    inline non_null_iterator& operator++() {
         this->_skip_null_elements();
         return *this;
     }
 
-    non_null_iterator operator++(int) {
+    inline non_null_iterator operator++(int) {
         non_null_iterator tmp = *this;
         this->_skip_null_elements();
         return tmp;
     }
 
-    [[nodiscard]] bool operator==(const non_null_iterator& other) const {
+    [[nodiscard]] gl_attr_force_inline bool operator==(const non_null_iterator& other) const {
         return this->_current == other._current;
     }
 
-    [[nodiscard]] bool operator!=(const non_null_iterator& other) const {
+    [[nodiscard]] gl_attr_force_inline bool operator!=(const non_null_iterator& other) const {
         return this->_current != other._current;
     }
 

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "edge_tags.hpp"
+#include "gl/attributes/force_inline.hpp"
 #include "gl/impl/impl_tags_decl.hpp"
 #include "types/default_types.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
-#include "gl/attributes/force_inline.hpp"
 
 #include <compare>
 

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -5,6 +5,7 @@
 #include "types/default_types.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
+#include "gl/attributes/force_inline.hpp"
 
 #include <compare>
 
@@ -44,15 +45,15 @@ public:
 
     ~vertex_descriptor() = default;
 
-    bool operator==(const vertex_descriptor& other) const {
+    gl_attr_force_inline bool operator==(const vertex_descriptor& other) const {
         return this->_id == other._id;
     }
 
-    std::strong_ordering operator<=>(const vertex_descriptor& other) const {
+    gl_attr_force_inline std::strong_ordering operator<=>(const vertex_descriptor& other) const {
         return this->_id <=> other._id;
     }
 
-    [[nodiscard]] inline types::id_type id() const {
+    [[nodiscard]] gl_attr_force_inline types::id_type id() const {
         return this->_id;
     }
 


### PR DESCRIPTION
Added the `gl_attr_force_inline` macro which defines forcing inline attributes for GNU GCC and CLANG compiler