### PR TITLE
YT-CPPGL-34: Remove mutable range functions

### DIFF
--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -34,8 +34,7 @@ public:
     using vertex_properties_type = typename traits_type::vertex_properties_type;
 
     using vertex_set_type = std::vector<vertex_ptr_type>;
-    using vertex_iterator_type = typename vertex_set_type::iterator;
-    using vertex_const_iterator_type = typename vertex_set_type::const_iterator;
+    using vertex_iterator_type = typename vertex_set_type::const_iterator;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -46,7 +45,6 @@ public:
 
     using edge_set_type = typename implementation_type::edge_set_type;
     using edge_iterator_type = typename implementation_type::edge_iterator_type;
-    using edge_const_iterator_type = typename implementation_type::edge_const_iterator_type;
 
 #ifdef GL_TESTING
     friend struct ::gl_testing::test_graph<traits_type>;
@@ -124,13 +122,9 @@ public:
         this->_remove_vertex_impl(vertex);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_const_iterator_type> vertices(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices(
     ) const {
         return make_const_iterator_range(this->_vertices);
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices_mut() {
-        return make_iterator_range(this->_vertices);
     }
 
     // --- edge methods ---
@@ -198,29 +192,17 @@ public:
         this->_impl.remove_edge(edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
-    adjacent_edges(const types::id_type vertex_id) const {
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
+        const types::id_type vertex_id
+    ) const {
         return this->_impl.adjacent_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
-        const types::id_type vertex_id
-    ) {
-        return this->_impl.adjacent_edges_mut(vertex_id);
-    }
-
-    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges(
+    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const vertex_ptr_type& vertex
     ) const {
         this->_verify_vertex(vertex);
         return this->_impl.adjacent_edges(vertex->id());
-    }
-
-    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
-        const vertex_ptr_type& vertex
-    ) {
-        this->_verify_vertex(vertex);
-        return this->_impl.adjacent_edges_mut(vertex->id());
     }
 
     // --- incidence methods ---

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -20,8 +20,7 @@ public:
     using edge_directional_tag = typename GraphTraits::edge_directional_tag;
 
     using edge_set_type = std::vector<edge_ptr_type>;
-    using edge_iterator_type = typename edge_set_type::iterator;
-    using edge_const_iterator_type = typename edge_set_type::const_iterator;
+    using edge_iterator_type = typename edge_set_type::const_iterator;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -86,15 +85,10 @@ public:
         specialized::remove_edge(*this, edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_const_iterator_type>
-    adjacent_edges(const types::id_type vertex_id) const {
-        return make_const_iterator_range(this->_list.at(vertex_id));
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
+    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
-    ) {
-        return make_iterator_range(this->_list.at(vertex_id));
+    ) const {
+        return make_const_iterator_range(this->_list.at(vertex_id));
     }
 
 private:

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -20,9 +20,7 @@ public:
     using edge_directional_tag = typename GraphTraits::edge_directional_tag;
 
     using edge_set_type = std::vector<edge_ptr_type>;
-    using edge_iterator_type = types::non_null_iterator<typename edge_set_type::iterator>;
-    using edge_const_iterator_type =
-        types::non_null_iterator<typename edge_set_type::const_iterator>;
+    using edge_iterator_type = types::non_null_iterator<typename edge_set_type::const_iterator>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -96,18 +94,11 @@ public:
         specialized::remove_edge(*this, edge);
     }
 
-    [[nodiscard]] inline types::iterator_range<edge_const_iterator_type> adjacent_edges(
+    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
         const auto& row = this->_matrix.at(vertex_id);
         return make_iterator_range(non_null_cbegin(row), non_null_cend(row));
-    }
-
-    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges_mut(
-        const types::id_type vertex_id
-    ) {
-        auto& row = this->_matrix.at(vertex_id);
-        return make_iterator_range(non_null_begin(row), non_null_end(row));
     }
 
 private:

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -107,7 +107,12 @@ public:
         return std::ranges::distance(this->begin(), this->end());
     }
 
-    // TODO: non-const element_at if not const iterator
+    [[nodiscard]] inline value_type& element_at(types::size_type position)
+    requires(not type_traits::c_const_iterator<iterator>)
+    {
+        this->_validate_element_position(position);
+        return *std::ranges::next(this->begin(), position);
+    }
 
     [[nodiscard]] inline const value_type& element_at(types::size_type position) const {
         this->_validate_element_position(position);

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -107,17 +107,12 @@ public:
         return std::ranges::distance(this->begin(), this->end());
     }
 
-    [[nodiscard]] inline value_type& element_at(types::size_type position) {
-        this->_validate_element_position(position);
-        return *std::ranges::next(this->begin(), position);
-    }
+    // TODO: non-const element_at if not const iterator
 
     [[nodiscard]] inline const value_type& element_at(types::size_type position) const {
         this->_validate_element_position(position);
         return *std::ranges::next(this->begin(), position);
     }
-
-    // TODO: add the [] operator
 
 private:
     [[nodiscard]] gl_attr_force_inline bool _is_distance_uninitialized() const

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -51,4 +51,9 @@ template <typename T>
 concept c_strong_smart_ptr =
     c_instantiation_of<T, std::unique_ptr> or c_instantiation_of<T, std::shared_ptr>;
 
+template <typename T>
+concept c_const_iterator = requires(T iter) {
+    { *iter } -> std::same_as<const std::remove_cvref_t<decltype(*iter)>&>;
+};
+
 } // namespace gl::type_traits

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -174,7 +174,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -186,7 +186,7 @@ TEST_CASE_FIXTURE(
         sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex - constants::one_element
     );
 
