### PR TITLE
YT-CPPGL-29: Implement the breadth-first search algorithm

### DIFF
--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -1,83 +1,58 @@
 #pragma once
 
-#include "gl/graph.hpp"
-#include "types.hpp"
+#include "detail/search_algorithm_util.hpp"
 
 #include <iostream>
 #include <queue>
 
 namespace gl::algorithm {
 
-namespace detail {
-
-template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
-[[nodiscard]] gl_attr_force_inline SearchTreeType init_search_tree(const GraphType& graph) {
-    if constexpr (type_traits::is_alg_no_return_type_v<SearchTreeType>)
-        return SearchTreeType{};
-    else
-        return SearchTreeType(graph.n_vertices());
-}
-
-template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
-void visit(
-    const typename GraphType::vertex_type& vertex,
-    const types::id_type source_id,
-    visited_list& visited,
-    SearchTreeType& search_tree
+template <
+    type_traits::c_alg_return_graph SearchTreeType,
+    type_traits::c_graph GraphType,
+    type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
+    type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
+type_traits::alg_return_type<SearchTreeType> breadth_first_search(
+    const GraphType& graph,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
 ) {
-    const auto vertex_id = vertex.id();
-
-    std::cout << "visiting: " << vertex_id << std::endl;
-    visited[vertex_id] = true;
-
-    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
-        if (source_id != vertex_id)
-            search_tree.add_edge(source_id, vertex_id);
-    }
-}
-
-} // namespace detail
-
-template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_graph GraphType>
-type_traits::alg_return_type<SearchTreeType> breadth_first_search(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
+    using edge_type = typename GraphType::edge_type;
 
-    struct bfs_qvertex {
-        types::id_type id;
-        types::id_type source_id;
-        // if source_id == vertex.id() then vertex_id is the id of the starting vertex
-    };
+    std::vector<bool> visited(graph.n_vertices(), false);
+    std::vector<types::id_type> sources(graph.n_vertices());
 
-    using vertex_queue_type = std::queue<bfs_qvertex>;
-    vertex_queue_type vertex_queue;
-
-    visited_list visited(graph.n_vertices(), false);
     auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
 
-    for (const auto& vertex : graph.vertices()) {
+    const auto search_vertex_predicate = [&visited](const vertex_type& vertex) -> bool {
+        return not visited[vertex.id()];
+    };
+
+    const auto visit = [&](const vertex_type& vertex, const types::id_type source_id) {
         const auto vertex_id = vertex.id();
-        if (visited[vertex_id])
-            continue;
-
-        vertex_queue.push(bfs_qvertex{vertex_id, vertex_id});
-
-        while (not vertex_queue.empty()) {
-            bfs_qvertex qv = vertex_queue.front();
-            vertex_queue.pop();
-
-            if (visited[qv.id])
-                continue;
-
-            const auto& vertex = graph.get_vertex(qv.id);
-            detail::visit<SearchTreeType, GraphType>(vertex, qv.source_id, visited, search_tree);
-
-            for (const auto& edge : graph.adjacent_edges(qv.id)) {
-                const auto adjacent_id = edge.incident_vertex(vertex).id();
-                if (not visited[adjacent_id])
-                    vertex_queue.push(bfs_qvertex{adjacent_id, qv.id});
-            }
+        visited[vertex_id] = true;
+        if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
+            if (source_id != vertex_id)
+                search_tree.add_edge(source_id, vertex_id);
         }
-    }
+    };
+
+    const auto enque_vertex_predicate = [&visited](const vertex_type& vertex, const edge_type& in_edge) {
+        return not visited[vertex.id()];
+    };
+
+    detail::bfs_impl(
+        graph,
+        search_vertex_predicate,
+        visit,
+        enque_vertex_predicate,
+        pre_visit,
+        post_visit
+    );
+
+    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>)
+        return search_tree;
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "gl/graph.hpp"
+#include "types.hpp"
+
+#include <iostream>
+#include <queue>
+
+namespace gl::algorithm {
+
+namespace detail {
+
+template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
+[[nodiscard]] gl_attr_force_inline SearchTreeType init_search_tree(const GraphType& graph) {
+    if constexpr (type_traits::is_alg_no_return_type_v<SearchTreeType>)
+        return SearchTreeType{};
+    else
+        return SearchTreeType(graph.n_vertices());
+}
+
+template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
+void visit(
+    const typename GraphType::vertex_type& vertex,
+    const types::id_type source_id,
+    visited_list& visited,
+    SearchTreeType& search_tree
+) {
+    const auto vertex_id = vertex.id();
+
+    std::cout << "visiting: " << vertex_id << std::endl;
+    visited[vertex_id] = true;
+
+    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
+        if (source_id != vertex_id)
+            search_tree.add_edge(source_id, vertex_id);
+    }
+}
+
+} // namespace detail
+
+template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_graph GraphType>
+type_traits::alg_return_type<SearchTreeType> breadth_first_search(const GraphType& graph) {
+    using vertex_type = typename GraphType::vertex_type;
+
+    struct bfs_qvertex {
+        types::id_type id;
+        types::id_type source_id;
+        // if source_id == vertex.id() then vertex_id is the id of the starting vertex
+    };
+
+    using vertex_queue_type = std::queue<bfs_qvertex>;
+    vertex_queue_type vertex_queue;
+
+    visited_list visited(graph.n_vertices(), false);
+    auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
+
+    for (const auto& vertex : graph.vertices()) {
+        const auto vertex_id = vertex.id();
+        if (visited[vertex_id])
+            continue;
+
+        vertex_queue.push(bfs_qvertex{vertex_id, vertex_id});
+
+        while (not vertex_queue.empty()) {
+            bfs_qvertex qv = vertex_queue.front();
+            vertex_queue.pop();
+
+            if (visited[qv.id])
+                continue;
+
+            const auto& vertex = graph.get_vertex(qv.id);
+            detail::visit<SearchTreeType, GraphType>(vertex, qv.source_id, visited, search_tree);
+
+            for (const auto& edge : graph.adjacent_edges(qv.id)) {
+                const auto adjacent_id = edge.incident_vertex(vertex).id();
+                if (not visited[adjacent_id])
+                    vertex_queue.push(bfs_qvertex{adjacent_id, qv.id});
+            }
+        }
+    }
+}
+
+} // namespace gl::algorithm

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -15,7 +15,7 @@ template <
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
 type_traits::alg_return_type<SearchTreeType> breadth_first_search(
     const GraphType& graph,
-    const types::optional_cref<typename GraphType::vertex_type>& root_vertex_opt = no_root_vertex,
+    const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
@@ -45,10 +45,10 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
             return not visited[vertex.id()];
         };
 
