### PR TITLE
YT-CPPGL-24: Proper graph element validation

### DIFF
--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -82,7 +82,7 @@ public:
         if (vertex == this->_vertices.second)
             return this->_vertices.first;
 
-        throw std::logic_error(std::format(
+        throw std::invalid_argument(std::format(
             "Got invalid vertex [id = {} | addr = ]", vertex->id(), types::formatter(vertex.get())
         ));
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -225,7 +225,7 @@ public:
         const {
         this->_verify_vertex(first);
         this->_verify_vertex(second);
-        return first == second or this->has_edge(first, second);
+        return first == second or this->has_edge(first->id(), second->id());
     }
 
     [[nodiscard]] bool are_incident(const vertex_ptr_type& vertex, const edge_ptr_type& edge) const {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -254,21 +254,21 @@ private:
         const auto& self_vertex = this->get_vertex(vertex_id);
 
         if (vertex != self_vertex)
-            throw std::logic_error(std::format(
+            throw std::invalid_argument(std::format(
                 "Got invalid vertex [id = {} | expected addr = {} | actual addr = {}]",
                 vertex_id,
-                types::formatter(self_vertex.get()),
-                types::formatter(vertex.get())
+                types::formatter(self_vertex),
+                types::formatter(vertex)
             ));
     }
 
     void _verify_edge(const edge_ptr_type& edge) const {
         if (not this->has_edge(edge))
-            throw std::logic_error(std::format(
+            throw std::invalid_argument(std::format(
                 "Got invalid edge [vertices = ({}, {}) | addr = {}]",
                 edge->first()->id(),
                 edge->second()->id(),
-                types::formatter(edge.get())
+                types::formatter(edge)
             ));
     }
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -196,8 +196,7 @@ public:
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
-        if (not this->has_vertex(vertex_id))
-            throw std::invalid_argument(std::format("Got invalid vertex id [{}]", vertex_id));
+        this->_verify_vertex_id(vertex_id);
         return this->_impl.adjacent_edges(vertex_id);
     }
 
@@ -212,23 +211,21 @@ public:
 
     [[nodiscard]] bool are_incident(const types::id_type first_id, const types::id_type second_id)
         const {
-        if (first_id == second_id) {
-            if (not this->has_vertex(first_id))
-                throw std::out_of_range(std::format("Got invalid vertex id [{}]", first_id));
+        this->_verify_vertex_id(first_id);
+
+        if (first_id == second_id)
             return true;
-        }
+
+        this->_verify_vertex_id(second_id);
 
         return this->has_edge(first_id, second_id);
     }
 
     [[nodiscard]] bool are_incident(const vertex_ptr_type& first, const vertex_ptr_type& second)
         const {
-        if (first == second) {
-            this->_verify_vertex(first);
-            return true;
-        }
-
-        return this->has_edge(first, second);
+        this->_verify_vertex(first);
+        this->_verify_vertex(second);
+        return first == second or this->has_edge(first, second);
     }
 
     [[nodiscard]] bool are_incident(const vertex_ptr_type& vertex, const edge_ptr_type& edge) const {
@@ -251,6 +248,11 @@ public:
     }
 
 private:
+    gl_attr_force_inline void _verify_vertex_id(const types::id_type vertex_id) const {
+        if (not this->has_vertex(vertex_id))
+            throw std::invalid_argument(std::format("Got invalid vertex id [{}]", vertex_id));
+    }
+
     void _verify_vertex(const vertex_ptr_type& vertex) const {
         const auto vertex_id = vertex->id();
         const auto& self_vertex = this->get_vertex(vertex_id);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -193,9 +193,11 @@ public:
         this->_impl.remove_edge(edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
+    [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
+        if (not this->has_vertex(vertex_id))
+            throw std::invalid_argument(std::format("Got invalid vertex id [{}]", vertex_id));
         return this->_impl.adjacent_edges(vertex_id);
     }
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -75,8 +75,12 @@ public:
         return specialized::has_edge(*this, first_id, second_id);
     }
 
-    [[nodiscard]] inline bool has_edge(const edge_ptr_type& edge) const {
-        const auto& adjacent_edges = this->_list.at(edge->first()->id());
+    [[nodiscard]] bool has_edge(const edge_ptr_type& edge) const {
+        const auto first_id = edge->first()->id();
+        if (first_id >= this->_list.size())
+            return false;
+
+        const auto& adjacent_edges = this->_list[first_id];
         return std::ranges::find(adjacent_edges, edge) != adjacent_edges.end();
     }
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -87,7 +87,7 @@ public:
     [[nodiscard]] gl_attr_force_inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
-        return make_const_iterator_range(this->_list.at(vertex_id));
+        return make_const_iterator_range(this->_list[vertex_id]);
     }
 
 private:

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -97,7 +97,7 @@ public:
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
         const types::id_type vertex_id
     ) const {
-        const auto& row = this->_matrix.at(vertex_id);
+        const auto& row = this->_matrix[vertex_id];
         return make_iterator_range(non_null_cbegin(row), non_null_cend(row));
     }
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -85,8 +85,16 @@ public:
         return this->_matrix[first_id][second_id] != nullptr;
     }
 
-    [[nodiscard]] inline bool has_edge(const edge_ptr_type& edge) const {
-        const auto& matrix_element = this->_matrix[edge->first()->id()][edge->second()->id()];
+    [[nodiscard]] bool has_edge(const edge_ptr_type& edge) const {
+        const auto first_id = edge->first()->id();
+        if (first_id >= this->_matrix.size())
+            return false;
+
+        const auto second_id = edge->second()->id();
+        if (second_id >= this->_matrix.size())
+            return false;
+
+        const auto& matrix_element = this->_matrix[first_id][second_id];
         return matrix_element != nullptr and matrix_element == edge;
     }
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -82,11 +82,11 @@ public:
     [[nodiscard]] gl_attr_force_inline bool has_edge(
         const types::id_type first_id, const types::id_type second_id
     ) const {
-        return this->_matrix.at(first_id).at(second_id) != nullptr;
+        return this->_matrix[first_id][second_id] != nullptr;
     }
 
     [[nodiscard]] inline bool has_edge(const edge_ptr_type& edge) const {
-        const auto& matrix_element = this->_matrix.at(edge->first()->id()).at(edge->second()->id());
+        const auto& matrix_element = this->_matrix[edge->first()->id()][edge->second()->id()];
         return matrix_element != nullptr and matrix_element == edge;
     }
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -56,14 +56,14 @@ struct directed_adjacency_list {
         return self._list.at(edge->first()->id()).emplace_back(std::move(edge));
     }
 
-    [[nodiscard]] inline static bool has_edge(
+    [[nodiscard]] static inline bool has_edge(
         const impl_type& self, const types::id_type first_id, const types::id_type second_id
     ) {
-        const auto& edge_set = self._list[first_id];
+        const auto& adjacent_edges = self._list[first_id];
         return std::ranges::find(
-                   edge_set, second_id, [](const auto& edge) { return edge->second()->id(); }
+                   adjacent_edges, second_id, [](const auto& edge) { return edge->second()->id(); }
                )
-            != edge_set.cend();
+            != adjacent_edges.cend();
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {
@@ -112,14 +112,14 @@ struct undirected_adjacency_list {
     [[nodiscard]] static inline bool has_edge(
         const impl_type& self, const types::id_type first_id, const types::id_type second_id
     ) {
-        const auto& edge_set = self._list[first_id];
+        const auto& adjacent_edges = self._list[first_id];
         return std::ranges::find_if(
-                   edge_set,
+                   adjacent_edges,
                    [second_id](const auto& edge) {
                        return edge->second()->id() == second_id or edge->first()->id() == second_id;
                    }
                )
-            != edge_set.cend();
+            != adjacent_edges.cend();
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -56,18 +56,14 @@ struct directed_adjacency_list {
         return self._list.at(edge->first()->id()).emplace_back(std::move(edge));
     }
 
-    [[nodiscard]] static inline bool has_edge(
+    [[nodiscard]] inline static bool has_edge(
         const impl_type& self, const types::id_type first_id, const types::id_type second_id
     ) {
-        // no need to check first - exception will be thrown in the at() function
-        if (second_id >= self._list.size())
-            throw std::out_of_range(std::format("Got invalid vertex id [{}]", second_id));
-
-        const auto& adjacent_edges = self._list.at(first_id);
+        const auto& edge_set = self._list[first_id];
         return std::ranges::find(
-                   adjacent_edges, second_id, [](const auto& edge) { return edge->second()->id(); }
+                   edge_set, second_id, [](const auto& edge) { return edge->second()->id(); }
                )
-            != adjacent_edges.cend();
+            != edge_set.cend();
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {
@@ -116,18 +112,14 @@ struct undirected_adjacency_list {
     [[nodiscard]] static inline bool has_edge(
         const impl_type& self, const types::id_type first_id, const types::id_type second_id
     ) {
-        // no need to check first - exception will be thrown in the at() function
-        if (second_id >= self._list.size())
-            throw std::out_of_range(std::format("Got invalid vertex id [{}]", second_id));
-
-        const auto& adjacent_edges = self._list.at(first_id);
+        const auto& edge_set = self._list[first_id];
         return std::ranges::find_if(
-                   adjacent_edges,
+                   edge_set,
                    [second_id](const auto& edge) {
                        return edge->second()->id() == second_id or edge->first()->id() == second_id;
                    }
                )
-            != adjacent_edges.cend();
+            != edge_set.cend();
     }
 
     static void remove_edge(impl_type& self, const edge_ptr_type& edge) {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -21,12 +21,13 @@ template <type_traits::c_instantiation_of<adjacency_list> AdjacencyList>
 ) {
     const auto it = std::ranges::find(edge_set, edge);
     if (it == edge_set.end())
-        throw std::logic_error(std::format(
+        throw std::invalid_argument(std::format(
             "Got invalid edge [vertices = ({}, {}) | addr = {}]",
             edge->first()->id(),
             edge->second()->id(),
-            types::formatter(edge.get())
+            types::formatter(edge)
         ));
+
     return it;
 }
 

--- a/include/gl/types/formatter.hpp
+++ b/include/gl/types/formatter.hpp
@@ -2,6 +2,7 @@
 
 #include "gl/attributes/force_inline.hpp"
 
+#include <memory>
 #include <type_traits>
 
 namespace gl::types {
@@ -10,6 +11,11 @@ template <typename T>
 [[nodiscard]] gl_attr_force_inline void* formatter(T* ptr) {
     // std::format is not compatible with all types of ptrs
     return static_cast<void*>(ptr);
+}
+
+template <type_traits::c_strong_smart_ptr PtrType>
+[[nodiscard]] gl_attr_force_inline void* formatter(const PtrType& ptr) {
+    return formatter(ptr.get());
 }
 
 } // namespace gl::types

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -169,6 +169,34 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
+TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+        ),
+        std::out_of_range
+    );
+
+    // the edge with an invalid vertex will not be found in the list
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+        ),
+        std::logic_error
+    );
+
+    // not existing edge between valid vertices
+    CHECK_THROWS_AS(
+        sut.remove_edge(lib::make_edge<edge_type>(
+            vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
+        )),
+        std::logic_error
+    );
+}
+
 TEST_CASE_FIXTURE(
     test_directed_adjacency_list, "remove_edge should remove the edge from the source vertex's list"
 ) {
@@ -330,6 +358,34 @@ TEST_CASE_FIXTURE(
     CHECK(sut.has_edge(valid_edge));
     CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list, "remove_edge should throw when an edge is invalid"
+) {
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+        ),
+        std::out_of_range
+    );
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+        ),
+        std::out_of_range
+    );
+
+    // not existing edge between valid vertices
+    CHECK_THROWS_AS(
+        sut.remove_edge(lib::make_edge<edge_type>(
+            vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
+        )),
+        std::logic_error
+    );
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -132,18 +132,27 @@ TEST_CASE_FIXTURE(
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    CHECK(sut.has_edge(valid_edge));
+
     const auto invalid_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
     );
+    CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
     const auto not_present_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
     );
-
-    CHECK(sut.has_edge(valid_edge));
-    CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+    ));
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+    ));
 }
 
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
@@ -323,18 +332,27 @@ TEST_CASE_FIXTURE(
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    CHECK(sut.has_edge(valid_edge));
+
     const auto invalid_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
     );
+    CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
     const auto not_present_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
     );
-
-    CHECK(sut.has_edge(valid_edge));
-    CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+    ));
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+    ));
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -185,7 +185,7 @@ TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when a
         sut.remove_edge(
             lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
         ),