-    adjacent_edges = sut.adjacent_edges_mut(constants::first_element_idx);
+    adjacent_edges = sut.adjacent_edges(constants::first_element_idx);
     REQUIRE_EQ(
         adjacent_edges.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -339,7 +339,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
+    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -355,7 +355,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges_mut(constants::first_element_idx);
+    adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -175,7 +175,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -188,7 +188,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the adjacent edges list has been properly aligned
-    adjacent_edges = sut.adjacent_edges_mut(constants::vertex_id_1);
+    adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -339,7 +339,7 @@ TEST_CASE_FIXTURE(
 ) {
     fully_connect_vertex(constants::vertex_id_1);
 
-    auto adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
+    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
@@ -355,7 +355,7 @@ TEST_CASE_FIXTURE(
     );
 
     // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges_mut(constants::vertex_id_1);
+    adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -194,14 +194,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK_EQ(*sut.get_vertex(added_vertex->id()), *added_vertex);
     }
 
-    SUBCASE("vertices(_mut) should return the correct vertex list iterator range") {
+    SUBCASE("vertices should return the correct vertex list iterator range") {
         sut_type sut{constants::n_elements};
 
-        const auto v_range = sut.vertices_mut();
+        const auto v_range = sut.vertices();
         CHECK(std::ranges::equal(v_range, fixture.get_vertex_list(sut)));
-
-        const auto v_crange = sut.vertices();
-        CHECK(std::ranges::equal(v_crange, fixture.get_vertex_list(sut)));
     }
 
     SUBCASE("remove_vertex(vertex) should throw if the id of the given is invalid") {
@@ -362,8 +359,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
             REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
             if constexpr (lib_tt::is_undirected_v<edge_type>)
@@ -372,8 +369,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
             CHECK_EQ(adjacent_edges_1.distance(), constants::zero_elements);
             CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -479,8 +476,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
             REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
             if constexpr (lib_tt::is_undirected_v<edge_type>)
@@ -489,8 +486,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges_mut(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges_mut(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
 
             CHECK_EQ(adjacent_edges_1.distance(), constants::zero_elements);
             CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -540,15 +537,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             func::discard_result(sut.adjacent_edges(fixture.out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.adjacent_edges_mut(fixture.out_of_range_vertex)),
-            std::out_of_range
-        );
-
-        CHECK_THROWS_AS(
             func::discard_result(sut.adjacent_edges(fixture.invalid_vertex)), std::logic_error
-        );
-        CHECK_THROWS_AS(
-            func::discard_result(sut.adjacent_edges_mut(fixture.invalid_vertex)), std::logic_error
         );
     }
 
@@ -558,7 +547,6 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         CHECK_NOTHROW([&sut, &vertex]() {
             CHECK_EQ(sut.adjacent_edges(vertex).distance(), constants::zero_elements);
-            CHECK_EQ(sut.adjacent_edges_mut(vertex).distance(), constants::zero_elements);
         }());
     }
 }


### PR DESCRIPTION
- Removed all graph structure methods returning an iterator_range with a non-const iterator type.
- Aligned iterator typename definitions