### PR TITLE
YT-CPPGL-22: Extend the adding/removing of vertices and edges functionality

### DIFF
--- a/include/gl/constants.hpp
+++ b/include/gl/constants.hpp
@@ -9,6 +9,7 @@ inline constexpr types::size_type one{1ull};
 inline constexpr types::size_type two{2ull};
 
 inline constexpr types::size_type default_size{zero};
+inline constexpr types::size_type begin_idx{zero};
 inline constexpr types::id_type initial_id{zero};
 inline constexpr types::size_type one_element{one};
 

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -137,6 +137,8 @@ using edge_ptr_type = typename EdgeType::directional_tag::template edge_ptr_type
 
 } // namespace types
 
+namespace detail {
+
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
 [[nodiscard]] gl_attr_force_inline types::edge_ptr_type<EdgeType> make_edge(
     const typename EdgeType::vertex_type& first, const typename EdgeType::vertex_type& second
@@ -152,5 +154,7 @@ template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
 ) {
     return EdgeType::directional_tag::template make<EdgeType>(first, second, properties);
 }
+
+} // namespace detail
 
 } // namespace gl

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -11,15 +11,6 @@
 
 #include <algorithm>
 
-#ifdef GL_TESTING
-
-namespace gl_testing {
-template <typename TraitsType>
-struct test_graph;
-} // namespace gl_testing
-
-#endif
-
 namespace gl {
 
 template <type_traits::c_instantiation_of<graph_traits> GraphTraits = graph_traits<>>
@@ -44,10 +35,6 @@ public:
 
     using edge_set_type = typename implementation_type::edge_set_type;
     using edge_iterator_type = typename implementation_type::edge_iterator_type;
-
-#ifdef GL_TESTING
-    friend struct ::gl_testing::test_graph<traits_type>;
-#endif
 
     graph(const graph&) = delete;
     graph& operator=(const graph&) = delete;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -25,9 +25,9 @@ public:
     using vertex_ptr_type = typename traits_type::vertex_ptr_type;
     using vertex_properties_type = typename traits_type::vertex_properties_type;
 
-    using vertex_set_type = std::vector<vertex_ptr_type>;
+    using vetex_list_type = std::vector<vertex_ptr_type>;
     using vertex_iterator_type =
-        types::dereferencing_iterator<typename vertex_set_type::const_iterator>;
+        types::dereferencing_iterator<typename vetex_list_type::const_iterator>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -36,7 +36,7 @@ public:
     using edge_directional_tag = typename traits_type::edge_directional_tag;
     using edge_properties_type = typename traits_type::edge_properties_type;
 
-    using edge_set_type = typename implementation_type::edge_set_type;
+    using edge_list_type = typename implementation_type::edge_list_type;
     using edge_iterator_type = typename implementation_type::edge_iterator_type;
 
     graph(const graph&) = delete;
@@ -85,7 +85,7 @@ public:
         this->_impl.add_vertices(n);
         this->_vertices.reserve(this->n_vertices() + n);
 
-        for (types::size_type _ = constants::default_size; _ < n; _++)
+        for (types::size_type _ = constants::begin_idx; _ < n; _++)
             this->_vertices.push_back(detail::make_vertex<vertex_type>(this->n_vertices()));
     }
 
@@ -129,6 +129,8 @@ public:
         this->_verify_vertex(vertex);
         this->_remove_vertex_impl(vertex);
     }
+
+    // TODO: remove_vertices_from
 
     [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices(
     ) const {
@@ -387,7 +389,7 @@ private:
         );
     }
 
-    vertex_set_type _vertices{};
+    vetex_list_type _vertices{};
     implementation_type _impl{};
 };
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -186,9 +186,7 @@ public:
     }
 
     template <type_traits::c_sized_range_of<types::id_type> IdRange>