-        std::logic_error
+        std::invalid_argument
     );
 
     // not existing edge between valid vertices
@@ -193,7 +193,7 @@ TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when a
         sut.remove_edge(lib::make_edge<edge_type>(
             vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
         )),
-        std::logic_error
+        std::invalid_argument
     );
 }
 
@@ -384,7 +384,7 @@ TEST_CASE_FIXTURE(
         sut.remove_edge(lib::make_edge<edge_type>(
             vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
         )),
-        std::logic_error
+        std::invalid_argument
     );
 }
 

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -47,29 +47,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.n_vertices(), target_n_vertices);
         CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
     }
-
-    SUBCASE("has_edge(id, id) throw for out of range vertex ids") {
-        SutType sut{constants::n_elements};
-
-        CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(
-                constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx
-            )),
-            std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            func::discard_result(
-                sut.has_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2)
-            ),
-            std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            func::discard_result(
-                sut.has_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx)
-            ),
-            std::out_of_range
-        );
-    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -132,18 +132,27 @@ TEST_CASE_FIXTURE(
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    CHECK(sut.has_edge(valid_edge));
+
     const auto invalid_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
     );
+    CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
     const auto not_present_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
     );
-
-    CHECK(sut.has_edge(valid_edge));
-    CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+    ));
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+    ));
 }
 
 TEST_CASE_FIXTURE(
@@ -324,18 +333,27 @@ TEST_CASE_FIXTURE(
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    CHECK(sut.has_edge(valid_edge));
+
     const auto invalid_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
     );
+    CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
     const auto not_present_edge = lib::make_edge<edge_type>(
         vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
     );
-
-    CHECK(sut.has_edge(valid_edge));
-    CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+    ));
+    CHECK_FALSE(sut.has_edge(
+        lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+    ));
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -169,7 +169,9 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
-TEST_CASE_FIXTURE(test_directed_adjacency_matrix, "remove_edge should throw when an edge is invalid") {
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "remove_edge should throw when an edge is invalid"
+) {
     const auto out_of_range_vertex =
         std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
 
@@ -357,6 +359,34 @@ TEST_CASE_FIXTURE(
     CHECK(sut.has_edge(valid_edge));
     CHECK_FALSE(sut.has_edge(invalid_edge));
     CHECK_FALSE(sut.has_edge(not_present_edge));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix, "remove_edge should throw when an edge is invalid"
+) {
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+        ),
+        std::out_of_range
+    );
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+        ),
+        std::out_of_range
+    );
+
+    // not existing edge between valid vertices
+    CHECK_THROWS_AS(
+        sut.remove_edge(lib::make_edge<edge_type>(
+            vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
+        )),
+        std::invalid_argument
+    );
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -169,6 +169,32 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
+TEST_CASE_FIXTURE(test_directed_adjacency_matrix, "remove_edge should throw when an edge is invalid") {
+    const auto out_of_range_vertex =
+        std::make_unique<vertex_type>(constants::out_of_range_elemenet_idx);
+
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(out_of_range_vertex, vertices[constants::vertex_id_2])
+        ),
+        std::out_of_range
+    );
+    CHECK_THROWS_AS(
+        sut.remove_edge(
+            lib::make_edge<edge_type>(vertices[constants::vertex_id_1], out_of_range_vertex)
+        ),
+        std::out_of_range
+    );
+
+    // not existing edge between valid vertices
+    CHECK_THROWS_AS(
+        sut.remove_edge(lib::make_edge<edge_type>(
+            vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
+        )),
+        std::invalid_argument
+    );
+}
+
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_edge should remove the edge from the source vertex's list"

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -47,29 +47,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.n_vertices(), target_n_vertices);
         CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
     }
