### PR TITLE
YT-CPPGL-20: Align the functions returning iterator_range

### DIFF
--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -111,13 +111,13 @@ public:
         this->_remove_vertex_impl(vertex);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices() {
-        return make_iterator_range(this->_vertices);
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices_c(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices(
     ) const {
         return make_const_iterator_range(this->_vertices);
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices_mut() {
+        return make_iterator_range(this->_vertices);
     }
 
     // clang-format off

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -167,15 +167,15 @@ public:
         this->_impl.remove_edge(edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
-        const types::id_type vertex_id
-    ) {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
+    adjacent_edges(const types::id_type vertex_id) const {
         return this->_impl.adjacent_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
-    adjacent_edges_c(const types::id_type vertex_id) const {
-        return this->_impl.adjacent_edges_c(vertex_id);
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
+        const types::id_type vertex_id
+    ) {
+        return this->_impl.adjacent_edges_mut(vertex_id);
     }
 
 private:

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -68,15 +68,15 @@ public:
         specialized::remove_edge(*this, edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
+    adjacent_edges(const types::id_type vertex_id) const {
+        return make_const_iterator_range(this->_list.at(vertex_id));
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
         const types::id_type vertex_id
     ) {
         return make_iterator_range(this->_list.at(vertex_id));
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
-    adjacent_edges_c(const types::id_type vertex_id) const {
-        return make_const_iterator_range(this->_list.at(vertex_id));
     }
 
 private:

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -79,18 +79,18 @@ public:
         specialized::remove_edge(*this, edge);
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
-        const types::id_type vertex_id
-    ) {
-        auto& row = this->_matrix.at(vertex_id);
-        return make_iterator_range(non_null_begin(row), non_null_end(row));
-    }
-
-    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges_c(
+    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
         const auto& row = this->_matrix.at(vertex_id);
         return make_iterator_range(non_null_cbegin(row), non_null_cend(row));
+    }
+
+    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
+        const types::id_type vertex_id
+    ) {
+        auto& row = this->_matrix.at(vertex_id);
+        return make_iterator_range(non_null_begin(row), non_null_end(row));
     }
 
 private:

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -21,7 +21,7 @@ struct directed_adjacency_matrix {
     static void remove_vertex(impl_type& self, const vertex_ptr_type& vertex) {
         const auto vertex_id = vertex->id();
 
-        self._n_unique_edges -= self.adjacent_edges_c(vertex_id).distance();
+        self._n_unique_edges -= self.adjacent_edges(vertex_id).distance();
         self._matrix.erase(std::next(std::begin(self._matrix), vertex->id()));
 
         for (auto& row : self._matrix) {
@@ -54,7 +54,7 @@ struct undirected_adjacency_matrix {
     static void remove_vertex(impl_type& self, const vertex_ptr_type& vertex) {
         const auto vertex_id = vertex->id();
 
-        self._n_unique_edges -= self.adjacent_edges_c(vertex_id).distance();
+        self._n_unique_edges -= self.adjacent_edges(vertex_id).distance();
         self._matrix.erase(std::next(std::begin(self._matrix), vertex->id()));
 
         for (auto& row : self._matrix)

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -30,7 +30,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
         std::ranges::for_each(constants::vertex_id_view, [&sut](const lib_t::id_type vertex_id) {
-            CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
+            CHECK_EQ(sut.adjacent_edges(vertex_id).distance(), constants::zero_elements);
         });
     }
 
@@ -106,9 +106,9 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
     REQUIRE(new_edge->is_incident_to(vertices[constants::vertex_id_2]));
 
-    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
+    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
     const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
     CHECK_EQ(new_edge_extracted.get(), new_edge.get());
@@ -119,7 +119,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -131,7 +131,7 @@ TEST_CASE_FIXTURE(
         sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex - constants::one_element
     );
 
-    adjacent_edges = sut.adjacent_edges(constants::first_element_idx);
+    adjacent_edges = sut.adjacent_edges_mut(constants::first_element_idx);
     REQUIRE_EQ(
         adjacent_edges.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -164,7 +164,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(n_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);
@@ -217,8 +217,8 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
-    const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+    const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+    const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
     REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
@@ -239,7 +239,7 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge->is_loop());
     REQUIRE(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
 
-    const auto adjacent_edges = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
@@ -252,7 +252,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -260,7 +260,7 @@ TEST_CASE_FIXTURE(
     const auto edge_to_remove_addr = edge_to_remove.get();
 
     const auto second_id = edge_to_remove->second()->id();
-    REQUIRE_EQ(sut.adjacent_edges_c(second_id).distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
@@ -268,7 +268,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
+    adjacent_edges_first = sut.adjacent_edges_mut(constants::first_element_idx);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -284,7 +284,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the second adjacent edges list has been properly aligned
-    const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
+    const auto adjacent_edges_second = sut.adjacent_edges(second_id);
     REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
     CHECK_EQ(
         std::ranges::find(
@@ -312,7 +312,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(n_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -30,7 +30,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
         std::ranges::for_each(constants::vertex_id_view, [&sut](const lib_t::id_type vertex_id) {
-            CHECK_EQ(sut.adjacent_edges_c(vertex_id).distance(), constants::zero_elements);
+            CHECK_EQ(sut.adjacent_edges(vertex_id).distance(), constants::zero_elements);
         });
     }
 
@@ -106,9 +106,9 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
     REQUIRE(new_edge->is_incident_to(vertices[constants::vertex_id_2]));
 
-    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-    CHECK_EQ(sut.adjacent_edges_c(constants::vertex_id_2).distance(), constants::zero_elements);
+    CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
     const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
     CHECK_EQ(new_edge_extracted.get(), new_edge.get());
@@ -120,7 +120,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -133,7 +133,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the adjacent edges list has been properly aligned
-    adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -164,7 +164,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(n_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);
@@ -217,8 +217,8 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-    const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
-    const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+    const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+    const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
     REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
@@ -239,7 +239,7 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge->is_loop());
     REQUIRE(new_edge->is_incident_from(vertices[constants::vertex_id_1]));
 
-    const auto adjacent_edges = sut.adjacent_edges_c(constants::vertex_id_1);
+    const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
@@ -252,7 +252,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -260,7 +260,7 @@ TEST_CASE_FIXTURE(
     const auto edge_to_remove_addr = edge_to_remove.get();
 
     const auto second_id = edge_to_remove->second()->id();
-    REQUIRE_EQ(sut.adjacent_edges_c(second_id).distance(), constants::one_element);
+    REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
@@ -268,7 +268,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -281,7 +281,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the second adjacent edges list has been properly aligned
-    const auto adjacent_edges_second = sut.adjacent_edges_c(second_id);
+    const auto adjacent_edges_second = sut.adjacent_edges(second_id);
     REQUIRE_EQ(adjacent_edges_second.distance(), constants::zero_elements);
     CHECK_EQ(
         std::ranges::find(
@@ -309,7 +309,7 @@ TEST_CASE_FIXTURE(
 
     for (const auto vertex_id :
          constants::vertex_id_view | std::views::take(n_vertices_after_remove)) {
-        const auto adjacent_edges = sut.adjacent_edges_c(vertex_id);
+        const auto adjacent_edges = sut.adjacent_edges(vertex_id);
         REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_after_remove);
         CHECK_FALSE(std::ranges::any_of(adjacent_edges, [&removed_vertex](const auto& edge) {
             return edge->is_incident_with(removed_vertex);

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -62,7 +62,7 @@ struct test_graph {
                 | std::views::transform(transforms::extract_vertex_id<
                                         typename GraphType::vertex_type>),
             [this, &graph](const lib_t::id_type vertex_id) {
-                return graph.adjacent_edges_c(vertex_id).distance()
+                return graph.adjacent_edges(vertex_id).distance()
                     == n_incident_edges_for_fully_connected_vertex;
             }
         ));
@@ -121,7 +121,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
 
         CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const lib_t::id_type vertex_id) {
-            return not static_cast<bool>(sut.adjacent_edges_c(vertex_id).distance());
+            return not static_cast<bool>(sut.adjacent_edges(vertex_id).distance());
         }));
     }
 
@@ -133,7 +133,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto& vertex = sut.add_vertex();
             CHECK_EQ(vertex->id(), v_id);
             CHECK_EQ(sut.n_vertices(), v_id + constants::one_element);
-            CHECK_EQ(sut.adjacent_edges_c(v_id).distance(), constants::empty_distance);
+            CHECK_EQ(sut.adjacent_edges(v_id).distance(), constants::empty_distance);
         }
 
         CHECK_EQ(sut.n_vertices(), target_n_vertices);
@@ -207,7 +207,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const lib_t::id_type vertex_id) {
-                return sut.adjacent_edges_c(vertex_id).distance() == expected_n_incident_edges;
+                return sut.adjacent_edges(vertex_id).distance() == expected_n_incident_edges;
             }
         ));
 
@@ -242,7 +242,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const lib_t::id_type vertex_id) {
-                return sut.adjacent_edges_c(vertex_id).distance() == expected_n_incident_edges;
+                return sut.adjacent_edges(vertex_id).distance() == expected_n_incident_edges;
             }
         ));
 
@@ -276,13 +276,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+            const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
             CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
 
-            const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+            const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
@@ -314,13 +314,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+            const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
             CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
 
-            const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+            const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
@@ -337,8 +337,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
+            auto adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
 
             REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
             if constexpr (lib_tt::is_undirected_v<edge_type>)
@@ -347,8 +347,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
+            adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
 
             CHECK_EQ(adjacent_edges_1.distance(), constants::zero_elements);
             CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -387,13 +387,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+            const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
             CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
 
-            const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+            const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
@@ -434,13 +434,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            const auto adjacent_edges_1 = sut.adjacent_edges_c(constants::vertex_id_1);
+            const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
             CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
 
-            const auto adjacent_edges_2 = sut.adjacent_edges_c(constants::vertex_id_2);
+            const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
@@ -457,8 +457,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
+            auto adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
 
             REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
             if constexpr (lib_tt::is_undirected_v<edge_type>)
@@ -467,8 +467,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
+            adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
 
             CHECK_EQ(adjacent_edges_1.distance(), constants::zero_elements);
             CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -26,7 +26,7 @@ struct test_graph {
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     requires(lib_tt::is_directed_v<typename GraphType::edge_type>)
     void initialize_full_graph(GraphType& graph) {
-        const auto vertices = graph.vertices_c();
+        const auto vertices = graph.vertices();
         for (const auto& first : vertices)
             for (const auto& second : vertices)
                 if (*first != *second)
@@ -42,7 +42,7 @@ struct test_graph {
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     requires(lib_tt::is_undirected_v<typename GraphType::edge_type>)
     void initialize_full_graph(GraphType& graph) {
-        const auto vertices = graph.vertices_c();
+        const auto vertices = graph.vertices();
         for (const auto& first : vertices)
             for (const auto& second : vertices)
                 if (*first < *second)
@@ -58,7 +58,7 @@ struct test_graph {
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     void validate_full_graph_edges(const GraphType& graph) {
         REQUIRE(std::ranges::all_of(
-            graph.vertices_c()
+            graph.vertices()
                 | std::views::transform(transforms::extract_vertex_id<
                                         typename GraphType::vertex_type>),
             [this, &graph](const lib_t::id_type vertex_id) {
@@ -111,7 +111,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         REQUIRE(std::ranges::equal(
-            sut.vertices_c() | std::views::transform(transforms::extract_vertex_id<>),
+            sut.vertices() | std::views::transform(transforms::extract_vertex_id<>),
             constants::vertex_id_view
         ));
 
@@ -161,13 +161,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK_EQ(*sut.get_vertex(added_vertex->id()), *added_vertex);
     }
 
-    SUBCASE("(c_)vertices should return the correct vertex list iterator range") {
+    SUBCASE("vertices(_mut) should return the correct vertex list iterator range") {
         sut_type sut{constants::n_elements};
 
-        const auto v_range = sut.vertices();
+        const auto v_range = sut.vertices_mut();
         CHECK(std::ranges::equal(v_range, fixture.get_vertex_list(sut)));
 
-        const auto v_crange = sut.vertices_c();
+        const auto v_crange = sut.vertices();
         CHECK(std::ranges::equal(v_crange, fixture.get_vertex_list(sut)));
     }
 
@@ -199,7 +199,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             fixture.n_incident_edges_for_fully_connected_vertex - constants::one_element;
 
         const auto vertex_id_view =
-            sut.vertices_c() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
+            sut.vertices() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
 
         REQUIRE(std::ranges::equal(
             vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)
@@ -234,7 +234,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             fixture.n_incident_edges_for_fully_connected_vertex - constants::one_element;
 
         const auto vertex_id_view =
-            sut.vertices_c() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
+            sut.vertices() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
 
         REQUIRE(std::ranges::equal(
             vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)
@@ -254,7 +254,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("add_edge tests with empty properties") {
         sut_type sut{constants::n_elements};
 
-        const auto vertices = sut.vertices_c();
+        const auto vertices = sut.vertices();
         const auto& vertex_1 = vertices.element_at(constants::vertex_id_1);
         const auto& vertex_2 = vertices.element_at(constants::vertex_id_2);
 
@@ -359,7 +359,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         using properties_traits_type = add_edge_property<traits_type, types::used_property>;
         lib::graph<properties_traits_type> sut{constants::n_elements};
 
-        const auto vertices = sut.vertices_c();
+        const auto vertices = sut.vertices();
         const auto& vertex_1 = vertices.element_at(constants::vertex_id_1);
         const auto& vertex_2 = vertices.element_at(constants::vertex_id_2);
 


### PR DESCRIPTION
Aligned the naming convention of all functions and methods which return an instance of `iterator_range`.
Changed `<range-func>` to `<range-func>_mut` and `<range-func>_c` to `<range-func>`.
