### PR TITLE
YT-CPPGL-18: Use unique_ptr for vertices

### DIFF
--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -3,15 +3,15 @@
 #include "edge_tags.hpp"
 #include "gl/attributes/force_inline.hpp"
 #include "types/default_types.hpp"
+#include "types/formatter.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
 #include "vertex_descriptor.hpp"
-#include "types/formatter.hpp"
 
+#include <format>
 #include <memory>
 #include <type_traits>
 #include <vector>
-#include <format>
 
 namespace gl {
 
@@ -65,8 +65,6 @@ public:
         return this->_vertices;
     }
 
-    // clang-format on
-
     [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& first() const {
         return this->_vertices.first;
     }
@@ -75,7 +73,8 @@ public:
         return this->_vertices.second;
     }
 
-    // TODO: align tests
+    // clang-format on
+
     [[nodiscard]] const vertex_ptr_type& incident_vertex(const vertex_ptr_type& vertex) const {
         if (vertex == this->_vertices.first)
             return this->_vertices.second;
@@ -89,8 +88,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_ptr_type& vertex) const {
-        return vertex == this->_vertices.first
-            or vertex == this->_vertices.second;
+        return vertex == this->_vertices.first or vertex == this->_vertices.second;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_incident_from(const vertex_ptr_type& vertex) const {
@@ -102,7 +100,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_loop() const {
-        return this->_vertices.first.get() == this->_vertices.second.get();
+        return this->_vertices.first == this->_vertices.second;
     }
 
     [[no_unique_address]] properties_type properties{};

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -6,10 +6,12 @@
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
 #include "vertex_descriptor.hpp"
+#include "types/formatter.hpp"
 
 #include <memory>
 #include <type_traits>
 #include <vector>
+#include <format>
 
 namespace gl {
 
@@ -59,36 +61,36 @@ public:
     // gl_attr_force_inline misplacement
 
     [[nodiscard]] gl_attr_force_inline
-    const types::homogeneous_pair<vertex_ptr_type>& incident_vertices() const {
+    const types::homogeneous_pair<const vertex_ptr_type&>& incident_vertices() const {
         return this->_vertices;
     }
 
     // clang-format on
 
-    [[nodiscard]] gl_attr_force_inline vertex_ptr_type first() const {
+    [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& first() const {
         return this->_vertices.first;
     }
 
-    [[nodiscard]] gl_attr_force_inline vertex_ptr_type second() const {
+    [[nodiscard]] gl_attr_force_inline const vertex_ptr_type& second() const {
         return this->_vertices.second;
     }
 
-    [[nodiscard]] vertex_ptr_type incident_vertex(const vertex_ptr_type& vertex) const {
-        const auto vertex_addr = vertex.get();
-
-        if (vertex_addr == this->_vertices.first.get())
+    // TODO: align tests
+    [[nodiscard]] const vertex_ptr_type& incident_vertex(const vertex_ptr_type& vertex) const {
+        if (vertex == this->_vertices.first)
             return this->_vertices.second;
 
-        if (vertex_addr == this->_vertices.second.get())
+        if (vertex == this->_vertices.second)
             return this->_vertices.first;
 
-        return nullptr;
+        throw std::logic_error(std::format(
+            "Got invalid vertex [id = {} | addr = ]", vertex->id(), types::formatter(vertex.get())
+        ));
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_ptr_type& vertex) const {
-        const auto vertex_addr = vertex.get();
-        return vertex_addr == this->_vertices.first.get()
-            or vertex_addr == this->_vertices.second.get();
+        return vertex == this->_vertices.first
+            or vertex == this->_vertices.second;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_incident_from(const vertex_ptr_type& vertex) const {
@@ -106,7 +108,7 @@ public:
     [[no_unique_address]] properties_type properties{};
 
 private:
-    types::homogeneous_pair<vertex_ptr_type> _vertices;
+    types::homogeneous_pair<const vertex_ptr_type&> _vertices;
 };
 
 template <

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -71,7 +71,7 @@ struct directed_t {
     [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
-        return vertex.get() == edge._vertices.first.get();
+        return vertex == edge._vertices.first;
     }
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
@@ -79,7 +79,7 @@ struct directed_t {
     [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
         const EdgeType& edge, const typename EdgeType::vertex_ptr_type& vertex
     ) {
-        return vertex.get() == edge._vertices.second.get();
+        return vertex == edge._vertices.second;
     }
 };
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -91,9 +91,7 @@ public:
     requires(not type_traits::is_default_properties_type_v<vertex_properties_type>)
     {
         this->_impl.add_vertex();
-        this->_vertices.push_back(
-            std::make_unique<vertex_type>(this->n_vertices(), properties)
-        );
+        this->_vertices.push_back(std::make_unique<vertex_type>(this->n_vertices(), properties));
         return this->_vertices.back();
     }
 
@@ -102,8 +100,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_vertex(const vertex_ptr_type& vertex) const {
-        return this->has_vertex(vertex->id())
-           and this->_vertices[vertex->id()].get() == vertex.get();
+        return this->has_vertex(vertex->id()) and this->_vertices[vertex->id()] == vertex;
     }
 
     // clang-format off
@@ -224,7 +221,7 @@ public:
 
     [[nodiscard]] bool are_incident(const vertex_ptr_type& first, const vertex_ptr_type& second)
         const {
-        if (first.get() == second.get()) {
+        if (first == second) {
             this->_verify_vertex(first);
             return true;
         }
@@ -256,7 +253,7 @@ private:
         const auto vertex_id = vertex->id();
         const auto& self_vertex = this->get_vertex(vertex_id);
 
-        if (vertex.get() != self_vertex.get())
+        if (vertex != self_vertex)
             throw std::logic_error(std::format(
                 "Got invalid vertex [id = {} | expected addr = {} | actual addr = {}]",
                 vertex_id,

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -55,10 +55,12 @@ public:
 
     graph() = default;
 
-    graph(const types::size_type n_vertices) : _vertices(n_vertices), _impl(n_vertices) {
+    graph(const types::size_type n_vertices) : _impl(n_vertices) {
+        this->_vertices.reserve(n_vertices);
+
         types::id_type vertex_id = 0ull;
-        std::ranges::generate(this->_vertices, [&vertex_id]() {
-            return std::make_shared<vertex_type>(vertex_id++);
+        std::ranges::generate_n(std::back_inserter(this->_vertices), n_vertices, [&vertex_id]() {
+            return std::make_unique<vertex_type>(vertex_id++);
         });
     }
 
@@ -79,18 +81,20 @@ public:
 
     // --- vertex methods ---
 
-    inline vertex_ptr_type add_vertex() {
+    inline const vertex_ptr_type& add_vertex() {
         this->_impl.add_vertex();
-        return this->_vertices.emplace_back(std::make_shared<vertex_type>(this->n_vertices()));
+        this->_vertices.push_back(std::make_unique<vertex_type>(this->n_vertices()));
+        return this->_vertices.back();
     }
 
-    inline vertex_ptr_type add_vertex(const vertex_properties_type& properties)
+    inline const vertex_ptr_type& add_vertex(const vertex_properties_type& properties)
     requires(not type_traits::is_default_properties_type_v<vertex_properties_type>)
     {
         this->_impl.add_vertex();
-        return this->_vertices.emplace_back(
-            std::make_shared<vertex_type>(this->n_vertices(), properties)
+        this->_vertices.push_back(
+            std::make_unique<vertex_type>(this->n_vertices(), properties)
         );
+        return this->_vertices.back();
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_vertex(const types::id_type vertex_id) const {

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -16,7 +16,7 @@ template <
     type_traits::c_graph_impl_tag ImplTag = impl::list_t>
 struct graph_traits {
     using vertex_type = vertex_descriptor<VertexProperties>;
-    using vertex_ptr_type = std::shared_ptr<vertex_type>;
+    using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
 
     using edge_type = edge_descriptor<vertex_type, EdgeDirectionalTag, EdgeProperties>;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -77,8 +77,7 @@ public:
 
     [[nodiscard]] inline bool has_edge(const edge_ptr_type& edge) const {
         const auto& adjacent_edges = this->_list.at(edge->first()->id());
-        return std::ranges::find(adjacent_edges, edge.get(), address_projection{})
-            != adjacent_edges.end();
+        return std::ranges::find(adjacent_edges, edge) != adjacent_edges.end();
     }
 
     gl_attr_force_inline void remove_edge(const edge_ptr_type& edge) {
@@ -94,12 +93,6 @@ public:
 private:
     using specialized = typename specialized::list_impl_traits<adjacency_list>::type;
     friend specialized;
-
-    struct address_projection {
-        gl_attr_force_inline auto operator()(const edge_ptr_type& edge) const {
-            return edge.get();
-        }
-    };
 
     type _list{};
     types::size_type _n_unique_edges{0ull};

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -87,7 +87,7 @@ public:
 
     [[nodiscard]] inline bool has_edge(const edge_ptr_type& edge) const {
         const auto& matrix_element = this->_matrix.at(edge->first()->id()).at(edge->second()->id());
-        return matrix_element != nullptr and matrix_element.get() == edge.get();
+        return matrix_element != nullptr and matrix_element == edge;
     }
 
     gl_attr_force_inline void remove_edge(const edge_ptr_type& edge) {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -49,10 +49,8 @@ struct directed_adjacency_list {
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {
-        using addr_proj = typename impl_type::address_projection;
-
         auto& adj_edges = self._list.at(edge->first()->id());
-        adj_edges.erase(std::ranges::find(adj_edges, edge.get(), addr_proj{}));
+        adj_edges.erase(std::ranges::find(adj_edges, edge));
         self._n_unique_edges--;
     }
 };
@@ -111,15 +109,12 @@ struct undirected_adjacency_list {
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {
-        using addr_proj = typename impl_type::address_projection;
-
-        const auto edge_addr = edge.get();
         auto& adj_edges_first = self._list.at(edge->first()->id());
         auto& adj_edges_second = self._list.at(edge->second()->id());
 
-        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge_addr, addr_proj{}));
+        adj_edges_first.erase(std::ranges::find(adj_edges_first, edge));
         if (not edge->is_loop())
-            adj_edges_second.erase(std::ranges::find(adj_edges_second, edge_addr, addr_proj{}));
+            adj_edges_second.erase(std::ranges::find(adj_edges_second, edge));
         self._n_unique_edges--;
     }
 };

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -71,8 +71,8 @@ struct undirected_adjacency_list {
         const auto vertex_id = vertex->id();
 
         for (const auto& edge : self._list.at(vertex_id)) {
-            const auto incident_vertex = edge->incident_vertex(vertex);
-            if (*incident_vertex == *vertex)
+            const auto& incident_vertex = edge->incident_vertex(vertex);
+            if (incident_vertex == vertex)
                 continue; // loop: will be removed with the vertex's list
 
             auto& adj_edges = self._list.at(incident_vertex->id());

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -69,7 +69,7 @@ using vertex = vertex_descriptor<Properties>;
 namespace types {
 
 template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
-using vertex_ptr_type = std::shared_ptr<VertexType>;
+using vertex_ptr_type = std::unique_ptr<VertexType>;
 
 } // namespace types
 

--- a/tests/include/transforms.hpp
+++ b/tests/include/transforms.hpp
@@ -9,7 +9,7 @@
 namespace gl_testing::transforms {
 
 template <lib_tt::c_instantiation_of<lib::vertex_descriptor> Vertextype = lib::vertex_descriptor<>>
-inline lib_t::id_type extract_vertex_id(const std::shared_ptr<Vertextype>& vertex) {
+inline lib_t::id_type extract_vertex_id(const lib_t::vertex_ptr_type<Vertextype>& vertex) {
     return vertex->id();
 }
 

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -134,7 +134,7 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
     const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted, new_edge);
 }
 
 TEST_CASE_FIXTURE(
@@ -192,7 +192,6 @@ TEST_CASE_FIXTURE(
         n_incident_edges_for_fully_connected_vertex - constants::one_element
     );
     // validate that the adjacent edges list has been properly aligned
-    CHECK_EQ(edge_to_remove.get(), adjacent_edges.element_at(constants::first_element_idx).get());
     CHECK_EQ(
         std::ranges::find(
             adjacent_edges, edge_to_remove_addr, transforms::address_projection<edge_type>{}
@@ -279,10 +278,10 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges_1.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_1, new_edge);
 
     const auto& new_edge_extracted_2 = adjacent_edges_2.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_2, new_edge);
 }
 
 TEST_CASE_FIXTURE(
@@ -298,7 +297,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_1, new_edge);
 }
 
 TEST_CASE_FIXTURE(
@@ -359,9 +358,6 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(
         adjacent_edges_first.distance(),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
-    );
-    CHECK_EQ(
-        edge_to_remove.get(), adjacent_edges_first.element_at(constants::first_element_idx).get()
     );
     CHECK_EQ(
         std::ranges::find(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -93,7 +93,7 @@ struct test_directed_adjacency_list {
 
     test_directed_adjacency_list() {
         for (const auto id : constants::vertex_id_view)
-            vertices.push_back(std::make_shared<vertex_type>(id));
+            vertices.push_back(std::make_unique<vertex_type>(id));
     }
 
     const edge_ptr_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
@@ -114,7 +114,7 @@ struct test_directed_adjacency_list {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<std::shared_ptr<vertex_type>> vertices;
+    std::vector<std::unique_ptr<vertex_type>> vertices;
 
     const lib_t::size_type n_unique_edges_in_full_graph =
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
@@ -235,7 +235,7 @@ struct test_undirected_adjacency_list {
 
     test_undirected_adjacency_list() {
         for (const auto id : constants::vertex_id_view)
-            vertices.push_back(std::make_shared<vertex_type>(id));
+            vertices.push_back(std::make_unique<vertex_type>(id));
     }
 
     const edge_ptr_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
@@ -257,7 +257,7 @@ struct test_undirected_adjacency_list {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<std::shared_ptr<vertex_type>> vertices;
+    std::vector<std::unique_ptr<vertex_type>> vertices;
 
     const lib_t::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -134,7 +134,7 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
     const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted, new_edge);
 }
 
 TEST_CASE_FIXTURE(
@@ -279,10 +279,10 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges_1.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_1, new_edge);
 
     const auto& new_edge_extracted_2 = adjacent_edges_2.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_2, new_edge);
 }
 
 TEST_CASE_FIXTURE(
@@ -298,7 +298,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
     const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
-    CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+    CHECK_EQ(new_edge_extracted_1, new_edge);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -93,7 +93,7 @@ struct test_directed_adjacency_matrix {
 
     test_directed_adjacency_matrix() {
         for (const auto id : constants::vertex_id_view)
-            vertices.push_back(std::make_shared<vertex_type>(id));
+            vertices.push_back(std::make_unique<vertex_type>(id));
     }
 
     const edge_ptr_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
@@ -114,7 +114,7 @@ struct test_directed_adjacency_matrix {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<std::shared_ptr<vertex_type>> vertices;
+    std::vector<std::unique_ptr<vertex_type>> vertices;
 
     static constexpr lib_t::size_type n_unique_edges_in_full_graph =
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
@@ -235,7 +235,7 @@ struct test_undirected_adjacency_matrix {
 
     test_undirected_adjacency_matrix() {
         for (const auto id : constants::vertex_id_view)
-            vertices.push_back(std::make_shared<vertex_type>(id));
+            vertices.push_back(std::make_unique<vertex_type>(id));
     }
 
     const edge_ptr_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
@@ -257,7 +257,7 @@ struct test_undirected_adjacency_matrix {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<std::shared_ptr<vertex_type>> vertices;
+    std::vector<std::unique_ptr<vertex_type>> vertices;
 
     static constexpr lib_t::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -1,6 +1,6 @@
 #include "constants.hpp"
-#include "types.hpp"
 #include "functional.hpp"
+#include "types.hpp"
 
 #include <gl/edge_descriptor.hpp>
 

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -1,5 +1,6 @@
 #include "constants.hpp"
 #include "types.hpp"
+#include "functional.hpp"
 
 #include <gl/edge_descriptor.hpp>
 
@@ -12,14 +13,14 @@ TEST_SUITE_BEGIN("test_edge_descriptor");
 struct test_edge_descriptor {
     using vertex_type = lib::vertex_descriptor<>;
 
-    std::shared_ptr<vertex_type> vd_1 = std::make_shared<vertex_type>(constants::vertex_id_1);
-    std::shared_ptr<vertex_type> vd_2 = std::make_shared<vertex_type>(constants::vertex_id_2);
-    std::shared_ptr<vertex_type> vd_3 = std::make_shared<vertex_type>(constants::vertex_id_3);
+    std::unique_ptr<vertex_type> vd_1 = std::make_unique<vertex_type>(constants::vertex_id_1);
+    std::unique_ptr<vertex_type> vd_2 = std::make_unique<vertex_type>(constants::vertex_id_2);
+    std::unique_ptr<vertex_type> vd_3 = std::make_unique<vertex_type>(constants::vertex_id_3);
 
-    std::shared_ptr<vertex_type> invalid_vd_1 =
-        std::make_shared<vertex_type>(constants::vertex_id_1);
-    std::shared_ptr<vertex_type> invalid_vd_2 =
-        std::make_shared<vertex_type>(constants::vertex_id_2);
+    std::unique_ptr<vertex_type> invalid_vd_1 =
+        std::make_unique<vertex_type>(constants::vertex_id_1);
+    std::unique_ptr<vertex_type> invalid_vd_2 =
+        std::make_unique<vertex_type>(constants::vertex_id_2);
 };
 
 TEST_CASE_FIXTURE(
@@ -66,25 +67,25 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("incident_vertices should return the pair of vertices the edge was initialized with") {
         const auto& vertices = sut.incident_vertices();
-        CHECK_EQ(*vertices.first, *fixture.vd_1);
-        CHECK_EQ(*vertices.second, *fixture.vd_2);
+        CHECK_EQ(vertices.first, fixture.vd_1);
+        CHECK_EQ(vertices.second, fixture.vd_2);
     }
 
     SUBCASE("first should return the first vertex descriptor the edge was initialized with") {
-        CHECK_EQ(*sut.first(), *fixture.vd_1);
+        CHECK_EQ(sut.first(), fixture.vd_1);
     }
 
     SUBCASE("second should return the second vertex descriptor the edge was initialized with") {
-        CHECK_EQ(*sut.second(), *fixture.vd_2);
+        CHECK_EQ(sut.second(), fixture.vd_2);
     }
 
-    SUBCASE("incident_vertex should return nullptr if input vertex is not incident with the edge") {
-        CHECK_FALSE(sut.incident_vertex(fixture.vd_3));
+    SUBCASE("incident_vertex should return throw if input vertex is not incident with the edge") {
+        CHECK_THROWS_AS(func::discard_result(sut.incident_vertex(fixture.vd_3)), std::logic_error);
     }
 
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {
-        CHECK_EQ(*sut.incident_vertex(fixture.vd_1), *fixture.vd_2);
-        CHECK_EQ(*sut.incident_vertex(fixture.vd_2), *fixture.vd_1);
+        CHECK_EQ(sut.incident_vertex(fixture.vd_1), fixture.vd_2);
+        CHECK_EQ(sut.incident_vertex(fixture.vd_2), fixture.vd_1);
     }
 
     SUBCASE("is_incident_with should return true when the given vertex is one of the connected "

--- a/tests/source/test_edge_tags.cpp
+++ b/tests/source/test_edge_tags.cpp
@@ -12,13 +12,13 @@ TEST_SUITE_BEGIN("test_edge_tags");
 struct test_edge_tags {
     using vertex_type = lib::vertex_descriptor<>;
 
-    std::shared_ptr<vertex_type> vd_1 = std::make_shared<vertex_type>(constants::vertex_id_1);
-    std::shared_ptr<vertex_type> vd_2 = std::make_shared<vertex_type>(constants::vertex_id_2);
+    std::unique_ptr<vertex_type> vd_1 = std::make_unique<vertex_type>(constants::vertex_id_1);
+    std::unique_ptr<vertex_type> vd_2 = std::make_unique<vertex_type>(constants::vertex_id_2);
 
-    std::shared_ptr<vertex_type> invalid_vd_1 =
-        std::make_shared<vertex_type>(constants::vertex_id_1);
-    std::shared_ptr<vertex_type> invalid_vd_2 =
-        std::make_shared<vertex_type>(constants::vertex_id_2);
+    std::unique_ptr<vertex_type> invalid_vd_1 =
+        std::make_unique<vertex_type>(constants::vertex_id_1);
+    std::unique_ptr<vertex_type> invalid_vd_2 =
+        std::make_unique<vertex_type>(constants::vertex_id_2);
 };
 
 struct test_directed_edge_tag : test_edge_tags {

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -72,10 +72,10 @@ struct test_graph {
     const lib_t::size_type n_incident_edges_for_fully_connected_vertex =
         constants::n_elements - constants::one_element;
 
-    const std::shared_ptr<vertex_type> out_of_range_vertex =
-        std::make_shared<vertex_type>(constants::out_of_range_elemenet_idx);
-    const std::shared_ptr<vertex_type> invalid_vertex =
-        std::make_shared<vertex_type>(constants::vertex_id_1);
+    const std::unique_ptr<vertex_type> out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+    const std::unique_ptr<vertex_type> invalid_vertex =
+        std::make_unique<vertex_type>(constants::vertex_id_1);
 };
 
 template <
@@ -178,7 +178,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             return sut.has_vertex(sut.get_vertex(vertex_id));
         }));
         CHECK(std::ranges::none_of(constants::vertex_id_view, [&sut](const auto vertex_id) {
-            return sut.has_vertex(std::make_shared<vertex_type>(vertex_id));
+            return sut.has_vertex(std::make_unique<vertex_type>(vertex_id));
         }));
         CHECK_FALSE(sut.has_vertex(fixture.out_of_range_vertex));
     }

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -307,14 +307,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
-            CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+            CHECK_EQ(new_edge_extracted_1, new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
                     adjacent_edges_2.element_at(constants::first_element_idx);
-                CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+                CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -340,14 +340,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
-            CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+            CHECK_EQ(new_edge_extracted_1, new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
                     adjacent_edges_2.element_at(constants::first_element_idx);
-                CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+                CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -413,14 +413,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
-            CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+            CHECK_EQ(new_edge_extracted_1, new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
                     adjacent_edges_2.element_at(constants::first_element_idx);
-                CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+                CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
@@ -457,14 +457,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
             const auto& new_edge_extracted_1 =
                 adjacent_edges_1.element_at(constants::first_element_idx);
-            CHECK_EQ(new_edge_extracted_1.get(), new_edge.get());
+            CHECK_EQ(new_edge_extracted_1, new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
                 const auto& new_edge_extracted_2 =
                     adjacent_edges_2.element_at(constants::first_element_idx);
-                CHECK_EQ(new_edge_extracted_2.get(), new_edge.get());
+                CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);

--- a/tests/source/test_graph_incidence.cpp
+++ b/tests/source/test_graph_incidence.cpp
@@ -12,10 +12,10 @@ TEST_SUITE_BEGIN("test_graph_incidence");
 struct test_graph_incidence {
     using vertex_type = lib::vertex_descriptor<>;
 
-    std::shared_ptr<vertex_type> invalid_vertex =
-        std::make_shared<vertex_type>(constants::vertex_id_1);
-    std::shared_ptr<vertex_type> out_of_range_vertex =
-        std::make_shared<vertex_type>(constants::out_of_range_elemenet_idx);
+    std::unique_ptr<vertex_type> invalid_vertex =
+        std::make_unique<vertex_type>(constants::vertex_id_1);
+    std::unique_ptr<vertex_type> out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
 };
 
 TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_template) {


### PR DESCRIPTION
- Changed the `vertex_ptr_type` from `std::shared_ptr` to `std::unique_ptr`
- Aligned dependant strucuteres to use the new type