-
-    SUBCASE("has_edge(id, id) throw for out of range vertex ids") {
-        SutType sut{constants::n_elements};
-
-        CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(
-                constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx
-            )),
-            std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            func::discard_result(
-                sut.has_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2)
-            ),
-            std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            func::discard_result(
-                sut.has_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx)
-            ),
-            std::out_of_range
-        );
-    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -80,7 +80,9 @@ TEST_CASE_TEMPLATE_DEFINE(
     }
 
     SUBCASE("incident_vertex should return throw if input vertex is not incident with the edge") {
-        CHECK_THROWS_AS(func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument);
+        CHECK_THROWS_AS(
+            func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument
+        );
     }
 
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -80,7 +80,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     }
 
     SUBCASE("incident_vertex should return throw if input vertex is not incident with the edge") {
-        CHECK_THROWS_AS(func::discard_result(sut.incident_vertex(fixture.vd_3)), std::logic_error);
+        CHECK_THROWS_AS(func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument);
     }
 
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -438,10 +438,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             );
 
             CHECK_THROWS_AS(
-                sut.add_edge(fixture.invalid_vertex, vertex_2, constants::used), std::invalid_argument
+                sut.add_edge(fixture.invalid_vertex, vertex_2, constants::used),
+                std::invalid_argument
             );
             CHECK_THROWS_AS(
-                sut.add_edge(vertex_1, fixture.invalid_vertex, constants::used), std::invalid_argument
+                sut.add_edge(vertex_1, fixture.invalid_vertex, constants::used),
+                std::invalid_argument
             );
         }
 

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -208,7 +208,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("remove_vertex(vertex) should throw if the id is valid but the address is not") {
         sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(sut.remove_vertex(fixture.invalid_vertex), std::logic_error);
+        CHECK_THROWS_AS(sut.remove_vertex(fixture.invalid_vertex), std::invalid_argument);
     }
 
     SUBCASE("remove_vertex(vertex) should remove the given vertex and align ids of remaining "
@@ -325,8 +325,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_THROWS_AS(sut.add_edge(fixture.out_of_range_vertex, vertex_2), std::out_of_range);
             CHECK_THROWS_AS(sut.add_edge(vertex_1, fixture.out_of_range_vertex), std::out_of_range);
 
-            CHECK_THROWS_AS(sut.add_edge(fixture.invalid_vertex, vertex_2), std::logic_error);
-            CHECK_THROWS_AS(sut.add_edge(vertex_1, fixture.invalid_vertex), std::logic_error);
+            CHECK_THROWS_AS(sut.add_edge(fixture.invalid_vertex, vertex_2), std::invalid_argument);
+            CHECK_THROWS_AS(sut.add_edge(vertex_1, fixture.invalid_vertex), std::invalid_argument);
         }
 
         SUBCASE("add_edge(vertices) should properly add the new edge") {
@@ -438,10 +438,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             );
 
             CHECK_THROWS_AS(
-                sut.add_edge(fixture.invalid_vertex, vertex_2, constants::used), std::logic_error
+                sut.add_edge(fixture.invalid_vertex, vertex_2, constants::used), std::invalid_argument
             );
             CHECK_THROWS_AS(
-                sut.add_edge(vertex_1, fixture.invalid_vertex, constants::used), std::logic_error
+                sut.add_edge(vertex_1, fixture.invalid_vertex, constants::used), std::invalid_argument
             );
         }
 