-    void add_edges_from(
-        const types::id_type source_id, const IdRange& destination_id_range
-    ) {
+    void add_edges_from(const types::id_type source_id, const IdRange& destination_id_range) {
         this->_verify_vertex_id(source_id);
         const auto& source = this->get_vertex(source_id);
 
@@ -204,11 +202,8 @@ public:
         this->_impl.add_edges_from(source_id, std::move(new_edges));
     }
 
-    template <type_traits::c_sized_range_of<std::reference_wrapper<const vertex_type>> VertexRefRange>
-    void add_edges_from(
-        const vertex_type& source,
-        const VertexRefRange& destination_range
-    ) {
+    template <type_traits::c_sized_range_of<types::const_ref_wrap<vertex_type>> VertexRefRange>
+    void add_edges_from(const vertex_type& source, const VertexRefRange& destination_range) {
         this->_verify_vertex(source);
 
         std::vector<edge_ptr_type> new_edges;
@@ -254,10 +249,10 @@ public:
         return this->_impl.get_edge(first.id(), second.id());
     }
 
-    [[nodiscard]] inline std::vector<std::reference_wrapper<const edge_type>> get_edges(
+    [[nodiscard]] inline std::vector<types::const_ref_wrap<edge_type>> get_edges(
         const types::id_type first_id, const types::id_type second_id
     ) const {
-        using edge_ref_set = std::vector<std::reference_wrapper<const edge_type>>;
+        using edge_ref_set = std::vector<types::const_ref_wrap<edge_type>>;
 
         if constexpr (std::same_as<implementation_tag, impl::list_t>) {
             return this->_impl.get_edges(first_id, second_id);
@@ -268,7 +263,7 @@ public:
         }
     }
 
-    [[nodiscard]] std::vector<std::reference_wrapper<const edge_type>> get_edges(
+    [[nodiscard]] std::vector<types::const_ref_wrap<edge_type>> get_edges(
         const vertex_type& first, const vertex_type& second
     ) const {
         this->_verify_vertex(first);
@@ -280,10 +275,8 @@ public:
         this->_impl.remove_edge(edge);
     }
 
-    template <type_traits::c_range_of<std::reference_wrapper<const edge_type>> EdgeRefRange>
-    inline void remove_edges_from(
-        const EdgeRefRange edges
-    ) {
+    template <type_traits::c_range_of<types::const_ref_wrap<edge_type>> EdgeRefRange>
+    inline void remove_edges_from(const EdgeRefRange edges) {
         for (const auto& edge_ref : edges)
             this->_impl.remove_edge(edge_ref.get());
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -132,21 +132,25 @@ public:
     // clang-format off
     // gl_attr_force_inline misplacement
 
-    gl_attr_force_inline const edge_type& add_edge(
+    const edge_type& add_edge(
         const types::id_type first_id, const types::id_type second_id
     ) {
+        this->_verify_vertex_id(first_id);
+        this->_verify_vertex_id(second_id);
         return this->_impl.add_edge(
             make_edge<edge_type>(this->get_vertex(first_id), this->get_vertex(second_id))
         );
     }
 
-    gl_attr_force_inline const edge_type& add_edge(
+    const edge_type& add_edge(
         const types::id_type first_id,
         const types::id_type second_id,
         const edge_properties_type& properties
     )
     requires(not type_traits::is_default_properties_type_v<edge_properties_type>)
     {
+        this->_verify_vertex_id(first_id);
+        this->_verify_vertex_id(second_id);
         return this->_impl.add_edge(make_edge<edge_type>(
             this->get_vertex(first_id), this->get_vertex(second_id), properties
         ));

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -144,6 +144,28 @@ public:
             this->_remove_vertex_impl(this->get_vertex(vertex_id));
     }
 
+    template <type_traits::c_sized_range_of<types::const_ref_wrap<vertex_type>> VertexRefRange>
+    void remove_vertices_from(const VertexRefRange& vertex_ref_range) {
+        // can be replaced with std::grater for C++26
+        struct vertex_ref_greater_comparator {
+            [[nodiscard]] bool operator()(
+                const types::const_ref_wrap<vertex_type>& lhs,
+                const types::const_ref_wrap<vertex_type>& rhs
+            ) const {
+                return lhs.get() > rhs.get();
+            }
+        };
+
+        // sorts the ids in a descending order and removes duplicate ids
+        std::set<types::const_ref_wrap<vertex_type>, vertex_ref_greater_comparator> vertex_ref_set(
+            std::ranges::begin(vertex_ref_range), std::ranges::end(vertex_ref_range)
+        );
+
+        // TODO: optimize
+        for (const auto& vertex_ref : vertex_ref_set)
+            this->_remove_vertex_impl(vertex_ref.get());
+    }
+
     [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices(
     ) const {
         return make_iterator_range(deref_cbegin(this->_vertices), deref_cend(this->_vertices));

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -89,13 +89,14 @@ public:
             this->_vertices.push_back(detail::make_vertex<vertex_type>(this->n_vertices()));
     }
 
-    void add_vertices_with(std::initializer_list<vertex_properties_type> properties_list) {
-        const auto n = properties_list.size();
+    template <type_traits::c_sized_range_of<vertex_properties_type> VertexPropertiesRange>
+    void add_vertices_with(const VertexPropertiesRange& properties_range) {
+        const auto n = std::ranges::size(properties_range);
 
         this->_impl.add_vertices(n);
         this->_vertices.reserve(this->n_vertices() + n);
 
-        for (const auto& properties : properties_list)
+        for (const auto& properties : properties_range)
             this->_vertices.push_back(
                 detail::make_vertex<vertex_type>(this->n_vertices(), properties)
             );
@@ -184,16 +185,17 @@ public:
         return this->_impl.add_edge(detail::make_edge<edge_type>(first, second, properties));
     }
 
+    template <type_traits::c_sized_range_of<types::id_type> IdRange>
     void add_edges_from(
-        const types::id_type source_id, std::initializer_list<types::id_type> destination_id_list
+        const types::id_type source_id, const IdRange& destination_id_range
     ) {
         this->_verify_vertex_id(source_id);
         const auto& source = this->get_vertex(source_id);
 
         std::vector<edge_ptr_type> new_edges;
-        new_edges.reserve(destination_id_list.size());
+        new_edges.reserve(std::ranges::size(destination_id_range));
 
-        for (const auto destination_id : destination_id_list) {
+        for (const auto destination_id : destination_id_range) {
             this->_verify_vertex_id(destination_id);
             new_edges.push_back(
                 detail::make_edge<edge_type>(source, this->get_vertex(destination_id))
@@ -202,16 +204,17 @@ public:
         this->_impl.add_edges_from(source_id, std::move(new_edges));
     }
 
+    template <type_traits::c_sized_range_of<std::reference_wrapper<const vertex_type>> VertexRefRange>
     void add_edges_from(
         const vertex_type& source,
-        std::initializer_list<std::reference_wrapper<const vertex_type>> destination_list
+        const VertexRefRange& destination_range
     ) {
         this->_verify_vertex(source);
 
         std::vector<edge_ptr_type> new_edges;
-        new_edges.reserve(destination_list.size());
+        new_edges.reserve(std::ranges::size(destination_range));
 
-        for (const auto& destination_ref : destination_list) {
+        for (const auto& destination_ref : destination_range) {
             const auto& destination = destination_ref.get();
             this->_verify_vertex(destination);
             new_edges.push_back(detail::make_edge<edge_type>(source, destination));
@@ -277,8 +280,9 @@ public:
         this->_impl.remove_edge(edge);
     }
 
+    template <type_traits::c_range_of<std::reference_wrapper<const edge_type>> EdgeRefRange>
     inline void remove_edges_from(
-        std::initializer_list<std::reference_wrapper<const edge_type>> edges
+        const EdgeRefRange edges
     ) {
         for (const auto& edge_ref : edges)
             this->_impl.remove_edge(edge_ref.get());

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -26,7 +26,8 @@ public:
     using vertex_properties_type = typename traits_type::vertex_properties_type;
 
     using vertex_set_type = std::vector<vertex_ptr_type>;
-    using vertex_iterator_type = types::dereferencing_iterator<typename vertex_set_type::const_iterator>;
+    using vertex_iterator_type =
+        types::dereferencing_iterator<typename vertex_set_type::const_iterator>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
@@ -95,7 +96,9 @@ public:
         this->_vertices.reserve(this->n_vertices() + n);
 
         for (const auto& properties : properties_list)
-            this->_vertices.push_back(detail::make_vertex<vertex_type>(this->n_vertices(), properties));
+            this->_vertices.push_back(
+                detail::make_vertex<vertex_type>(this->n_vertices(), properties)
+            );
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_vertex(const types::id_type vertex_id) const {
@@ -180,8 +183,7 @@ public:
     }
 
     void add_edges_from(
-        const types::id_type source_id,
-        std::initializer_list<types::id_type> destination_id_list
+        const types::id_type source_id, std::initializer_list<types::id_type> destination_id_list
     ) {
         this->_verify_vertex_id(source_id);
         const auto& source = this->get_vertex(source_id);
@@ -191,7 +193,9 @@ public:
 
         for (const auto destination_id : destination_id_list) {
             this->_verify_vertex_id(destination_id);
-            new_edges.push_back(detail::make_edge<edge_type>(source, this->get_vertex(destination_id)));
+            new_edges.push_back(
+                detail::make_edge<edge_type>(source, this->get_vertex(destination_id))
+            );
         }
         this->_impl.add_edges_from(source_id, std::move(new_edges));
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -69,17 +69,29 @@ public:
         return this->_vertices.emplace_back(this->n_vertices());
     }
 
-    void add_vertices(const types::size_type n) {
-        // TODO:
-        // * impl.add(n)
-        // * vertices.add(n)
-    }
-
     inline const vertex_type& add_vertex(const vertex_properties_type& properties)
     requires(not type_traits::is_default_properties_type_v<vertex_properties_type>)
     {
         this->_impl.add_vertex();
         return this->_vertices.emplace_back(this->n_vertices(), properties);
+    }
+
+    void add_vertices(const types::size_type n) {
+        this->_impl.add_vertices(n);
+        this->_vertices.reserve(this->n_vertices() + n);
+
+        for (types::size_type _ = constants::default_size; _ < n; _++)
+            this->_vertices.emplace_back(this->n_vertices());
+    }
+
+    void add_vertices_with(const std::initializer_list<vertex_properties_type> properties_list) {
+        const auto n = properties_list.size();
+
+        this->_impl.add_vertices(n);
+        this->_vertices.reserve(this->n_vertices() + n);
+
+        for (const auto& properties : properties_list)
+            this->_vertices.emplace_back(this->n_vertices(), properties);
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_vertex(const types::id_type vertex_id) const {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -10,6 +10,7 @@
 #include "types/types.hpp"
 
 #include <algorithm>
+#include <set>
 
 namespace gl {
 
@@ -131,7 +132,17 @@ public:
         this->_remove_vertex_impl(vertex);
     }
 
-    // TODO: remove_vertices_from
+    template <type_traits::c_sized_range_of<types::id_type> IdRange>
+    void remove_vertices_from(const IdRange& vertex_id_range) {
+        // sorts the ids in a descending order and removes duplicate ids
+        std::set<types::id_type, std::greater<types::id_type>> vertex_id_set(
+            std::ranges::begin(vertex_id_range), std::ranges::end(vertex_id_range)
+        );
+
+        // TODO: optimize
+        for (const auto vertex_id : vertex_id_set)
+            this->_remove_vertex_impl(this->get_vertex(vertex_id));
+    }
 
     [[nodiscard]] gl_attr_force_inline types::iterator_range<vertex_iterator_type> vertices(
     ) const {
@@ -187,14 +198,12 @@ public:
 
     template <type_traits::c_sized_range_of<types::id_type> IdRange>
     void add_edges_from(const types::id_type source_id, const IdRange& destination_id_range) {
-        this->_verify_vertex_id(source_id);
         const auto& source = this->get_vertex(source_id);
 
         std::vector<edge_ptr_type> new_edges;
         new_edges.reserve(std::ranges::size(destination_id_range));
 
         for (const auto destination_id : destination_id_range) {
-            this->_verify_vertex_id(destination_id);
             new_edges.push_back(
                 detail::make_edge<edge_type>(source, this->get_vertex(destination_id))
             );

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -176,19 +176,37 @@ public:
     }
 
     void add_edges_from(
-        const types::id_type source_id, const std::initializer_list<types::id_type>& destination_ids
+        const types::id_type source_id,
+        const std::initializer_list<types::id_type>& destination_id_list
     ) {
         this->_verify_vertex_id(source_id);
         const auto& source = this->get_vertex(source_id);
 
         std::vector<edge_ptr_type> new_edges;
-        new_edges.reserve(destination_ids.size());
+        new_edges.reserve(destination_id_list.size());
 
-        for (const auto destination_id : destination_ids) {
+        for (const auto destination_id : destination_id_list) {
             this->_verify_vertex_id(destination_id);
             new_edges.push_back(make_edge<edge_type>(source, this->get_vertex(destination_id)));
         }
         this->_impl.add_edges_from(source_id, std::move(new_edges));
+    }
+
+    void add_edges_from(
+        const vertex_type& source,
+        const std::initializer_list<std::reference_wrapper<const vertex_type>>& destination_list
+    ) {
+        this->_verify_vertex(source);
+
+        std::vector<edge_ptr_type> new_edges;
+        new_edges.reserve(destination_list.size());
+
+        for (const auto& destination_ref : destination_list) {
+            const auto& destination = destination_ref.get();
+            this->_verify_vertex(destination);
+            new_edges.push_back(make_edge<edge_type>(source, destination));
+        }
+        this->_impl.add_edges_from(source.id(), std::move(new_edges));
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -69,6 +69,12 @@ public:
         return this->_vertices.emplace_back(this->n_vertices());
     }
 
+    void add_vertices(const types::size_type n) {
+        // TODO:
+        // * impl.add(n)
+        // * vertices.add(n)
+    }
+
     inline const vertex_type& add_vertex(const vertex_properties_type& properties)
     requires(not type_traits::is_default_properties_type_v<vertex_properties_type>)
     {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -30,6 +30,7 @@ public:
     // TODO: reverese iterators should be available for bidirectional ranges
 
     using edge_type = typename traits_type::edge_type;
+    using edge_ptr_type = typename traits_type::edge_ptr_type;
     using edge_directional_tag = typename traits_type::edge_directional_tag;
     using edge_properties_type = typename traits_type::edge_properties_type;
 
@@ -172,6 +173,22 @@ public:
         this->_verify_vertex(first);
         this->_verify_vertex(second);
         return this->_impl.add_edge(make_edge<edge_type>(first, second, properties));
+    }
+
+    void add_edges_from(
+        const types::id_type source_id, const std::initializer_list<types::id_type>& destination_ids
+    ) {
+        this->_verify_vertex_id(source_id);
+        const auto& source = this->get_vertex(source_id);
+
+        std::vector<edge_ptr_type> new_edges;
+        new_edges.reserve(destination_ids.size());
+
+        for (const auto destination_id : destination_ids) {
+            this->_verify_vertex_id(destination_id);
+            new_edges.push_back(make_edge<edge_type>(source, this->get_vertex(destination_id)));
+        }
+        this->_impl.add_edges_from(source_id, std::move(new_edges));
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -15,11 +15,12 @@ template <
     type_traits::c_graph_impl_tag ImplTag = impl::list_t>
 struct graph_traits {
     using vertex_type = vertex_descriptor<VertexProperties>;
+    using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
 
     using edge_type = edge_descriptor<vertex_type, EdgeDirectionalTag, EdgeProperties>;
-    using edge_directional_tag = typename edge_type::directional_tag;
     using edge_ptr_type = types::edge_ptr_type<edge_type>;
+    using edge_directional_tag = typename edge_type::directional_tag;
     using edge_properties_type = typename edge_type::properties_type;
 
     using implementation_tag = ImplTag;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -7,8 +7,8 @@
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_list.hpp"
 
-#include <vector>
 #include <iostream>
+#include <vector>
 
 namespace gl::impl {
 
@@ -55,7 +55,6 @@ public:
 
     gl_attr_force_inline void add_vertex() {
         this->_list.push_back(edge_set_type{});
-        std::cout << "adj_list.size = " << this->_list.size() << std::endl;
     }
 
     inline void add_vertices(const types::size_type n) {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -8,6 +8,7 @@
 #include "specialized/adjacency_list.hpp"
 
 #include <vector>
+#include <iostream>
 
 namespace gl::impl {
 
@@ -54,6 +55,7 @@ public:
 
     gl_attr_force_inline void add_vertex() {
         this->_list.push_back(edge_set_type{});
+        std::cout << "adj_list.size = " << this->_list.size() << std::endl;
     }
 
     inline void add_vertices(const types::size_type n) {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -56,6 +56,12 @@ public:
         this->_list.push_back(edge_set_type{});
     }
 
+    inline void add_vertices(const types::size_type n) {
+        this->_list.reserve(this->n_vertices() + n);
+        for (types::size_type _ = constants::default_size; _ < n; _++)
+            this->_list.push_back(edge_set_type{});
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         specialized_impl::remove_vertex(*this, vertex);
     }

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -21,13 +21,13 @@ public:
     using edge_ptr_type = typename GraphTraits::edge_ptr_type;
     using edge_directional_tag = typename GraphTraits::edge_directional_tag;
 
-    using edge_set_type = std::vector<edge_ptr_type>;
+    using edge_list_type = std::vector<edge_ptr_type>;
     using edge_iterator_type =
-        types::dereferencing_iterator<typename edge_set_type::const_iterator>;
+        types::dereferencing_iterator<typename edge_list_type::const_iterator>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
-    using type = std::vector<edge_set_type>;
+    using type = std::vector<edge_list_type>;
 
     adjacency_list(const adjacency_list&) = delete;
     adjacency_list& operator=(const adjacency_list&) = delete;
@@ -54,13 +54,13 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertex() {
-        this->_list.push_back(edge_set_type{});
+        this->_list.push_back(edge_list_type{});
     }
 
     inline void add_vertices(const types::size_type n) {
         this->_list.reserve(this->n_vertices() + n);
-        for (types::size_type _ = constants::default_size; _ < n; _++)
-            this->_list.push_back(edge_set_type{});
+        for (types::size_type _ = constants::begin_idx; _ < n; _++)
+            this->_list.push_back(edge_list_type{});
     }
 
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -133,7 +133,7 @@ public:
 
     [[nodiscard]] auto get_edges(const types::id_type first_id, const types::id_type second_id)
         const {
-        using edge_ref_set = std::vector<std::reference_wrapper<const edge_type>>;
+        using edge_ref_set = std::vector<types::const_ref_wrap<edge_type>>;
 
         if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
             return edge_ref_set{};

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -77,6 +77,12 @@ public:
 
     // clang-format on
 
+    gl_attr_force_inline void add_edges_from(
+        const types::id_type source_id, std::vector<edge_ptr_type> new_edges
+    ) {
+        specialized_impl::add_edges_from(*this, source_id, std::move(new_edges));
+    }
+
     [[nodiscard]] bool has_edge(const types::id_type first_id, const types::id_type second_id)
         const {
         if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -20,13 +20,13 @@ public:
     using edge_ptr_type = typename GraphTraits::edge_ptr_type;
     using edge_directional_tag = typename GraphTraits::edge_directional_tag;
 
-    using edge_set_type = std::vector<edge_ptr_type>;
+    using edge_list_type = std::vector<edge_ptr_type>;
     using edge_iterator_type = types::dereferencing_iterator<
-        types::non_null_iterator<typename edge_set_type::const_iterator>>;
+        types::non_null_iterator<typename edge_list_type::const_iterator>>;
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
-    using type = std::vector<edge_set_type>;
+    using type = std::vector<edge_list_type>;
 
     adjacency_matrix(const adjacency_matrix&) = delete;
     adjacency_matrix& operator=(const adjacency_matrix&) = delete;
@@ -74,7 +74,7 @@ public:
             std::generate_n(std::back_inserter(row), n, _make_null_edge);
         }
 
-        for (types::size_type _ = constants::default_size; _ < n; _++) {
+        for (types::size_type _ = constants::begin_idx; _ < n; _++) {
             auto& new_row = this->_matrix.emplace_back();
             new_row.reserve(new_n_vertices);
             std::generate_n(std::back_inserter(new_row), new_n_vertices, _make_null_edge);

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -8,6 +8,7 @@
 #include "specialized/adjacency_matrix.hpp"
 
 #include <vector>
+#include <iostream>
 
 namespace gl::impl {
 
@@ -64,6 +65,11 @@ public:
         auto& new_row = this->_matrix.emplace_back();
         new_row.reserve(this->n_vertices());
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
+
+        std::cout << "adj_matrix.size = " << this->_matrix.size() << std::endl;
+        for (int i = 0; i < this->_matrix.size(); i++) {
+            std::cout << "adj_matrix.row(" << i << ").size = " << this->_matrix[i].size() << std::endl;
+        }
     }
 
     void add_vertices(const types::size_type n) {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -82,7 +82,7 @@ public:
     }
 
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
-        sepcialized_impl::remove_vertex(*this, vertex);
+        specialized_impl::remove_vertex(*this, vertex);
     }
 
     // --- edge methods ---
@@ -91,10 +91,16 @@ public:
     // gl_attr_force_inline misplacement
 
     gl_attr_force_inline const edge_type& add_edge(edge_ptr_type edge) {
-        return sepcialized_impl::add_edge(*this, std::move(edge));
+        return specialized_impl::add_edge(*this, std::move(edge));
     }
 
     // clang-format on
+
+    gl_attr_force_inline void add_edges_from(
+        const types::id_type source_id, std::vector<edge_ptr_type> new_edges
+    ) {
+        specialized_impl::add_edges_from(*this, source_id, std::move(new_edges));
+    }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(
         const types::id_type first_id, const types::id_type second_id
@@ -126,7 +132,7 @@ public:
     }
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
-        sepcialized_impl::remove_edge(*this, edge);
+        specialized_impl::remove_edge(*this, edge);
     }
 
     [[nodiscard]] inline types::iterator_range<edge_iterator_type> adjacent_edges(
@@ -140,8 +146,8 @@ public:
     }
 
 private:
-    using sepcialized_impl = typename specialized::matrix_impl_traits<adjacency_matrix>::type;
-    friend sepcialized_impl;
+    using specialized_impl = typename specialized::matrix_impl_traits<adjacency_matrix>::type;
+    friend specialized_impl;
 
     static constexpr edge_ptr_type _make_null_edge() {
         return nullptr;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -66,6 +66,21 @@ public:
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
     }
 
+    void add_vertices(const types::size_type n) {
+        const auto new_n_vertices = this->n_vertices() + n;
+
+        for (auto& row : this->_matrix) {
+            row.reserve(new_n_vertices);
+            std::generate_n(std::back_inserter(row), n, _make_null_edge);
+        }
+
+        for (types::size_type _ = constants::default_size; _ < n; _++) {
+            auto& new_row = this->_matrix.emplace_back();
+            new_row.reserve(new_n_vertices);
+            std::generate_n(std::back_inserter(new_row), new_n_vertices, _make_null_edge);
+        }
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         sepcialized_impl::remove_vertex(*this, vertex);
     }

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -8,7 +8,6 @@
 #include "specialized/adjacency_matrix.hpp"
 
 #include <vector>
-#include <iostream>
 
 namespace gl::impl {
 
@@ -65,11 +64,6 @@ public:
         auto& new_row = this->_matrix.emplace_back();
         new_row.reserve(this->n_vertices());
         std::generate_n(std::back_inserter(new_row), this->n_vertices(), _make_null_edge);
-
-        std::cout << "adj_matrix.size = " << this->_matrix.size() << std::endl;
-        for (int i = 0; i < this->_matrix.size(); i++) {
-            std::cout << "adj_matrix.row(" << i << ").size = " << this->_matrix[i].size() << std::endl;
-        }
     }
 
     void add_vertices(const types::size_type n) {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -68,11 +68,17 @@ struct directed_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list.at(edge->first().id());
+        auto& adjacent_edges_first = self._list[edge->first().id()];
         adjacent_edges_first.push_back(std::move(edge));
         self._n_unique_edges++;
         return *adjacent_edges_first.back();
     }
+
+    // static void add_edges_from(
+    //     impl_type& self, const types::id_type source_id, std::initializer_list<edge_ptr_type> edges
+    // ) {
+    //     auto& adjacent_edges_source = self._list.at(source_id)
+    // }
 
     [[nodiscard]] gl_attr_force_inline static bool is_edge_incident_to(
         const edge_ptr_type& edge,
@@ -138,10 +144,10 @@ struct undirected_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list.at(edge->first().id());
+        auto& adjacent_edges_first = self._list[edge->first().id()];
 
         if (not edge->is_loop())
-            self._list.at(edge->second().id()).push_back(edge);
+            self._list[edge->second().id()].push_back(edge);
         adjacent_edges_first.push_back(std::move(edge));
 
         self._n_unique_edges++;

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -74,11 +74,15 @@ struct directed_adjacency_list {
         return *adjacent_edges_first.back();
     }
 
-    // static void add_edges_from(
-    //     impl_type& self, const types::id_type source_id, std::initializer_list<edge_ptr_type> edges
-    // ) {
-    //     auto& adjacent_edges_source = self._list.at(source_id)
-    // }
+    static void add_edges_from(
+        impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
+    ) {
+        auto& adjacent_edges_source = self._list[source_id];
+        adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
+        for (auto& edge : new_edges)
+            adjacent_edges_source.push_back(std::move(edge));
+        self._n_unique_edges += new_edges.size();
+    }
 
     [[nodiscard]] gl_attr_force_inline static bool is_edge_incident_to(
         const edge_ptr_type& edge,
@@ -152,6 +156,21 @@ struct undirected_adjacency_list {
 
         self._n_unique_edges++;
         return *adjacent_edges_first.back();
+    }
+
+    static void add_edges_from(
+        impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
+    ) {
+        auto& adjacent_edges_source = self._list[source_id];
+        adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
+
+        for (auto& edge : new_edges) {
+            if (not edge->is_loop())
+                self._list[edge->second().id()].push_back(edge);
+            adjacent_edges_source.push_back(std::move(edge));
+        }
+
+        self._n_unique_edges += new_edges.size();
     }
 
     [[nodiscard]] inline static bool is_edge_incident_to(

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -35,8 +35,7 @@ template <type_traits::c_graph_type GraphType>
 
     for (types::id_type source_id = constants::zero; source_id < n_source_vertices; source_id++) {
         const auto destination_ids = detail::get_binary_destination_ids(source_id);
-        graph.add_edge(source_id, destination_ids.first);
-        graph.add_edge(source_id, destination_ids.second);
+        graph.add_edges_from(source_id, {destination_ids.first, destination_ids.second});
     }
 
     return graph;
@@ -62,8 +61,7 @@ template <type_traits::c_graph_type GraphType>
         for (types::id_type source_id = constants::zero; source_id < n_source_vertices;
              source_id++) {
             const auto destination_ids = detail::get_binary_destination_ids(source_id);
-            graph.add_edge(source_id, destination_ids.first);
-            graph.add_edge(source_id, destination_ids.second);
+            graph.add_edges_from(source_id, {destination_ids.first, destination_ids.second});
             graph.add_edge(destination_ids.first, source_id);
             graph.add_edge(destination_ids.second, source_id);
         }

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -15,6 +15,8 @@ namespace detail {
     );
 }
 
+using vertex_id_range = std::vector<types::id_type>;
+
 } // namespace detail
 
 template <type_traits::c_graph_type GraphType>
@@ -35,7 +37,7 @@ template <type_traits::c_graph_type GraphType>
 
     for (types::id_type source_id = constants::zero; source_id < n_source_vertices; source_id++) {
         const auto destination_ids = detail::get_binary_destination_ids(source_id);
-        graph.add_edges_from(source_id, {destination_ids.first, destination_ids.second});
+        graph.add_edges_from(source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second});
     }
 
     return graph;
@@ -61,7 +63,7 @@ template <type_traits::c_graph_type GraphType>
         for (types::id_type source_id = constants::zero; source_id < n_source_vertices;
              source_id++) {
             const auto destination_ids = detail::get_binary_destination_ids(source_id);
-            graph.add_edges_from(source_id, {destination_ids.first, destination_ids.second});
+            graph.add_edges_from(source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second});
             graph.add_edge(destination_ids.first, source_id);
             graph.add_edge(destination_ids.second, source_id);
         }

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -37,7 +37,9 @@ template <type_traits::c_graph_type GraphType>
 
     for (types::id_type source_id = constants::zero; source_id < n_source_vertices; source_id++) {
         const auto destination_ids = detail::get_binary_destination_ids(source_id);
-        graph.add_edges_from(source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second});
+        graph.add_edges_from(
+            source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second}
+        );
     }
 
     return graph;
@@ -63,7 +65,9 @@ template <type_traits::c_graph_type GraphType>
         for (types::id_type source_id = constants::zero; source_id < n_source_vertices;
              source_id++) {
             const auto destination_ids = detail::get_binary_destination_ids(source_id);
-            graph.add_edges_from(source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second});
+            graph.add_edges_from(
+                source_id, detail::vertex_id_range{destination_ids.first, destination_ids.second}
+            );
             graph.add_edge(destination_ids.first, source_id);
             graph.add_edge(destination_ids.second, source_id);
         }

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gl/types/types.hpp"
+
 #include <concepts>
 #include <memory>
 #include <ranges>
@@ -36,15 +38,26 @@ template <typename R>
 concept c_range = std::ranges::range<R>;
 
 template <typename R>
+concept c_sized_range = std::ranges::sized_range<R>;
+
+template <typename R, typename T>
+concept c_range_of = c_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
+
+template <typename R, typename T>
+concept c_sized_range_of = c_sized_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
+
+// preserves cv qualifiers
+template <typename R, typename T>
+concept c_range_of_cv = c_range<R> and std::same_as<T, std::ranges::range_value_t<R>>;
+
+// preserves cv qualifiers
+template <typename R, typename T>
+concept c_sized_range_of_cv = c_sized_range<R> and std::same_as<T, std::ranges::range_value_t<R>>;
+
+template <typename R>
 concept c_const_range = requires(R& r) {
     std::ranges::cbegin(r);
     std::ranges::cend(r);
-};
-
-template <typename R>
-concept c_reverse_range = requires(R& r) {
-    std::ranges::rbegin(r);
-    std::ranges::rend(r);
 };
 
 template <typename T>

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -41,10 +41,12 @@ template <typename R>
 concept c_sized_range = std::ranges::sized_range<R>;
 
 template <typename R, typename T>
-concept c_range_of = c_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
+concept c_range_of =
+    c_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
 
 template <typename R, typename T>
-concept c_sized_range_of = c_sized_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
+concept c_sized_range_of =
+    c_sized_range<R> and std::same_as<T, std::remove_cv_t<std::ranges::range_value_t<R>>>;
 
 // preserves cv qualifiers
 template <typename R, typename T>

--- a/include/gl/types/types.hpp
+++ b/include/gl/types/types.hpp
@@ -15,4 +15,7 @@ using homogeneous_pair = std::pair<T, T>;
 template <typename T>
 using optional_ref = std::optional<std::reference_wrapper<std::remove_reference_t<T>>>;
 
+template <typename T>
+using const_ref_wrap = std::reference_wrapper<const T>;
+
 } // namespace gl::types

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -73,4 +73,22 @@ using vertex_ptr_type = std::unique_ptr<VertexType>;
 
 } // namespace types
 
+namespace detail {
+
+template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
+[[nodiscard]] gl_attr_force_inline types::vertex_ptr_type<VertexType> make_vertex(
+    const types::id_type id
+) {
+    return std::make_unique<VertexType>(id);
+}
+
+template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
+[[nodiscard]] gl_attr_force_inline types::vertex_ptr_type<VertexType> make_vertex(
+    const types::id_type id, const typename VertexType::properties_type& properties
+) {
+    return std::make_unique<VertexType>(id, properties);
+}
+
+}
+
 } // namespace gl

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -66,4 +66,11 @@ private:
 template <type_traits::c_properties Properties = types::empty_properties>
 using vertex = vertex_descriptor<Properties>;
 
+namespace types {
+
+template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
+using vertex_ptr_type = std::unique_ptr<VertexType>;
+
+} // namespace types
+
 } // namespace gl

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -89,6 +89,6 @@ template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
     return std::make_unique<VertexType>(id, properties);
 }
 
-}
+} // namespace detail
 
 } // namespace gl

--- a/tests/include/transforms.hpp
+++ b/tests/include/transforms.hpp
@@ -8,8 +8,8 @@
 
 namespace gl_testing::transforms {
 
-template <lib_tt::c_instantiation_of<lib::vertex_descriptor> Vertextype = lib::vertex_descriptor<>>
-inline lib_t::id_type extract_vertex_id(const Vertextype& vertex) {
+template <lib_tt::c_instantiation_of<lib::vertex_descriptor> VertexType = lib::vertex_descriptor<>>
+inline lib_t::id_type extract_vertex_id(const VertexType& vertex) {
     return vertex.id();
 }
 

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -81,7 +81,7 @@ struct test_directed_adjacency_list {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {
@@ -329,7 +329,7 @@ struct test_undirected_adjacency_list {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -222,7 +222,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
     "get_edges(id, id) should return a valid edge view if the given vertices are connected"
 ) {
-    std::vector<std::reference_wrapper<const edge_type>> expected_edges;
+    std::vector<lib_t::const_ref_wrap<edge_type>> expected_edges;
     for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
         expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2))
         );
@@ -497,7 +497,7 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_list,
     "get_edges(id, id) should return a valid edge view if the given vertices are connected"
 ) {
-    std::vector<std::reference_wrapper<const edge_type>> expected_edges;
+    std::vector<lib_t::const_ref_wrap<edge_type>> expected_edges;
     for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
         expected_edges.push_back(std::cref(add_edge(constants::vertex_id_1, constants::vertex_id_2))
         );

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -81,7 +81,9 @@ struct test_directed_adjacency_list {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(
+            lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
+        );
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {
@@ -329,7 +331,9 @@ struct test_undirected_adjacency_list {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(
+            lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
+        );
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -46,6 +46,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.n_vertices(), target_n_vertices);
         CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
     }
+
+    SUBCASE("add_vertices(n) should properly extend the current adjacency list") {
+        SutType sut{};
+        sut.add_vertices(constants::n_elements);
+
+        CHECK_EQ(sut.n_vertices(), constants::n_elements);
+        CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
+    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -47,6 +47,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.n_vertices(), target_n_vertices);
         CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
     }
+
+    SUBCASE("add_vertices(n) should properly extend the current adjacency list") {
+        SutType sut{};
+        sut.add_vertices(constants::n_elements);
+
+        CHECK_EQ(sut.n_vertices(), constants::n_elements);
+        CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
+    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -82,7 +82,9 @@ struct test_directed_adjacency_matrix {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(
+            lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
+        );
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {
@@ -280,7 +282,9 @@ struct test_undirected_adjacency_matrix {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(
+            lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
+        );
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -82,7 +82,7 @@ struct test_directed_adjacency_matrix {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {
@@ -280,7 +280,7 @@ struct test_undirected_adjacency_matrix {
     }
 
     const edge_type& add_edge(const lib_t::id_type first_id, const lib_t::id_type second_id) {
-        return sut.add_edge(lib::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
+        return sut.add_edge(lib::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id]));
     }
 
     void fully_connect_vertex(const lib_t::id_type first_id) {

--- a/tests/source/test_edge_tags.cpp
+++ b/tests/source/test_edge_tags.cpp
@@ -26,7 +26,7 @@ struct test_directed_edge_tag : test_edge_tags {
 };
 
 TEST_CASE_FIXTURE(
-    test_directed_edge_tag, "detail::make_edge should return a unique ptr to a directed edge"
+    test_directed_edge_tag, "make_edge should return a unique ptr to a directed edge"
 ) {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(edge)>, std::unique_ptr<edge_type>>);
 
@@ -39,7 +39,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
-    "detail::make_edge should return a unique ptr to a directed edge with the given properties"
+    "make_edge should return a unique ptr to a directed edge with the given properties"
 ) {
     using property_edge_type = lib::directed_edge<vertex_type, types::used_property>;
 
@@ -82,7 +82,7 @@ struct test_undirected_edge_tag : test_edge_tags {
 };
 
 TEST_CASE_FIXTURE(
-    test_undirected_edge_tag, "detail::make_edge should return a shared ptr to a directed edge"
+    test_undirected_edge_tag, "make_edge should return a shared ptr to a directed edge"
 ) {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(edge)>, std::shared_ptr<edge_type>>);
 
@@ -95,7 +95,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
-    "detail::make_edge should return a shared ptr to a directed edge with the given properties"
+    "make_edge should return a shared ptr to a directed edge with the given properties"
 ) {
     using property_edge_type = lib::undirected_edge<vertex_type, types::used_property>;
 

--- a/tests/source/test_edge_tags.cpp
+++ b/tests/source/test_edge_tags.cpp
@@ -22,11 +22,11 @@ struct test_directed_edge_tag : test_edge_tags {
     using sut_type = lib::directed_t;
     using edge_type = lib::directed_edge<vertex_type>;
 
-    const std::unique_ptr<edge_type> edge = lib::make_edge<edge_type>(vd_1, vd_2);
+    const std::unique_ptr<edge_type> edge = lib::detail::make_edge<edge_type>(vd_1, vd_2);
 };
 
 TEST_CASE_FIXTURE(
-    test_directed_edge_tag, "make_edge should return a unique ptr to a directed edge"
+    test_directed_edge_tag, "detail::make_edge should return a unique ptr to a directed edge"
 ) {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(edge)>, std::unique_ptr<edge_type>>);
 
@@ -39,12 +39,12 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
-    "make_edge should return a unique ptr to a directed edge with the given properties"
+    "detail::make_edge should return a unique ptr to a directed edge with the given properties"
 ) {
     using property_edge_type = lib::directed_edge<vertex_type, types::used_property>;
 
     const types::used_property used{true};
-    const auto property_edge = lib::make_edge<property_edge_type>(vd_1, vd_2, used);
+    const auto property_edge = lib::detail::make_edge<property_edge_type>(vd_1, vd_2, used);
 
     static_assert(std::is_same_v<
                   std::remove_cvref_t<decltype(property_edge)>,
@@ -78,11 +78,11 @@ struct test_undirected_edge_tag : test_edge_tags {
     using sut_type = lib::undirected_t;
     using edge_type = lib::undirected_edge<vertex_type>;
 
-    const std::shared_ptr<edge_type> edge = lib::make_edge<edge_type>(vd_1, vd_2);
+    const std::shared_ptr<edge_type> edge = lib::detail::make_edge<edge_type>(vd_1, vd_2);
 };
 
 TEST_CASE_FIXTURE(
-    test_undirected_edge_tag, "make_edge should return a shared ptr to a directed edge"
+    test_undirected_edge_tag, "detail::make_edge should return a shared ptr to a directed edge"
 ) {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(edge)>, std::shared_ptr<edge_type>>);
 
@@ -95,12 +95,12 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
-    "make_edge should return a shared ptr to a directed edge with the given properties"
+    "detail::make_edge should return a shared ptr to a directed edge with the given properties"
 ) {
     using property_edge_type = lib::undirected_edge<vertex_type, types::used_property>;
 
     const types::used_property used{true};
-    const auto property_edge = lib::make_edge<property_edge_type>(vd_1, vd_2, used);
+    const auto property_edge = lib::detail::make_edge<property_edge_type>(vd_1, vd_2, used);
 
     static_assert(std::is_same_v<
                   std::remove_cvref_t<decltype(property_edge)>,

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -320,11 +320,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("add_edge(ids) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
                 sut.add_edge(constants::out_of_range_elemenet_idx, constants::vertex_id_2),
-                std::out_of_range
+                std::invalid_argument
             );
             CHECK_THROWS_AS(
                 sut.add_edge(constants::vertex_id_1, constants::out_of_range_elemenet_idx),
-                std::out_of_range
+                std::invalid_argument
             );
         }
 
@@ -422,13 +422,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 sut.add_edge(
                     constants::out_of_range_elemenet_idx, constants::vertex_id_2, constants::used
                 ),
-                std::out_of_range
+                std::invalid_argument
             );
             CHECK_THROWS_AS(
                 sut.add_edge(
                     constants::vertex_id_1, constants::out_of_range_elemenet_idx, constants::used
                 ),
-                std::out_of_range
+                std::invalid_argument
             );
         }
 

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -89,6 +89,11 @@ using add_edge_property = lib::graph_traits<
     EdgeProperties,
     typename TraitsType::implementation_tag>;
 
+using vertex_id_list = std::vector<lib_t::id_type>;
+
+template <lib_tt::c_instantiation_of<lib::vertex_descriptor> VertexType>
+using vertex_ref_list = std::vector<std::reference_wrapper<const VertexType>>;
+
 TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_template) {
     using fixture_type = test_graph<TraitsType>;
     using sut_type = typename fixture_type::sut_type;
@@ -166,7 +171,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         using properties_traits_type = add_vertex_property<traits_type, types::visited_property>;
         lib::graph<properties_traits_type> sut;
 
-        const std::initializer_list<types::visited_property> properties_list{
+        const std::vector<types::visited_property> properties_list{
             constants::visited, constants::not_visited, constants::visited
         };
         const auto expected_n_vertices = properties_list.size();
@@ -391,14 +396,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             CHECK_THROWS_AS(
-                sut.add_edges_from(constants::out_of_range_elemenet_idx, {}), std::out_of_range
+                sut.add_edges_from(constants::out_of_range_elemenet_idx, vertex_id_list{}), std::out_of_range
             );
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
                     constants::vertex_id_1,
-                    {constants::vertex_id_2, constants::out_of_range_elemenet_idx}
+                    vertex_id_list{constants::vertex_id_2, constants::out_of_range_elemenet_idx}
                 ),
                 std::out_of_range
             );
@@ -409,7 +414,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             constexpr auto source_id = constants::vertex_id_1;
-            const std::initializer_list<lib_t::id_type> destination_id_list{
+            const std::vector<lib_t::id_type> destination_id_list{
                 constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
             };
 
@@ -425,20 +430,20 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 "graph") {
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            CHECK_THROWS_AS(sut.add_edges_from(fixture.out_of_range_vertex, {}), std::out_of_range);
+            CHECK_THROWS_AS(sut.add_edges_from(fixture.out_of_range_vertex, vertex_ref_list<vertex_type>{}), std::out_of_range);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-            CHECK_THROWS_AS(sut.add_edges_from(fixture.invalid_vertex, {}), std::invalid_argument);
+            CHECK_THROWS_AS(sut.add_edges_from(fixture.invalid_vertex, vertex_ref_list<vertex_type>{}), std::invalid_argument);
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             CHECK_THROWS_AS(
-                sut.add_edges_from(vertex_1, {vertex_2, fixture.out_of_range_vertex}),
+                sut.add_edges_from(vertex_1, vertex_ref_list<vertex_type>{vertex_2, fixture.out_of_range_vertex}),
                 std::out_of_range
             );
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             CHECK_THROWS_AS(
-                sut.add_edges_from(vertex_1, {vertex_2, fixture.invalid_vertex}),
+                sut.add_edges_from(vertex_1, vertex_ref_list<vertex_type>{vertex_2, fixture.invalid_vertex}),
                 std::invalid_argument
             );
             CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
@@ -448,7 +453,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             const auto& source = vertex_1;
-            const std::initializer_list<std::reference_wrapper<const vertex_type>> destination_list{
+            const std::vector<std::reference_wrapper<const vertex_type>> destination_list{
                 vertex_1, vertex_2, vertex_3
             };
 
@@ -495,7 +500,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements + constants::one_element);
 
-            std::initializer_list<std::reference_wrapper<const edge_type>> edges_to_remove{
+            std::vector<std::reference_wrapper<const edge_type>> edges_to_remove{
                 edge_1, edge_2, edge_3
             };
 
@@ -649,7 +654,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements + constants::one_element);
 
-            std::initializer_list<std::reference_wrapper<const property_edge_type>> edges_to_remove{
+            const std::vector<std::reference_wrapper<const property_edge_type>> edges_to_remove{
                 edge_1, edge_2, edge_3
             };
 

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -327,6 +327,38 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         constexpr auto expected_n_vertices = n_vertices - constants::two;
         REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+
+        constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
+        CHECK(std::ranges::all_of(
+            sut.vertices(),
+            [&sut, expected_n_adjacent_edges](const auto& vertex) {
+                return sut.adjacent_edges(vertex).distance() == expected_n_adjacent_edges;
+            }
+        ));
+    }
+
+    SUBCASE("remove_vetices_from(vertices) should properly remove elements at given indices "
+            "(ignoring duplicate vertex references)") {
+        constexpr auto n_vertices = constants::n_elements + constants::one_element;
+
+        sut_type sut{n_vertices};
+        fixture.initialize_full_graph(sut);
+
+        const auto& v1 = sut.get_vertex(constants::vertex_id_1);
+        const auto& v3 = sut.get_vertex(constants::vertex_id_3);
+
+        sut.remove_vertices_from(vertex_ref_list<vertex_type>{v1, v3, v1});
+
+        constexpr auto expected_n_vertices = n_vertices - constants::two;
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+
+        constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
+        CHECK(std::ranges::all_of(
+            sut.vertices(),
+            [&sut, expected_n_adjacent_edges](const auto& vertex) {
+                return sut.adjacent_edges(vertex).distance() == expected_n_adjacent_edges;
+            }
+        ));
     }
 
     // --- edge method tests ---

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -153,6 +153,37 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK_EQ(vertex.properties, constants::visited);
     }
 
+    SUBCASE("add_vertices(n) should properly extend the current adjacency list") {
+        sut_type sut{};
+        sut.add_vertices(constants::n_elements);
+
+        CHECK_EQ(sut.n_vertices(), constants::n_elements);
+        CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
+    }
+
+    SUBCASE("add_vertices_with should properly extend the current adjacency list with the given "
+            "properties") {
+        using properties_traits_type = add_vertex_property<traits_type, types::visited_property>;
+        lib::graph<properties_traits_type> sut;
+
+        const std::initializer_list<types::visited_property> properties_list{
+            constants::visited, constants::not_visited, constants::visited
+        };
+        const auto expected_n_vertices = properties_list.size();
+
+        sut.add_vertices_with(properties_list);
+
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
+
+        CHECK(std::ranges::equal(
+            sut.vertices(),
+            properties_list,
+            std::ranges::equal_to{},
+            [](const auto& vertex) { return vertex.properties; }
+        ));
+    }
+
     SUBCASE("has_vertex(id) should return true when a vertex with the given id is present in "
             "the graph") {
         sut_type sut{constants::n_elements};

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -8,7 +8,6 @@
 #include <doctest.h>
 
 #include <algorithm>
-#include <iostream>
 
 namespace gl_testing {
 
@@ -483,67 +482,38 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             CHECK_EQ(adjacent_edges_2.distance(), constants::zero_elements);
         }
 
-        // SUBCASE("remove_edges_from should properly erase all given edges") {
-        //     REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
+        SUBCASE("remove_edges_from should properly erase all given edges") {
+            REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
-        //     std::cout << "[test begin]\n";
+            const auto& edge_1 = sut.add_edge(vertex_1, vertex_2);
+            const auto& edge_2 = sut.add_edge(vertex_2, vertex_3);
+            const auto& edge_3 = sut.add_edge(vertex_3, vertex_1);
 
-        //     const auto& edge_1 = sut.add_edge(vertex_1, vertex_2);
-        //     const auto& edge_2 = sut.add_edge(vertex_2, vertex_3);
-        //     const auto& edge_3 = sut.add_edge(vertex_3, vertex_1);
+            // an additional edge to verify that only the given edges are removed
+            const auto& vertex_4 = sut.add_vertex();
+            const auto& edge_4 = sut.add_edge(vertex_1, vertex_4);
 
-        //     std::cout << "base vertices: " << vertex_1.id() << ", " << vertex_2.id() << ", " << vertex_3.id() << std::endl;
+            REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements + constants::one_element);
 
-        //     std::cout << "base edges\n";
+            std::initializer_list<std::reference_wrapper<const edge_type>> edges_to_remove{
+                edge_1, edge_2, edge_3
+            };
 
-        //     const auto& vertex_4 = sut.add_vertex();
+            const auto has_edge = [&sut](const auto& edge_ref) {
+                return sut.has_edge(edge_ref.get());
+            };
 
-        //     std::cout << "new vertex -> " << vertex_4.id() << " | size = " << sut.n_vertices() << std::endl;
-        //     std::cout << "base vertices: " << vertex_1.id() << ", " << vertex_2.id() << ", " << vertex_3.id() << std::endl;
+            REQUIRE(std::ranges::all_of(edges_to_remove, has_edge));
+            REQUIRE(sut.has_edge(edge_4));
 
-        //     const auto& edge_4 = sut.add_edge(vertex_1, vertex_4);
+            sut.remove_edges_from(edges_to_remove);
 
-        //     std::cout << "dangling edge\n";
-
-        //     REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements + constants::one_element);
-
-        //     std::cout << "req: n_edges\n";
-
-        //     std::initializer_list<std::reference_wrapper<const edge_type>> edges_to_remove{
-        //         edge_1, edge_2, edge_3
-        //     };
-
-        //     const auto has_edge = [&sut](const auto& edge_ref) {
-        //         return sut.has_edge(edge_ref.get());
-        //     };
-
-        //     std::cout << "req prep: has_edge\n";
-
-        //     REQUIRE(std::ranges::all_of(edges_to_remove, has_edge));
-        //     REQUIRE(sut.has_edge(edge_4));
-
-        //     std::cout << "req: has_edge\n";
-
-        //     sut.remove_edges_from(edges_to_remove);
-
-        //     std::cout << "rem edges\n";
-
-        //     CHECK_EQ(sut.n_unique_edges(), constants::one_element);
-
-        //     std::cout << "check: n_edges\n";
-
-        //     CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
-        //     CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
-        //     CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
-
-        //     std::cout << "check: has_edges(base) = false\n";
-
-        //     CHECK(sut.has_edge(edge_4));
-
-        //     std::cout << "check: has_edge(dangling) = true\n";
-
-        //     std::cout << "[test end]\n\n";
-        // }
+            CHECK_EQ(sut.n_unique_edges(), constants::one_element);
+            CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
+            CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
+            CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
+            CHECK(sut.has_edge(edge_4));
+        }
     }
 
     SUBCASE("edge method tests for non-default properties type") {

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -20,11 +20,6 @@ struct test_graph {
     using vertex_type = typename sut_type::vertex_type;
 
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
-    typename GraphType::vertex_set_type& get_vertex_list(GraphType& graph) {
-        return graph._vertices;
-    }
-
-    template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     requires(lib_tt::is_directed_v<typename GraphType::edge_type>)
     void initialize_full_graph(GraphType& graph) {
         const auto vertices = graph.vertices();
@@ -195,8 +190,16 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("vertices should return the correct vertex list iterator range") {
         sut_type sut{constants::n_elements};
 
-        const auto v_range = sut.vertices();
-        CHECK(std::ranges::equal(v_range, fixture.get_vertex_list(sut)));
+        // clang-format off
+
+        CHECK(std::ranges::equal(
+            sut.vertices(),
+            constants::vertex_id_view,
+            std::ranges::equal_to{},
+            transforms::extract_vertex_id<vertex_type>
+        ));
+
+        // clang-format on
     }
 
     SUBCASE("remove_vertex(vertex) should throw if the id of the given is invalid") {
@@ -214,7 +217,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
         fixture.initialize_full_graph(sut);
 
-        sut.remove_vertex(fixture.get_vertex_list(sut).at(constants::vertex_id_1));
+        sut.remove_vertex(constants::vertex_id_1);
 
         constexpr lib_t::size_type n_vertices_after_remove =
             constants::n_elements - constants::one_element;

--- a/tests/source/test_graph_incidence.cpp
+++ b/tests/source/test_graph_incidence.cpp
@@ -29,13 +29,13 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
             func::discard_result(
                 sut.are_incident(constants::out_of_range_elemenet_idx, constants::vertex_id_2)
             ),
-            std::invalid_argument
+            std::out_of_range
         );
         CHECK_THROWS_AS(
             func::discard_result(
                 sut.are_incident(constants::vertex_id_1, constants::out_of_range_elemenet_idx)
             ),
-            std::invalid_argument
+            std::out_of_range
         );
     }
 


### PR DESCRIPTION
Added the following functionality to the `graph` class
- adding multiple vertices at once
- removing multiple vertices at once
- adding multiple edges for one source at once
- removing multiple edges at once
Adjusted the vertex list inside the `graph` class to hold vertices in `std::unique_ptr` to avoid actual vertex object memory address changes 