-    if (root_vertex_opt) {
+    if (root_vertex_id_opt) {
         detail::rooted_bfs_impl(
             graph,
-            root_vertex_opt->get(),
+            graph.get_vertex(root_vertex_id_opt.value()),
             search_vertex_predicate,
             visit,
             enque_vertex_predicate,

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "constants.hpp"
 #include "detail/search_algorithm_util.hpp"
 
 #include <iostream>
@@ -14,6 +15,7 @@ template <
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
 type_traits::alg_return_type<SearchTreeType> breadth_first_search(
     const GraphType& graph,
+    const types::optional_cref<typename GraphType::vertex_type>& root_vertex_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
@@ -38,18 +40,27 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
         }
     };
 
-    const auto enque_vertex_predicate = [&visited](const vertex_type& vertex, const edge_type& in_edge) {
-        return not visited[vertex.id()];
-    };
+    const auto enque_vertex_predicate =
+        [&visited](const vertex_type& vertex, const edge_type& in_edge) {
+            return not visited[vertex.id()];
+        };
 
-    detail::bfs_impl(
-        graph,
-        search_vertex_predicate,
-        visit,
-        enque_vertex_predicate,
-        pre_visit,
-        post_visit
-    );
+    if (root_vertex_opt) {
+        detail::rooted_bfs_impl(
+            graph,
+            root_vertex_opt->get(),
+            search_vertex_predicate,
+            visit,
+            enque_vertex_predicate,
+            pre_visit,
+            post_visit
+        );
+    }
+    else {
+        detail::bfs_impl(
+            graph, search_vertex_predicate, visit, enque_vertex_predicate, pre_visit, post_visit
+        );
+    }
 
     if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>)
         return search_tree;

--- a/include/gl/algorithm/constants.hpp
+++ b/include/gl/algorithm/constants.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <optional>
+
+namespace gl::algorithm {
+
+inline constexpr std::nullopt_t no_root_vertex = std::nullopt;
+
+} // namespace gl::algorithm

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "gl/graph.hpp"
+#include "gl/algorithm/types.hpp"
+
+#include <queue>
+
+namespace gl::algorithm::detail {
+
+template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
+[[nodiscard]] gl_attr_force_inline SearchTreeType init_search_tree(const GraphType& graph) {
+    if constexpr (type_traits::is_alg_no_return_type_v<SearchTreeType>)
+        return SearchTreeType{};
+    else
+        return SearchTreeType(graph.n_vertices());
+}
+
+struct search_vertex_info {
+    search_vertex_info(types::id_type id) : id(id), source_id(id) {}
+    search_vertex_info(types::id_type id, types::id_type source_id) : id(id), source_id(source_id) {}
+
+    // if id == source_id then vertex_id is the id of the starting vertex
+    types::id_type id;
+    types::id_type source_id;
+};
+
+template <
+    type_traits::c_graph GraphType,
+    type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
+    type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
+void bfs_impl(
+    const GraphType& graph,
+    const vertex_callback<GraphType, bool>& search_vertex_pred,
+    const vertex_callback<GraphType, void, types::id_type>& visit,
+    const vertex_callback<GraphType, bool, const typename GraphType::edge_type&>& enque_vertex_pred,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using vertex_queue_type = std::queue<search_vertex_info>;
+    vertex_queue_type vertex_queue;
+
+    // iterate over all vertices to search through all connected components
+    for (const auto& root_vertex : graph.vertices()) {
+        if (not search_vertex_pred(root_vertex))
+            continue;
+
+        vertex_queue.push(search_vertex_info{root_vertex.id()});
+
+        while (not vertex_queue.empty()) {
+            const search_vertex_info sv = vertex_queue.front();
+            vertex_queue.pop();
+
+            const auto& vertex = graph.get_vertex(sv.id);
+            if (not search_vertex_pred(vertex))
+                continue;
+
+
+            if constexpr (not type_traits::is_empty_callback_v<PreVisitCallback>)
+                pre_visit(vertex);
+
+            visit(vertex, sv.source_id);
+
+            for (const auto& edge : graph.adjacent_edges(sv.id)) {
+                const auto& incident_vertex = edge.incident_vertex(vertex);
+                if (enque_vertex_pred(incident_vertex, edge))
+                    vertex_queue.push(search_vertex_info{incident_vertex.id(), sv.id});
+            }
+
+            if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
+                post_visit(vertex);
+        }
+    }
+}
+
+} // namespace gl::algorithm::detail

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -7,7 +7,7 @@
 
 namespace gl::algorithm::detail {
 
-template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directed_graph GraphType>
+template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_graph GraphType>
 [[nodiscard]] gl_attr_force_inline SearchTreeType init_search_tree(const GraphType& graph) {
     if constexpr (type_traits::is_alg_no_return_type_v<SearchTreeType>)
         return SearchTreeType{};

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "gl/graph.hpp"
 #include "gl/algorithm/types.hpp"
+#include "gl/graph.hpp"
 
 #include <queue>
 
@@ -17,7 +17,9 @@ template <type_traits::c_alg_return_graph SearchTreeType, type_traits::c_directe
 
 struct search_vertex_info {
     search_vertex_info(types::id_type id) : id(id), source_id(id) {}
-    search_vertex_info(types::id_type id, types::id_type source_id) : id(id), source_id(source_id) {}
+
+    search_vertex_info(types::id_type id, types::id_type source_id)
+    : id(id), source_id(source_id) {}
 
     // if id == source_id then vertex_id is the id of the starting vertex
     types::id_type id;
@@ -28,8 +30,9 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
-void bfs_impl(
+void rooted_bfs_impl(
     const GraphType& graph,
+    const typename GraphType::vertex_type& root_vertex,
     const vertex_callback<GraphType, bool>& search_vertex_pred,
     const vertex_callback<GraphType, void, types::id_type>& visit,
     const vertex_callback<GraphType, bool, const typename GraphType::edge_type&>& enque_vertex_pred,
@@ -37,39 +40,54 @@ void bfs_impl(
     const PostVisitCallback& post_visit = {}
 ) {
     using vertex_queue_type = std::queue<search_vertex_info>;
-    vertex_queue_type vertex_queue;
 
-    // iterate over all vertices to search through all connected components
-    for (const auto& root_vertex : graph.vertices()) {
-        if (not search_vertex_pred(root_vertex))
+    if (not search_vertex_pred(root_vertex))
+        return;
+
+    vertex_queue_type vertex_queue;
+    vertex_queue.push(search_vertex_info{root_vertex.id()});
+
+    while (not vertex_queue.empty()) {
+        const search_vertex_info sv = vertex_queue.front();
+        vertex_queue.pop();
+
+        const auto& vertex = graph.get_vertex(sv.id);
+        if (not search_vertex_pred(vertex))
             continue;
 
-        vertex_queue.push(search_vertex_info{root_vertex.id()});
+        if constexpr (not type_traits::is_empty_callback_v<PreVisitCallback>)
+            pre_visit(vertex);
 
-        while (not vertex_queue.empty()) {
-            const search_vertex_info sv = vertex_queue.front();
-            vertex_queue.pop();
+        visit(vertex, sv.source_id);
 
-            const auto& vertex = graph.get_vertex(sv.id);
-            if (not search_vertex_pred(vertex))
-                continue;
-
-
-            if constexpr (not type_traits::is_empty_callback_v<PreVisitCallback>)
-                pre_visit(vertex);
-
-            visit(vertex, sv.source_id);
-
-            for (const auto& edge : graph.adjacent_edges(sv.id)) {
-                const auto& incident_vertex = edge.incident_vertex(vertex);
-                if (enque_vertex_pred(incident_vertex, edge))
-                    vertex_queue.push(search_vertex_info{incident_vertex.id(), sv.id});
-            }
-
-            if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
-                post_visit(vertex);
+        for (const auto& edge : graph.adjacent_edges(sv.id)) {
+            const auto& incident_vertex = edge.incident_vertex(vertex);
+            if (enque_vertex_pred(incident_vertex, edge))
+                vertex_queue.push(search_vertex_info{incident_vertex.id(), sv.id});
         }
+
+        if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
+            post_visit(vertex);
     }
+}
+
+template <
+    type_traits::c_graph GraphType,
+    type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
+    type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
+gl_attr_force_inline void bfs_impl(
+    const GraphType& graph,
+    const vertex_callback<GraphType, bool>& search_vertex_pred,
+    const vertex_callback<GraphType, void, types::id_type>& visit,
+    const vertex_callback<GraphType, bool, const typename GraphType::edge_type&>& enque_vertex_pred,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    // iterate over all vertices to search through all connected components
+    for (const auto& root_vertex : graph.vertices())
+        rooted_bfs_impl(
+            graph, root_vertex, search_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit
+        );
 }
 
 } // namespace gl::algorithm::detail

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -13,13 +13,11 @@ struct no_return {};
 
 struct empty_callback {};
 
-template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
-using vertex_callback = std::function<void(const VertexType&)>;
+template <type_traits::c_graph GraphType, typename ReturnType, typename... Args>
+using vertex_callback = std::function<ReturnType(const typename GraphType::vertex_type&, Args...)>;
 
-template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
-using edge_callback = std::function<void(const EdgeType&)>;
-
-using visited_list = std::vector<bool>;
+template <type_traits::c_graph GraphType, typename ReturnType, typename... Args>
+using edge_callback = std::function<ReturnType(const typename GraphType::edge_type&, Args...)>;
 
 } // namespace algorithm
 
@@ -44,13 +42,13 @@ struct is_empty_callback : std::is_same<F, algorithm::empty_callback> {};
 template <typename F>
 inline constexpr bool is_empty_callback_v = is_empty_callback<F>::value;
 
-template <typename F, typename VertexType>
-concept c_vertex_callback =
-    c_one_of<F, algorithm::empty_callback, algorithm::vertex_callback<VertexType>>;
+template <typename F, typename GraphType, typename ReturnType, typename... Args>
+concept c_vertex_callback = is_empty_callback_v<F>
+    or std::convertible_to<F, algorithm::vertex_callback<GraphType, ReturnType, Args...>>;
 
-template <typename F, typename EdgeType>
-concept c_edge_callback =
-    c_one_of<F, algorithm::empty_callback, algorithm::edge_callback<EdgeType>>;
+template <typename F, typename GraphType, typename ReturnType, typename... Args>
+concept c_edge_callback = is_empty_callback_v<F>
+    or std::convertible_to<F, algorithm::edge_callback<GraphType, ReturnType, Args...>>;
 
 } // namespace type_traits
 

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "gl/graph.hpp"
+
+#include <functional>
+#include <vector>
+
+namespace gl {
+
+namespace algorithm {
+
+struct no_return {};
+
+struct empty_callback {};
+
+template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
+using vertex_callback = std::function<void(const VertexType&)>;
+
+template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
+using edge_callback = std::function<void(const EdgeType&)>;
+
+using visited_list = std::vector<bool>;
+
+} // namespace algorithm
+
+namespace type_traits {
+
+template <typename T>
+struct is_alg_no_return_type : std::is_same<T, algorithm::no_return> {};
+
+template <typename T>
+inline constexpr bool is_alg_no_return_type_v = is_alg_no_return_type<T>::value;
+
+template <typename T>
+concept c_alg_return_graph = c_graph<T> or std::same_as<T, algorithm::no_return>;
+
+template <c_alg_return_graph ReturnGraphType>
+using alg_return_type =
+    std::conditional_t<std::is_same_v<ReturnGraphType, algorithm::no_return>, void, ReturnGraphType>;
+
+template <typename F>
+struct is_empty_callback : std::is_same<F, algorithm::empty_callback> {};
+
+template <typename F>
+inline constexpr bool is_empty_callback_v = is_empty_callback<F>::value;
+
+template <typename F, typename VertexType>
+concept c_vertex_callback =
+    c_one_of<F, algorithm::empty_callback, algorithm::vertex_callback<VertexType>>;
+
+template <typename F, typename EdgeType>
+concept c_edge_callback =
+    c_one_of<F, algorithm::empty_callback, algorithm::edge_callback<EdgeType>>;
+
+} // namespace type_traits
+
+} // namespace gl

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -43,11 +43,13 @@ template <typename F>
 inline constexpr bool is_empty_callback_v = is_empty_callback<F>::value;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
-concept c_vertex_callback = is_empty_callback_v<F>
+concept c_vertex_callback =
+    is_empty_callback_v<F>
     or std::convertible_to<F, algorithm::vertex_callback<GraphType, ReturnType, Args...>>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
-concept c_edge_callback = is_empty_callback_v<F>
+concept c_edge_callback =
+    is_empty_callback_v<F>
     or std::convertible_to<F, algorithm::edge_callback<GraphType, ReturnType, Args...>>;
 
 } // namespace type_traits

--- a/include/gl/algorithms.hpp
+++ b/include/gl/algorithms.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "algorithm/breadth_first_search.hpp"

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -424,19 +424,19 @@ private:
 namespace type_traits {
 
 template <typename T>
-concept c_graph_type = c_instantiation_of<T, graph>;
+concept c_graph = c_instantiation_of<T, graph>;
 
-template <c_graph_type GraphType>
+template <c_graph GraphType>
 inline constexpr bool is_directed_v<GraphType> = is_directed_v<typename GraphType::edge_type>;
 
-template <c_graph_type GraphType>
+template <c_graph GraphType>
 inline constexpr bool is_undirected_v<GraphType> = is_undirected_v<typename GraphType::edge_type>;
 
 template <typename T>
-concept c_directed_graph_type = c_graph_type<T> and is_directed_v<T>;
+concept c_directed_graph = c_graph<T> and is_directed_v<T>;
 
 template <typename T>
-concept c_undirected_graph_type = c_graph_type<T> and is_undirected_v<T>;
+concept c_undirected_graph = c_graph<T> and is_undirected_v<T>;
 
 } // namespace type_traits
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -264,13 +264,13 @@ public:
         return this->_impl.has_edge(edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::optional_ref<const edge_type> get_edge(
+    [[nodiscard]] gl_attr_force_inline types::optional_cref<edge_type> get_edge(
         const types::id_type first_id, const types::id_type second_id
     ) const {
         return this->_impl.get_edge(first_id, second_id);
     }
 
-    [[nodiscard]] types::optional_ref<const edge_type> get_edge(
+    [[nodiscard]] types::optional_cref<edge_type> get_edge(
         const vertex_type& first, const vertex_type& second
     ) const {
         if (not (this->has_vertex(first) and this->has_vertex(second)))

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -19,7 +19,7 @@ using vertex_id_range = std::vector<types::id_type>;
 
 } // namespace detail
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType complete_binary_tree(const types::size_type depth) {
     constexpr types::size_type min_non_trivial_depth = 2ull;
 
@@ -45,7 +45,7 @@ template <type_traits::c_graph_type GraphType>
     return graph;
 }
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType bidirectional_complete_binary_tree(const types::size_type depth) {
     if constexpr (type_traits::is_directed_v<GraphType>) {
         constexpr types::size_type min_non_trivial_depth = 2ull;

--- a/include/gl/topology/bipartite.hpp
+++ b/include/gl/topology/bipartite.hpp
@@ -5,7 +5,7 @@
 
 namespace gl::topology {
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType full_bipartite(
     const types::size_type n_vertices_a, const types::size_type n_vertices_b
 ) {

--- a/include/gl/topology/clique.hpp
+++ b/include/gl/topology/clique.hpp
@@ -5,7 +5,7 @@
 
 namespace gl::topology {
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType clique(const types::size_type n_vertices) {
     GraphType graph{n_vertices};
 

--- a/include/gl/topology/cycle.hpp
+++ b/include/gl/topology/cycle.hpp
@@ -5,7 +5,7 @@
 
 namespace gl::topology {
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType cycle(const types::size_type n_vertices) {
     GraphType graph{n_vertices};
 
@@ -15,7 +15,7 @@ template <type_traits::c_graph_type GraphType>
     return graph;
 }
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType bidirectional_cycle(const types::size_type n_vertices) {
     if constexpr (type_traits::is_directed_v<GraphType>) {
         GraphType graph{n_vertices};

--- a/include/gl/topology/path.hpp
+++ b/include/gl/topology/path.hpp
@@ -5,7 +5,7 @@
 
 namespace gl::topology {
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType path(const types::size_type n_vertices) {
     GraphType graph{n_vertices};
 
@@ -16,7 +16,7 @@ template <type_traits::c_graph_type GraphType>
     return graph;
 }
 
-template <type_traits::c_graph_type GraphType>
+template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType bidirectional_path(const types::size_type n_vertices) {
     if constexpr (type_traits::is_directed_v<GraphType>) {
         GraphType graph{n_vertices};

--- a/include/gl/types/types.hpp
+++ b/include/gl/types/types.hpp
@@ -16,6 +16,9 @@ template <typename T>
 using optional_ref = std::optional<std::reference_wrapper<std::remove_reference_t<T>>>;
 
 template <typename T>
+using optional_cref = std::optional<std::reference_wrapper<const std::remove_cvref_t<T>>>;
+
+template <typename T>
 using const_ref_wrap = std::reference_wrapper<const T>;
 
 } // namespace gl::types

--- a/tests/include/constants.hpp
+++ b/tests/include/constants.hpp
@@ -23,6 +23,9 @@ IC lib_t::size_type one_element = one;
 // n_elements for graph topology tests
 IC lib_t::size_type n_elements_top = 10ull;
 
+// n_elements for graph algorithm tests
+IC lib_t::size_type n_elements_alg = 10ull;
+
 IC lib_t::size_type first_element_idx = zero;
 IC lib_t::size_type last_element_idx = n_elements - one_element;
 IC lib_t::size_type out_of_range_elemenet_idx = n_elements;

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -83,6 +83,65 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search no return with root vertex should properly traverse the graph",
+    GraphType,
+    bfs_no_return_with_root_graph_template
+) {
+    using graph_type = lib::graph<>;
+
+    graph_type graph;
+    std::optional<lib_t::id_type> root_vertex_id;
+    std::deque<lib_t::id_type> expected_previsit_order;
+
+    SUBCASE("single vertex graph") {
+        graph = lib::topology::clique<graph_type>(constants::one_element);
+        root_vertex_id.emplace(constants::vertex_id_1);
+        expected_previsit_order = {0};
+    }
+
+    SUBCASE("clique") {
+        graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
+        root_vertex_id.emplace(constants::vertex_id_3);
+
+        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
+            expected_previsit_order.push_back(id);
+        expected_previsit_order.erase(
+            std::next(expected_previsit_order.begin(), constants::vertex_id_3)
+        );
+        expected_previsit_order.push_front(constants::vertex_id_3);
+    }
+
+    CAPTURE(graph);
+    CAPTURE(root_vertex_id);
+    CAPTURE(expected_previsit_order);
+
+    std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
+
+    std::vector<lib_t::id_type> previsit_order, postvisit_order;
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
+        graph,
+        root_vertex_id,
+        [&](const auto& vertex) { // previsit
+            previsit_order.push_back(vertex.id());
+        },
+        [&](const auto& vertex) { // postvisit
+            postvisit_order.push_back(vertex.id());
+        }
+    );
+
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_no_return_with_root_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
     "breadth_first_search with return should properly traverse the graph",
     GraphType,
     bfs_return_graph_template

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -11,32 +11,36 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_algorithm");
 
-TEST_CASE("breadth_first_search_no_return") {
+TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search no return should properly traverse the graph",
+    GraphType,
+    bfs_no_return_graph_template
+) {
     using graph_type = lib::graph<>;
 
     graph_type graph;
-    std::vector<lib_t::id_type> expected_visit_order;
+    std::vector<lib_t::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
         graph = lib::topology::clique<graph_type>(constants::zero_elements);
-        expected_visit_order = {};
+        expected_previsit_order = {};
     }
 
     SUBCASE("single vertex graph") {
         graph = lib::topology::clique<graph_type>(constants::one_element);
-        expected_visit_order = {0};
+        expected_previsit_order = {0};
     }
 
     SUBCASE("clique") {
         graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
         for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
-            expected_visit_order.push_back(id);
+            expected_previsit_order.push_back(id);
     }
 
     SUBCASE("path graph") {
         graph = lib::topology::bidirectional_path<graph_type>(constants::n_elements_alg);
         for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
-            expected_visit_order.push_back(id);
+            expected_previsit_order.push_back(id);
     }
 
     SUBCASE("full bipartite graph") {
@@ -46,48 +50,86 @@ TEST_CASE("breadth_first_search_no_return") {
         root = 0 -> connected to B -> connected to A (root already visited)
         */
         graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
-        expected_visit_order = {0, 3, 4, 1, 2};
+        expected_previsit_order = {0, 3, 4, 1, 2};
     }
 
     CAPTURE(graph);
-    CAPTURE(expected_visit_order);
+    CAPTURE(expected_previsit_order);
 
-    std::vector<lib_t::id_type> visited_vertices;
+    std::vector<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
+
+    std::vector<lib_t::id_type> previsit_order, postvisit_order;
     lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
-            visited_vertices.push_back(vertex.id());
+            previsit_order.push_back(vertex.id());
+        },
+        [&](const auto& vertex) { // postvisit
+            postvisit_order.push_back(vertex.id());
         }
     );
 
-    CHECK(std::ranges::equal(visited_vertices, expected_visit_order));
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
 }
 
-TEST_CASE("breadth_virst_search") {
-    using graph_type = lib::graph<>;
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_no_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search with return should properly traverse the graph",
+    GraphType,
+    bfs_return_graph_template
+) {
+    using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
-
-    std::cout << "[no return]\n";
-    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
-        graph,
-        lib::algorithm::no_root_vertex,
-        [](const gl::vertex_descriptor<std::monostate>& vertex) {
-            std::cout << "visiting: " << vertex.id() << std::endl;
-        }
-    );
-
-    std::cout << "\n[return]\n";
+    const auto graph = lib::topology::complete_binary_tree<graph_type>(constants::three);
     const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
-    for (const auto& vertex : search_tree.vertices()) {
-        std::cout << vertex.id() << " :";
-        for (const auto& edge : search_tree.adjacent_edges(vertex))
-            std::cout << " " << edge.incident_vertex(vertex).id();
-        std::cout << std::endl;
-    }
+
+    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+
+    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+
+    // verify that for each vertex the edges are equivalent to those in the original graph
+    CHECK(std::ranges::all_of(vertex_id_view, [&](const lib_t::id_type id) {
+        const auto adj_edges_graph = graph.adjacent_edges(id);
+        const auto adj_edges_search_tree = search_tree.adjacent_edges(id);
+
+        if (adj_edges_search_tree.distance() != adj_edges_graph.distance())
+            return false;
+
+        for (auto [graph_edge_it, search_tree_edge_it] =
+                 std::make_pair(adj_edges_graph.begin(), adj_edges_search_tree.begin());
+             graph_edge_it != adj_edges_graph.end();
+             graph_edge_it++, search_tree_edge_it++) {
+            // verify that the edges match
+            const auto search_tree_incident_vertex_id =
+                search_tree_edge_it->incident_vertex(search_tree.get_vertex(id)).id();
+            const auto graph_incident_vertex_id =
+                graph_edge_it->incident_vertex(graph.get_vertex(id)).id();
+
+            if (search_tree_incident_vertex_id != graph_incident_vertex_id)
+                return false;
+        }
+
+        return true;
+    }));
 }
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
 
 TEST_SUITE_END(); // test_algorithm
 

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -5,15 +5,34 @@
 
 #include <doctest.h>
 
+#include <iostream>
+
 namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_algorithm");
 
 TEST_CASE("breadth_virst_search") {
     using graph_type = lib::graph<>;
+    using vertex_type = typename graph_type::vertex_type;
+
     const auto graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
 
-    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(graph);
+    std::cout << "[no return]\n";
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
+        graph,
+        [](const gl::vertex_descriptor<std::monostate>& vertex) {
+            std::cout << "visiting: " << vertex.id() << std::endl;
+        }
+    );
+
+    std::cout << "\n[return]\n";
+    const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
+    for (const auto& vertex : search_tree.vertices()) {
+        std::cout << vertex.id() << " :";
+        for (const auto& edge : search_tree.adjacent_edges(vertex))
+            std::cout << " " << edge.incident_vertex(vertex).id();
+        std::cout << std::endl;
+    }
 }
 
 TEST_SUITE_END(); // test_algorithm

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -11,6 +11,59 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_algorithm");
 
+TEST_CASE("breadth_first_search_no_return") {
+    using graph_type = lib::graph<>;
+
+    graph_type graph;
+    std::vector<lib_t::id_type> expected_visit_order;
+
+    SUBCASE("single vertex graph") {
+        graph = lib::topology::clique<graph_type>(constants::zero_elements);
+        expected_visit_order = {};
+    }
+
+    SUBCASE("single vertex graph") {
+        graph = lib::topology::clique<graph_type>(constants::one_element);
+        expected_visit_order = {0};
+    }
+
+    SUBCASE("clique") {
+        graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
+        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
+            expected_visit_order.push_back(id);
+    }
+
+    SUBCASE("path graph") {
+        graph = lib::topology::bidirectional_path<graph_type>(constants::n_elements_alg);
+        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
+            expected_visit_order.push_back(id);
+    }
+
+    SUBCASE("full bipartite graph") {
+        /*
+        A = {0, 1, 2}
+        B = {3, 4}
+        root = 0 -> connected to B -> connected to A (root already visited)
+        */
+        graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
+        expected_visit_order = {0, 3, 4, 1, 2};
+    }
+
+    CAPTURE(graph);
+    CAPTURE(expected_visit_order);
+
+    std::vector<lib_t::id_type> visited_vertices;
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
+        graph,
+        lib::algorithm::no_root_vertex,
+        [&](const auto& vertex) { // previsit
+            visited_vertices.push_back(vertex.id());
+        }
+    );
+
+    CHECK(std::ranges::equal(visited_vertices, expected_visit_order));
+}
+
 TEST_CASE("breadth_virst_search") {
     using graph_type = lib::graph<>;
     using vertex_type = typename graph_type::vertex_type;
@@ -20,6 +73,7 @@ TEST_CASE("breadth_virst_search") {
     std::cout << "[no return]\n";
     lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
         graph,
+        lib::algorithm::no_root_vertex,
         [](const gl::vertex_descriptor<std::monostate>& vertex) {
             std::cout << "visiting: " << vertex.id() << std::endl;
         }

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -1,0 +1,21 @@
+#include "constants.hpp"
+
+#include <gl/algorithms.hpp>
+#include <gl/topologies.hpp>
+
+#include <doctest.h>
+
+namespace gl_testing {
+
+TEST_SUITE_BEGIN("test_algorithm");
+
+TEST_CASE("breadth_virst_search") {
+    using graph_type = lib::graph<>;
+    const auto graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
+
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(graph);
+}
+
+TEST_SUITE_END(); // test_algorithm
+
+} // namespace gl_testing

--- a/tests/source/test_graph_topology_builders.cpp
+++ b/tests/source/test_graph_topology_builders.cpp
@@ -12,7 +12,7 @@ TEST_SUITE_BEGIN("test_graph_topology_builders");
 
 namespace {
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] lib_t::size_type n_unique_edges_for_bidir_topology(
     const lib_t::size_type n_connections
 ) {
@@ -22,7 +22,7 @@ template <lib_tt::c_graph_type GraphType>
         return n_connections / constants::two;
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 void verify_graph_size(
     const GraphType& graph,
     const lib_t::size_type expected_n_vertices,
@@ -32,7 +32,7 @@ void verify_graph_size(
     REQUIRE_EQ(graph.n_unique_edges(), expected_n_connections);
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 void verify_bidir_graph_size(
     const GraphType& graph,
     const lib_t::size_type expected_n_vertices,
@@ -48,7 +48,7 @@ void verify_bidir_graph_size(
 
 namespace predicate {
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_fully_connected(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -59,7 +59,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_not_connected(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -69,7 +69,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_not_connected_to_any_from(
     const GraphType& graph, const auto& vertex_it_range
 ) {
@@ -82,7 +82,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_next_only(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -95,7 +95,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_prev_only(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -109,7 +109,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_id_adjacent(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -127,7 +127,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_connected_to_binary_chlidren(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -150,7 +150,7 @@ template <lib_tt::c_graph_type GraphType>
     };
 }
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto is_biconnected_to_binary_chlidren(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source_vertex) {
@@ -190,7 +190,7 @@ template <lib_tt::c_graph_type GraphType>
 
 /*
 
-template <lib_tt::c_graph_type GraphType>
+template <lib_tt::c_graph GraphType>
 [[nodiscard]] auto predicate(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type&) {};


### PR DESCRIPTION
Added the implementation of the breadth-first search algorithm for any graph type and with options to specify the source vertex and pre/post_visit callbacks