@@ -508,10 +508,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(fixture.invalid_vertex, vd_2)), std::logic_error
+            func::discard_result(sut.has_edge(fixture.invalid_vertex, vd_2)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(vd_1, fixture.invalid_vertex)), std::logic_error
+            func::discard_result(sut.has_edge(vd_1, fixture.invalid_vertex)), std::invalid_argument
         );
     }
 
@@ -537,7 +537,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             func::discard_result(sut.adjacent_edges(fixture.out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.adjacent_edges(fixture.invalid_vertex)), std::logic_error
+            func::discard_result(sut.adjacent_edges(fixture.invalid_vertex)), std::invalid_argument
         );
     }
 

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -532,6 +532,25 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK_FALSE(sut.has_edge(vd_2, vd_3));
     }
 
+    SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {
+        sut_type sut{constants::n_elements};
+        CHECK_THROWS_AS(
+            func::discard_result(sut.adjacent_edges(constants::out_of_range_elemenet_idx)),
+            std::invalid_argument
+        );
+    }
+
+    SUBCASE("adjacent_edges(id) should return a proper iterator range for a valid vertex") {
+        sut_type sut{constants::one_element};
+
+        CHECK_NOTHROW([&sut]() {
+            CHECK_EQ(
+                sut.adjacent_edges(constants::first_element_idx).distance(),
+                constants::zero_elements
+            );
+        }());
+    }
+
     SUBCASE("adjacent_edges(vertex) should throw if the vertex is invalid") {
         sut_type sut{constants::n_elements};
 

--- a/tests/source/test_graph_incidence.cpp
+++ b/tests/source/test_graph_incidence.cpp
@@ -82,13 +82,13 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
 
         CHECK_THROWS_AS(
             func::discard_result(sut.are_incident(fixture.invalid_vertex, fixture.invalid_vertex)),
-            std::logic_error
+            std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, vd_2)), std::logic_error
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, vd_2)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, fixture.invalid_vertex)), std::logic_error
+            func::discard_result(sut.are_incident(vd_1, fixture.invalid_vertex)), std::invalid_argument
         );
     }
 
