### PR TITLE
YT-CPPGL-33: Extend the edge getting functionality

### DIFF
--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -9,7 +9,6 @@
 #include "types/types.hpp"
 
 #include <algorithm>
-#include <optional>
 
 #ifdef GL_TESTING
 
@@ -202,8 +201,7 @@ public:
         using edge_ref_set = std::vector<std::reference_wrapper<const edge_type>>;
 
         if constexpr (std::same_as<implementation_tag, impl::list_t>) {
-            auto edge_ref_view = this->_impl.get_edges(first_id, second_id);
-            return edge_ref_set(edge_ref_view.begin(), edge_ref_view.end());
+            return this->_impl.get_edges(first_id, second_id);
         }
         else {
             const auto edge_opt = this->_impl.get_edge(first_id, second_id);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -180,11 +180,21 @@ public:
         return this->_impl.has_edge(edge);
     }
 
-    /*
-    TODO:
-    * get_edge(id, id) -> impl.get_edge(id, id)
-    * get_edge(vertex, vertex) -> has_vertex(vertex{1,2}) ? impl.get_edge(id, id) : nullopt
-    */
+    [[nodiscard]] gl_attr_force_inline types::optional_ref<const edge_type> get_edge(
+        const types::id_type first_id, const types::id_type second_id
+    ) const {
+        return this->_impl.get_edge(first_id, second_id);
+    }
+
+    [[nodiscard]] types::optional_ref<const edge_type> get_edge(
+        const vertex_type& first, const vertex_type& second
+    ) const {
+        if (not (this->has_vertex(first) and this->has_vertex(second)))
+            return std::nullopt;
+
+        // TODO: optimize this so that the vertex ids are not checked twice
+        return this->_impl.get_edge(first.id(), second.id());
+    }
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         this->_impl.remove_edge(edge);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -180,6 +180,12 @@ public:
         return this->_impl.has_edge(edge);
     }
 
+    /*
+    TODO:
+    * get_edge(id, id) -> impl.get_edge(id, id)
+    * get_edge(vertex, vertex) -> has_vertex(vertex{1,2}) ? impl.get_edge(id, id) : nullopt
+    */
+
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         this->_impl.remove_edge(edge);
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -196,6 +196,21 @@ public:
         return this->_impl.get_edge(first.id(), second.id());
     }
 
+    [[nodiscard]] inline std::vector<std::reference_wrapper<const edge_type>> get_edges(
+        const types::id_type first_id, const types::id_type second_id
+    ) const {
+        using return_type = std::vector<std::reference_wrapper<const edge_type>>;
+
+        if constexpr (std::same_as<implementation_tag, impl::list_t>) {
+            auto edge_view = this->_impl.get_edges(first_id, second_id);
+            return return_type(edge_view.begin(), edge_view.end());
+        }
+        else {
+            const auto edge_opt = this->_impl.get_edge(first_id, second_id);
+            return edge_opt.has_value() ? return_type{edge_opt.value()} : return_type{};
+        }
+    }
+
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         this->_impl.remove_edge(edge);
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -9,6 +9,7 @@
 #include "types/types.hpp"
 
 #include <algorithm>
+#include <optional>
 
 #ifdef GL_TESTING
 
@@ -164,9 +165,8 @@ public:
         return this->_impl.add_edge(make_edge<edge_type>(first, second, properties));
     }
 
-    [[nodiscard]] gl_attr_force_inline bool has_edge(
-        const types::id_type first_id, const types::id_type second_id
-    ) const {
+    [[nodiscard]] bool has_edge(const types::id_type first_id, const types::id_type second_id)
+        const {
         return this->_impl.has_edge(first_id, second_id);
     }
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -199,15 +199,15 @@ public:
     [[nodiscard]] inline std::vector<std::reference_wrapper<const edge_type>> get_edges(
         const types::id_type first_id, const types::id_type second_id
     ) const {
-        using return_type = std::vector<std::reference_wrapper<const edge_type>>;
+        using edge_ref_set = std::vector<std::reference_wrapper<const edge_type>>;
 
         if constexpr (std::same_as<implementation_tag, impl::list_t>) {
-            auto edge_view = this->_impl.get_edges(first_id, second_id);
-            return return_type(edge_view.begin(), edge_view.end());
+            auto edge_ref_view = this->_impl.get_edges(first_id, second_id);
+            return edge_ref_set(edge_ref_view.begin(), edge_ref_view.end());
         }
         else {
             const auto edge_opt = this->_impl.get_edge(first_id, second_id);
-            return edge_opt.has_value() ? return_type{edge_opt.value()} : return_type{};
+            return edge_opt.has_value() ? edge_ref_set{edge_opt.value()} : edge_ref_set{};
         }
     }
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -211,6 +211,14 @@ public:
         }
     }
 