@@ -111,17 +111,17 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto& edge = sut.add_edge(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::logic_error
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::logic_error
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::invalid_argument
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::logic_error
+            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::logic_error
+            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::invalid_argument
         );
     }
 
@@ -129,17 +129,17 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto invalid_edge = lib::make_edge<typename SutType::edge_type>(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::logic_error
+            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::logic_error
+            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::logic_error
+            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::logic_error
+            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
         );
     }
 
@@ -159,10 +159,10 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto invalid_edge = lib::make_edge<typename SutType::edge_type>(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, invalid_edge)), std::logic_error
+            func::discard_result(sut.are_incident(edge, invalid_edge)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, edge)), std::logic_error
+            func::discard_result(sut.are_incident(invalid_edge, edge)), std::invalid_argument
         );
     }
 

--- a/tests/source/test_graph_incidence.cpp
+++ b/tests/source/test_graph_incidence.cpp
@@ -28,22 +28,16 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
 
     SUBCASE("are_incident(vertex_id, vertex_id) should throw for out of range vertex ids") {
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(
-                constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx
-            )),
-            std::out_of_range
-        );
-        CHECK_THROWS_AS(
             func::discard_result(
                 sut.are_incident(constants::out_of_range_elemenet_idx, constants::vertex_id_2)
             ),
-            std::out_of_range
+            std::invalid_argument
         );
         CHECK_THROWS_AS(
             func::discard_result(
                 sut.are_incident(constants::vertex_id_1, constants::out_of_range_elemenet_idx)
             ),
-            std::out_of_range
+            std::invalid_argument
         );
     }
 

--- a/tests/source/test_graph_incidence.cpp
+++ b/tests/source/test_graph_incidence.cpp
@@ -85,10 +85,12 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
             std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, vd_2)), std::invalid_argument
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, vd_2)),
+            std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, fixture.invalid_vertex)), std::invalid_argument
+            func::discard_result(sut.are_incident(vd_1, fixture.invalid_vertex)),
+            std::invalid_argument
         );
     }
 
@@ -111,17 +113,21 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto& edge = sut.add_edge(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::invalid_argument
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)),
+            std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)), std::invalid_argument
+            func::discard_result(sut.are_incident(fixture.invalid_vertex, edge)),
+            std::invalid_argument
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::invalid_argument
+            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)),
+            std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)), std::invalid_argument
+            func::discard_result(sut.are_incident(edge, fixture.invalid_vertex)),
+            std::invalid_argument
         );
     }
 


### PR DESCRIPTION
- Added strict edge fining/getting for adjacency implementation types
- Changed the logic of element validation in `has_edge`, `adjacent_edges` and `are_incident` methods
- Replaced `std::logic_error` with `std::invalid_argument` for element validation failure