+    [[nodiscard]] std::vector<std::reference_wrapper<const edge_type>> get_edges(
+        const vertex_type& first, const vertex_type& second
+    ) const {
+        this->_verify_vertex(first);
+        this->_verify_vertex(second);
+        return this->get_edges(first.id(), second.id());
+    }
+
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         this->_impl.remove_edge(edge);
     }

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -112,20 +112,15 @@ public:
 
     [[nodiscard]] auto get_edges(const types::id_type first_id, const types::id_type second_id)
         const {
-        constexpr auto get_edge_ref = [](const edge_ptr_type& edge) {
-            return std::cref(*edge);
-        };
-
         const auto adjacent_edges =
             (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id))
                 ? std::span(this->_list[first_id])
-                : std::span<edge_ptr_type>{};
+                : std::span<edge_ptr_type>();
 
-        return adjacent_edges
-             | std::views::filter([second_id](const auto& edge) {
+        return adjacent_edges | std::views::filter([second_id](const auto& edge) {
                    return specialized_impl::is_edge_incident_to(edge, second_id);
                })
-             | std::views::transform(get_edge_ref);
+             | std::views::transform([](const edge_ptr_type& edge) { return std::cref(*edge); });
     }
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -88,15 +88,25 @@ public:
 
     [[nodiscard]] bool has_edge(const edge_type& edge) const {
         const auto first_id = edge.first().id();
-        if (first_id >= this->_matrix.size())
-            return false;
-
         const auto second_id = edge.second().id();
-        if (second_id >= this->_matrix.size())
+
+        if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
             return false;
 
         const auto& matrix_element = this->_matrix[first_id][second_id];
         return matrix_element != nullptr and &edge == matrix_element.get();
+    }
+
+    [[nodiscard]] types::optional_ref<const edge_type> get_edge(
+        const types::id_type first_id, const types::id_type second_id
+    ) const {
+        if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
+            return std::nullopt;
+
+        const auto& matrix_element = this->_matrix[first_id][second_id];
+        if (not matrix_element)
+            return std::nullopt;
+        return std::cref(*matrix_element);
     }
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
@@ -119,6 +129,11 @@ private:
 
     static constexpr edge_ptr_type _make_null_edge() {
         return nullptr;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool _is_valid_vertex_id(const types::id_type vertex_id
+    ) const {
+        return vertex_id < this->_matrix.size();
     }
 
     type _matrix{};

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -6,6 +6,7 @@
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_matrix.hpp"
 
+#include <span>
 #include <vector>
 
 namespace gl::impl {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -6,7 +6,6 @@
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_matrix.hpp"
 
-#include <span>
 #include <vector>
 
 namespace gl::impl {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -74,6 +74,12 @@ struct directed_adjacency_list {
         return *adjacent_edges_first.back();
     }
 
+    [[nodiscard]] gl_attr_force_inline static bool is_edge_incident_to(
+        const edge_ptr_type& edge, const types::id_type vertex_id
+    ) {
+        return edge->second().id() == vertex_id;
+    }
+
     [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(
         const edge_set_type& edge_set, const types::id_type vertex_id
     ) {
@@ -140,6 +146,12 @@ struct undirected_adjacency_list {
 
         self._n_unique_edges++;
         return *adjacent_edges_first.back();
+    }
+
+    [[nodiscard]] gl_attr_force_inline static bool is_edge_incident_to(
+        const edge_ptr_type& edge, const types::id_type vertex_id
+    ) {
+        return edge->second().id() == vertex_id or edge->first().id() == vertex_id;
     }
 
     [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -43,6 +43,8 @@ struct directed_adjacency_list {
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
     using edge_ptr_type = typename impl_type::edge_ptr_type;
+    using edge_set_type = typename impl_type::edge_set_type;
+    using edge_iterator_type = typename impl_type::edge_iterator_type::iterator_type;
 
     struct address_projection {
         auto operator()(const edge_type& edge) {
@@ -72,6 +74,14 @@ struct directed_adjacency_list {
         return *adjacent_edges_first.back();
     }
 
+    [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(
+        const edge_set_type& edge_set, const types::id_type vertex_id
+    ) {
+        return std::ranges::find(edge_set, vertex_id, [](const auto& edge) {
+            return edge->second().id();
+        });
+    }
+
     [[nodiscard]] static inline bool has_edge(
         const impl_type& self, const types::id_type first_id, const types::id_type second_id
     ) {
@@ -96,6 +106,8 @@ struct undirected_adjacency_list {
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
     using edge_ptr_type = typename impl_type::edge_ptr_type;
+    using edge_set_type = typename impl_type::edge_set_type;
+    using edge_iterator_type = typename impl_type::edge_iterator_type::iterator_type;
 
     struct address_projection {
         auto operator()(const edge_type& edge) {
@@ -138,6 +150,14 @@ struct undirected_adjacency_list {
 
         self._n_unique_edges++;
         return *adjacent_edges_first.back();
+    }
+
+    [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(
+        const edge_set_type& edge_set, const types::id_type vertex_id
+    ) {
+        return std::ranges::find_if(edge_set, [vertex_id](const auto& edge) {
+            return edge->second().id() == vertex_id or edge->first().id() == vertex_id;
+        });
     }
 
     [[nodiscard]] static inline bool has_edge(

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -82,16 +82,6 @@ struct directed_adjacency_list {
         });
     }
 
-    [[nodiscard]] static inline bool has_edge(
-        const impl_type& self, const types::id_type first_id, const types::id_type second_id
-    ) {
-        const auto& adjacent_edges = self._list[first_id];
-        return std::ranges::find(
-                   adjacent_edges, second_id, [](const auto& edge) { return edge->second().id(); }
-               )
-            != adjacent_edges.cend();
-    }
-
     static void remove_edge(impl_type& self, const edge_type& edge) {
         auto& adj_edges = self._list.at(edge.first().id());
         adj_edges.erase(detail::strict_find<impl_type, address_projection>(adj_edges, &edge));
@@ -158,19 +148,6 @@ struct undirected_adjacency_list {
         return std::ranges::find_if(edge_set, [vertex_id](const auto& edge) {
             return edge->second().id() == vertex_id or edge->first().id() == vertex_id;
         });
-    }
-
-    [[nodiscard]] static inline bool has_edge(
-        const impl_type& self, const types::id_type first_id, const types::id_type second_id
-    ) {
-        const auto& adjacent_edges = self._list[first_id];
-        return std::ranges::find_if(
-                   adjacent_edges,
-                   [second_id](const auto& edge) {
-                       return edge->second().id() == second_id or edge->first().id() == second_id;
-                   }
-               )
-            != adjacent_edges.cend();
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -80,14 +80,6 @@ struct directed_adjacency_list {
         return edge->second().id() == vertex_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(
-        const edge_set_type& edge_set, const types::id_type vertex_id
-    ) {
-        return std::ranges::find(edge_set, vertex_id, [](const auto& edge) {
-            return edge->second().id();
-        });
-    }
-
     static void remove_edge(impl_type& self, const edge_type& edge) {
         auto& adj_edges = self._list.at(edge.first().id());
         adj_edges.erase(detail::strict_find<impl_type, address_projection>(adj_edges, &edge));
@@ -152,14 +144,6 @@ struct undirected_adjacency_list {
         const edge_ptr_type& edge, const types::id_type vertex_id
     ) {
         return edge->second().id() == vertex_id or edge->first().id() == vertex_id;
-    }
-
-    [[nodiscard]] gl_attr_force_inline static edge_iterator_type find_edge_incident_to(
-        const edge_set_type& edge_set, const types::id_type vertex_id
-    ) {
-        return std::ranges::find_if(edge_set, [vertex_id](const auto& edge) {
-            return edge->second().id() == vertex_id or edge->first().id() == vertex_id;
-        });
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {

--- a/include/gl/types/types.hpp
+++ b/include/gl/types/types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 namespace gl::types {
@@ -10,5 +11,8 @@ using size_type = std::uint64_t;
 
 template <typename T>
 using homogeneous_pair = std::pair<T, T>;
+
+template <typename T>
+using optional_ref = std::optional<std::reference_wrapper<std::remove_reference_t<T>>>;
 
 } // namespace gl::types

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -184,7 +184,6 @@ TEST_CASE_FIXTURE(
     const auto& edge_2 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
 
     const auto edge_opt = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
-
     REQUIRE(edge_opt.has_value());
     CHECK_EQ(&edge_opt->get(), &edge_1);
     CHECK_NE(&edge_opt->get(), &edge_2);

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -191,6 +191,46 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
 }
 
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "get_edgse(id, id) should return an empty view if either id is invalid"
+) {
+    CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::vertex_id_2).empty());
+    CHECK(sut.get_edges(constants::vertex_id_1, constants::out_of_range_elemenet_idx).empty());
+    CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+              .empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "get_edges(id, id) should return an empty if there is no edge connecting the given vertices"
+) {
+    CHECK(sut.get_edges(constants::vertex_id_1, constants::vertex_id_2).empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "get_edges(id, id) should return a valid edge view if the given vertices are connected"
+) {
+    std::vector<std::reference_wrapper<const edge_type>> expected_edges;
+    for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
+        expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2)));
+
+    constexpr auto address_projection = [](const auto& edge_ref) {
+        return &edge_ref.get();
+    };
+
+    CHECK(std::ranges::equal(
+        sut.get_edges(constants::vertex_id_1, constants::vertex_id_2),
+        expected_edges,
+        std::ranges::equal_to{},
+        address_projection,
+        address_projection
+    ));
+
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
+}
+
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
     const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
 

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -8,7 +8,6 @@
 #include <doctest.h>
 
 #include <algorithm>
-#include <functional>
 
 namespace gl_testing {
 
@@ -115,6 +114,16 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
+    test_directed_adjacency_list, "has_edge(id, id) should return false if either id is invalid"
+) {
+    CHECK_FALSE(sut.has_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.has_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
     "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
     "with the given ids in the specified direction"
@@ -148,6 +157,37 @@ TEST_CASE_FIXTURE(
     const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
     CHECK_FALSE(sut.has_edge(edge_type{out_of_range_vertex, vertices[constants::vertex_id_2]}));
     CHECK_FALSE(sut.has_edge(edge_type{vertices[constants::vertex_id_1], out_of_range_vertex}));
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list, "get_edge(id, id) should return nullopt if either id is invalid"
+) {
+    CHECK_FALSE(sut.get_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.get_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
+) {
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "get_edge(id, id) should return the first valid edge if the given vertices are connected"
+) {
+    const auto& edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto& edge_2 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    const auto edge_opt = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    REQUIRE(edge_opt.has_value());
+    CHECK_EQ(&edge_opt->get(), &edge_1);
+    CHECK_NE(&edge_opt->get(), &edge_2);
 }
 
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
@@ -304,6 +344,16 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
+    test_directed_adjacency_list, "has_edge(id, id) should return false if either id is invalid"
+) {
+    CHECK_FALSE(sut.has_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.has_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
     test_undirected_adjacency_list,
     "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
     "with the given ids in any direction"
@@ -337,6 +387,41 @@ TEST_CASE_FIXTURE(
     const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
     CHECK_FALSE(sut.has_edge(edge_type{out_of_range_vertex, vertices[constants::vertex_id_2]}));
     CHECK_FALSE(sut.has_edge(edge_type{vertices[constants::vertex_id_1], out_of_range_vertex}));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list, "get_edge(id, id) should return nullopt if either id is invalid"
+) {
+    CHECK_FALSE(sut.get_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.get_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
+) {
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "get_edge(id, id) should return the first valid edge if the given vertices are connected"
+) {
+    const auto& edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto& edge_2 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    const auto edge_opt_1 = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+    REQUIRE(edge_opt_1.has_value());
+    CHECK_EQ(&edge_opt_1->get(), &edge_1);
+    CHECK_NE(&edge_opt_1->get(), &edge_2);
+
+    const auto edge_opt_2 = sut.get_edge(constants::vertex_id_2, constants::vertex_id_1);
+    REQUIRE(edge_opt_2.has_value());
+    CHECK_EQ(&edge_opt_2->get(), &edge_1);
+    CHECK_NE(&edge_opt_2->get(), &edge_2);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -193,7 +193,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
-    "get_edgse(id, id) should return an empty view if either id is invalid"
+    "get_edges(id, id) should return an empty view if either id is invalid"
 ) {
     CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::vertex_id_2).empty());
     CHECK(sut.get_edges(constants::vertex_id_1, constants::out_of_range_elemenet_idx).empty());
@@ -214,11 +214,10 @@ TEST_CASE_FIXTURE(
 ) {
     std::vector<std::reference_wrapper<const edge_type>> expected_edges;
     for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
-        expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2)));
+        expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2))
+        );
 
-    constexpr auto address_projection = [](const auto& edge_ref) {
-        return &edge_ref.get();
-    };
+    constexpr auto address_projection = [](const auto& edge_ref) { return &edge_ref.get(); };
 
     CHECK(std::ranges::equal(
         sut.get_edges(constants::vertex_id_1, constants::vertex_id_2),
@@ -228,7 +227,7 @@ TEST_CASE_FIXTURE(
         address_projection
     ));
 
-    CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
+    CHECK(sut.get_edges(constants::vertex_id_2, constants::vertex_id_2).empty());
 }
 
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
@@ -463,6 +462,51 @@ TEST_CASE_FIXTURE(
     REQUIRE(edge_opt_2.has_value());
     CHECK_EQ(&edge_opt_2->get(), &edge_1);
     CHECK_NE(&edge_opt_2->get(), &edge_2);
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "get_edges(id, id) should return an empty view if either id is invalid"
+) {
+    CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::vertex_id_2).empty());
+    CHECK(sut.get_edges(constants::vertex_id_1, constants::out_of_range_elemenet_idx).empty());
+    CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+              .empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "get_edges(id, id) should return an empty if there is no edge connecting the given vertices"
+) {
+    CHECK(sut.get_edges(constants::vertex_id_1, constants::vertex_id_2).empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "get_edges(id, id) should return a valid edge view if the given vertices are connected"
+) {
+    std::vector<std::reference_wrapper<const edge_type>> expected_edges;
+    for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
+        expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2))
+        );
+
+    constexpr auto address_projection = [](const auto& edge_ref) { return &edge_ref.get(); };
+
+    CHECK(std::ranges::equal(
+        sut.get_edges(constants::vertex_id_1, constants::vertex_id_2),
+        expected_edges,
+        std::ranges::equal_to{},
+        address_projection,
+        address_projection
+    ));
+
+    CHECK(std::ranges::equal(
+        sut.get_edges(constants::vertex_id_2, constants::vertex_id_1),
+        expected_edges,
+        std::ranges::equal_to{},
+        address_projection,
+        address_projection
+    ));
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -188,6 +188,8 @@ TEST_CASE_FIXTURE(
     REQUIRE(edge_opt.has_value());
     CHECK_EQ(&edge_opt->get(), &edge_1);
     CHECK_NE(&edge_opt->get(), &edge_2);
+
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
 }
 
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -151,6 +151,36 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "get_edge(id, id) should return nullopt if either id is invalid"
+) {
+    CHECK_FALSE(sut.get_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.get_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix,
+    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
+) {
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix,
+    "get_edge(id, id) should return a valid edge if the given vertices are connected"
+) {
+    const auto& edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    const auto edge_opt = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+    REQUIRE(edge_opt.has_value());
+    CHECK_EQ(&edge_opt->get(), &edge_1);
+
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
+}
+
+TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix, "remove_edge should throw when an edge is invalid"
 ) {
     const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
@@ -338,6 +368,39 @@ TEST_CASE_FIXTURE(
     const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
     CHECK_FALSE(sut.has_edge(edge_type{out_of_range_vertex, vertices[constants::vertex_id_2]}));
     CHECK_FALSE(sut.has_edge(edge_type{vertices[constants::vertex_id_1], out_of_range_vertex}));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "get_edge(id, id) should return nullopt if either id is invalid"
+) {
+    CHECK_FALSE(sut.get_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx));
+    CHECK_FALSE(
+        sut.get_edge(constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx)
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
+) {
+    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "get_edge(id, id) should return a valid edge if the given vertices are connected"
+) {
+    const auto& edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+
+    const auto edge_opt_1 = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+    REQUIRE(edge_opt_1.has_value());
+    CHECK_EQ(&edge_opt_1->get(), &edge_1);
+
+    const auto edge_opt_2 = sut.get_edge(constants::vertex_id_2, constants::vertex_id_1);
+    REQUIRE(edge_opt_2.has_value());
+    CHECK_EQ(&edge_opt_2->get(), &edge_1);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -580,10 +580,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         CHECK(sut.get_edges(constants::out_of_range_elemenet_idx, constants::vertex_id_2).empty());
         CHECK(sut.get_edges(constants::vertex_id_1, constants::out_of_range_elemenet_idx).empty());
+
+        // clang-format off
+
         CHECK(sut.get_edges(
-                     constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx
-        )
-                  .empty());
+            constants::out_of_range_elemenet_idx, constants::out_of_range_elemenet_idx
+        ).empty());
+
+        // clang-format on
     }
 
     SUBCASE("get_edges(id, id) should return an empty vector if the given vertices are not incident"
@@ -631,6 +635,29 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 address_projection
             ));
         }
+    }
+
+    SUBCASE("get_edges(vertex, vertex) should throw if either vertex is invalid") {
+        sut_type sut{constants::n_elements};
+
+        const auto& vd_1 = sut.get_vertex(constants::vertex_id_1);
+        const auto& vd_2 = sut.get_vertex(constants::vertex_id_2);
+
+        CHECK_THROWS_AS(
+            func::discard_result(sut.get_edges(fixture.out_of_range_vertex, vd_2)),
+            std::out_of_range
+        );
+        CHECK_THROWS_AS(
+            func::discard_result(sut.get_edges(vd_1, fixture.out_of_range_vertex)),
+            std::out_of_range
+        );
+
+        CHECK_THROWS_AS(
+            func::discard_result(sut.get_edges(fixture.invalid_vertex, vd_2)), std::invalid_argument
+        );
+        CHECK_THROWS_AS(
+            func::discard_result(sut.get_edges(vd_1, fixture.invalid_vertex)), std::invalid_argument
+        );
     }
 
     SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -494,7 +494,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         }
     }
 
-    SUBCASE("has_edge(vertex_ptr pair) should throw if one of the vertices is invalid") {
+    SUBCASE("has_edge(vertex, vertex) should throw if one of the vertices is invalid") {
         sut_type sut{constants::n_elements};
 
         const auto& vd_1 = sut.get_vertex(constants::vertex_id_1);
@@ -515,7 +515,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
     }
 
-    SUBCASE("has_edge(vertex_ptr pair) should return true if there is an edge connecting the given "
+    SUBCASE("has_edge(vertex, vertex) should return true if there is an edge connecting the given "
             "vertices in the graph") {
         sut_type sut{constants::n_elements};
 
@@ -528,6 +528,51 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(sut.has_edge(vd_1, vd_2));
         CHECK_FALSE(sut.has_edge(vd_1, vd_3));
         CHECK_FALSE(sut.has_edge(vd_2, vd_3));
+    }
+
+    SUBCASE("get_edge(vertex, vertex) should return nullopt if either vertex is invalid") {
+        sut_type sut{constants::n_elements};
+        const auto& valid_vertex = sut.get_vertex(constants::vertex_id_1);
+
+        const vertex_type out_of_range_vertex{constants::out_of_range_elemenet_idx};
+        CHECK_FALSE(sut.get_edge(valid_vertex, out_of_range_vertex));
+        CHECK_FALSE(sut.get_edge(out_of_range_vertex, valid_vertex));
+        CHECK_FALSE(sut.get_edge(out_of_range_vertex, out_of_range_vertex));
+
+        const vertex_type invalid_vertex{constants::vertex_id_1};
+        CHECK_FALSE(sut.get_edge(valid_vertex, invalid_vertex));
+        CHECK_FALSE(sut.get_edge(invalid_vertex, valid_vertex));
+        CHECK_FALSE(sut.get_edge(invalid_vertex, invalid_vertex));
+    }
+
+    SUBCASE("get_edge(vertex, vertex) should return nullopt if the given vertices are not incident"
+    ) {
+        sut_type sut{constants::n_elements};
+        CHECK_FALSE(sut.get_edge(
+            sut.get_vertex(constants::vertex_id_1), sut.get_vertex(constants::vertex_id_2)
+        ));
+    }
+
+    SUBCASE("get_edge(vertex, vertex) should return a valid edge if the given vetices are incident"
+    ) {
+        sut_type sut{constants::n_elements};
+        const auto& vd_1 = sut.get_vertex(constants::vertex_id_1);
+        const auto& vd_2 = sut.get_vertex(constants::vertex_id_2);
+
+        const auto& edge = sut.add_edge(vd_1, vd_2);
+
+        const auto edge_opt_1 = sut.get_edge(vd_1, vd_2);
+        REQUIRE(edge_opt_1.has_value());
+        CHECK_EQ(&edge_opt_1->get(), &edge);
+
+        if constexpr (lib_tt::is_undirected_v<edge_type>) {
+            const auto edge_opt_2 = sut.get_edge(vd_2, vd_1);
+            REQUIRE(edge_opt_2.has_value());
+            CHECK_EQ(&edge_opt_2->get(), &edge);
+        }
+        else {
+            CHECK_FALSE(sut.get_edge(vd_2, vd_1).has_value());
+        }
     }
 
     SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {


### PR DESCRIPTION
Added the `get_edge` and `get_edges` methods to the `graph` class allowing for extracting a single all edges connecting the given vertices depending on the graph implementation