### PR TITLE
YT-CPPGL-28: Implement the depth first search algorithm

### DIFF
--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -3,7 +3,6 @@
 #include "constants.hpp"
 #include "detail/search_algorithm_util.hpp"
 
-#include <iostream>
 #include <queue>
 
 namespace gl::algorithm {

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -27,31 +27,17 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
 
     auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
 
-    const auto search_vertex_predicate = [&visited](const vertex_type& vertex) -> bool {
-        return not visited[vertex.id()];
-    };
-
-    const auto visit = [&](const vertex_type& vertex, const types::id_type source_id) {
-        const auto vertex_id = vertex.id();
-        visited[vertex_id] = true;
-        if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
-            if (source_id != vertex_id)
-                search_tree.add_edge(source_id, vertex_id);
-        }
-    };
-
-    const auto enque_vertex_predicate =
-        [&visited](const vertex_type& vertex, const edge_type& in_edge) -> bool {
-        return not visited[vertex.id()];
-    };
+    const auto search_vertex_pred = detail::default_search_vertex_predicate<GraphType>(visited);
+    const auto visit = detail::default_visit_callback<GraphType>(visited, search_tree);
+    const auto enque_vertex_pred = detail::default_enqueue_vertex_predicate<GraphType>(visited);
 
     if (root_vertex_id_opt) {
         detail::bfs_impl(
             graph,
             graph.get_vertex(root_vertex_id_opt.value()),
-            search_vertex_predicate,
+            search_vertex_pred,
             visit,
-            enque_vertex_predicate,
+            enque_vertex_pred,
             pre_visit,
             post_visit
         );
@@ -61,9 +47,9 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
             detail::bfs_impl(
                 graph,
                 root_vertex,
-                search_vertex_predicate,
+                search_vertex_pred,
                 visit,
-                enque_vertex_predicate,
+                enque_vertex_pred,
                 pre_visit,
                 post_visit
             );

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -9,7 +9,7 @@
 namespace gl::algorithm {
 
 template <
-    type_traits::c_alg_return_graph SearchTreeType,
+    type_traits::c_alg_return_graph SearchTreeType = no_return,
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>

--- a/include/gl/algorithm/constants.hpp
+++ b/include/gl/algorithm/constants.hpp
@@ -6,4 +6,7 @@ namespace gl::algorithm {
 
 inline constexpr std::nullopt_t no_root_vertex = std::nullopt;
 
+inline constexpr bool run_recursively = true;
+inline constexpr bool run_iteratively = false;
+
 } // namespace gl::algorithm

--- a/include/gl/algorithm/constants.hpp
+++ b/include/gl/algorithm/constants.hpp
@@ -6,7 +6,4 @@ namespace gl::algorithm {
 
 inline constexpr std::nullopt_t no_root_vertex = std::nullopt;
 
-inline constexpr bool run_recursively = true;
-inline constexpr bool run_iteratively = false;
-
 } // namespace gl::algorithm

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -13,7 +13,7 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
-type_traits::alg_return_type<SearchTreeType> breadth_first_search(
+type_traits::alg_return_type<SearchTreeType> depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -46,7 +46,7 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
     };
 
     if (root_vertex_id_opt) {
-        detail::bfs_impl(
+        detail::dfs_impl(
             graph,
             graph.get_vertex(root_vertex_id_opt.value()),
             search_vertex_predicate,
@@ -58,7 +58,7 @@ type_traits::alg_return_type<SearchTreeType> breadth_first_search(
     }
     else {
         for (const auto& root_vertex : graph.vertices())
-            detail::bfs_impl(
+            detail::dfs_impl(
                 graph,
                 root_vertex,
                 search_vertex_predicate,

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -9,7 +9,8 @@
 namespace gl::algorithm {
 
 template <
-    type_traits::c_alg_return_graph SearchTreeType,
+    type_traits::c_alg_return_graph SearchTreeType = no_return,
+    bool RunRecursively = run_iteratively,
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
@@ -45,32 +46,58 @@ type_traits::alg_return_type<SearchTreeType> depth_first_search(
         return not visited[vertex.id()];
     };
 
-    if (root_vertex_id_opt) {
-        detail::dfs_impl(
-            graph,
-            graph.get_vertex(root_vertex_id_opt.value()),
-            search_vertex_predicate,
-            visit,
-            enque_vertex_predicate,
-            pre_visit,
-            post_visit
-        );
+    if constexpr (RunRecursively) {
+        std::cout << "running recursively\n";
+        // TODO: rdfs_impl
     }
     else {
-        for (const auto& root_vertex : graph.vertices())
+        std::cout << "running iteratively\n";
+        if (root_vertex_id_opt) {
             detail::dfs_impl(
                 graph,
-                root_vertex,
+                graph.get_vertex(root_vertex_id_opt.value()),
                 search_vertex_predicate,
                 visit,
                 enque_vertex_predicate,
                 pre_visit,
                 post_visit
             );
+        }
+        else {
+            for (const auto& root_vertex : graph.vertices())
+                detail::dfs_impl(
+                    graph,
+                    root_vertex,
+                    search_vertex_predicate,
+                    visit,
+                    enque_vertex_predicate,
+                    pre_visit,
+                    post_visit
+                );
+        }
     }
 
     if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>)
         return search_tree;
+}
+
+template <
+    type_traits::c_alg_return_graph SearchTreeType = no_return,
+    type_traits::c_graph GraphType,
+    type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
+    type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
+type_traits::alg_return_type<SearchTreeType> recursive_depth_first_search(
+    const GraphType& graph,
+    const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
+        return depth_first_search<SearchTreeType, run_recursively>(graph, root_vertex_id_opt, pre_visit, post_visit);
+    }
+    else {
+        depth_first_search<SearchTreeType, run_recursively>(graph, root_vertex_id_opt, pre_visit, post_visit);
+    }
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -28,53 +28,32 @@ type_traits::alg_return_type<SearchTreeType> depth_first_search(
 
     auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
 
-    const auto search_vertex_predicate = [&visited](const vertex_type& vertex) -> bool {
-        return not visited[vertex.id()];
-    };
+    const auto search_vertex_pred = detail::default_search_vertex_predicate<GraphType>(visited);
+    const auto visit = detail::default_visit_callback<GraphType>(visited, search_tree);
+    const auto enque_vertex_pred = detail::default_enqueue_vertex_predicate<GraphType>(visited);
 
-    const auto visit = [&](const vertex_type& vertex, const types::id_type source_id) {
-        const auto vertex_id = vertex.id();
-        visited[vertex_id] = true;
-        if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
-            if (source_id != vertex_id)
-                search_tree.add_edge(source_id, vertex_id);
-        }
-    };
-
-    const auto enque_vertex_predicate =
-        [&visited](const vertex_type& vertex, const edge_type& in_edge) -> bool {
-        return not visited[vertex.id()];
-    };
-
-    if constexpr (RunRecursively) {
-        std::cout << "running recursively\n";
-        // TODO: rdfs_impl
+    if (root_vertex_id_opt) {
+        detail::dfs_impl(
+            graph,
+            graph.get_vertex(root_vertex_id_opt.value()),
+            search_vertex_pred,
+            visit,
+            enque_vertex_pred,
+            pre_visit,
+            post_visit
+        );
     }
     else {
-        std::cout << "running iteratively\n";
-        if (root_vertex_id_opt) {
+        for (const auto& root_vertex : graph.vertices())
             detail::dfs_impl(
                 graph,
-                graph.get_vertex(root_vertex_id_opt.value()),
-                search_vertex_predicate,
+                root_vertex,
+                search_vertex_pred,
                 visit,
-                enque_vertex_predicate,
+                enque_vertex_pred,
                 pre_visit,
                 post_visit
             );
-        }
-        else {
-            for (const auto& root_vertex : graph.vertices())
-                detail::dfs_impl(
-                    graph,
-                    root_vertex,
-                    search_vertex_predicate,
-                    visit,
-                    enque_vertex_predicate,
-                    pre_visit,
-                    post_visit
-                );
-        }
     }
 
     if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>)
@@ -92,12 +71,47 @@ type_traits::alg_return_type<SearchTreeType> recursive_depth_first_search(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
-        return depth_first_search<SearchTreeType, run_recursively>(graph, root_vertex_id_opt, pre_visit, post_visit);
+    using vertex_type = typename GraphType::vertex_type;
+    using edge_type = typename GraphType::edge_type;
+
+    std::vector<bool> visited(graph.n_vertices(), false);
+    std::vector<types::id_type> sources(graph.n_vertices());
+
+    auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
+
+    const auto search_vertex_pred = detail::default_search_vertex_predicate<GraphType>(visited);
+    const auto visit = detail::default_visit_callback<GraphType>(visited, search_tree);
+    const auto enque_vertex_pred = detail::default_enqueue_vertex_predicate<GraphType>(visited);
+
+    if (root_vertex_id_opt) {
+        const auto root_id = root_vertex_id_opt.value();
+        detail::rdfs_impl(
+            graph,
+            graph.get_vertex(root_id),
+            root_id,
+            search_vertex_pred,
+            visit,
+            enque_vertex_pred,
+            pre_visit,
+            post_visit
+        );
     }
     else {
-        depth_first_search<SearchTreeType, run_recursively>(graph, root_vertex_id_opt, pre_visit, post_visit);
+        for (const auto& root_vertex : graph.vertices())
+            detail::rdfs_impl(
+                graph,
+                root_vertex,
+                root_vertex.id(),
+                search_vertex_pred,
+                visit,
+                enque_vertex_pred,
+                pre_visit,
+                post_visit
+            );
     }
+
+    if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>)
+        return search_tree;
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -3,14 +3,12 @@
 #include "constants.hpp"
 #include "detail/search_algorithm_util.hpp"
 
-#include <iostream>
 #include <queue>
 
 namespace gl::algorithm {
 
 template <
     type_traits::c_alg_return_graph SearchTreeType = no_return,
-    bool RunRecursively = run_iteratively,
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -27,6 +27,37 @@ struct search_vertex_info {
     types::id_type source_id;
 };
 
+template <type_traits::c_graph GraphType>
+[[nodiscard]] gl_attr_force_inline auto default_search_vertex_predicate(std::vector<bool>& visited
+) {
+    return [&](const typename GraphType::vertex_type& vertex) -> bool {
+        return not visited[vertex.id()];
+    };
+}
+
+template <type_traits::c_graph GraphType, type_traits::c_alg_return_graph SearchTreeType>
+[[nodiscard]] gl_attr_force_inline auto default_visit_callback(
+    std::vector<bool>& visited, SearchTreeType& search_tree
+) {
+    return [&](const typename GraphType::vertex_type& vertex, const types::id_type source_id) {
+        const auto vertex_id = vertex.id();
+        visited[vertex_id] = true;
+        if constexpr (not type_traits::is_alg_no_return_type_v<SearchTreeType>) {
+            if (source_id != vertex_id)
+                search_tree.add_edge(source_id, vertex_id);
+        }
+    };
+}
+
+template <type_traits::c_graph GraphType>
+[[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(std::vector<bool>& visited
+) {
+    return [&](const typename GraphType::vertex_type& vertex,
+               const typename GraphType::edge_type& in_edge) -> bool {
+        return not visited[vertex.id()];
+    };
+}
+
 template <
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -4,6 +4,7 @@
 #include "gl/graph.hpp"
 
 #include <queue>
+#include <stack>
 
 namespace gl::algorithm::detail {
 
@@ -30,7 +31,7 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
-void rooted_bfs_impl(
+void bfs_impl(
     const GraphType& graph,
     const typename GraphType::vertex_type& root_vertex,
     const vertex_callback<GraphType, bool>& search_vertex_pred,
@@ -45,7 +46,7 @@ void rooted_bfs_impl(
         return;
 
     vertex_queue_type vertex_queue;
-    vertex_queue.push(search_vertex_info{root_vertex.id()});
+    vertex_queue.emplace(root_vertex.id());
 
     while (not vertex_queue.empty()) {
         const search_vertex_info sv = vertex_queue.front();
@@ -63,7 +64,7 @@ void rooted_bfs_impl(
         for (const auto& edge : graph.adjacent_edges(sv.id)) {
             const auto& incident_vertex = edge.incident_vertex(vertex);
             if (enque_vertex_pred(incident_vertex, edge))
-                vertex_queue.push(search_vertex_info{incident_vertex.id(), sv.id});
+                vertex_queue.emplace(incident_vertex.id(), sv.id);
         }
 
         if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
@@ -75,19 +76,45 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
     type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
-gl_attr_force_inline void bfs_impl(
+void dfs_impl(
     const GraphType& graph,
+    const typename GraphType::vertex_type& root_vertex,
     const vertex_callback<GraphType, bool>& search_vertex_pred,
     const vertex_callback<GraphType, void, types::id_type>& visit,
     const vertex_callback<GraphType, bool, const typename GraphType::edge_type&>& enque_vertex_pred,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    // iterate over all vertices to search through all connected components
-    for (const auto& root_vertex : graph.vertices())
-        rooted_bfs_impl(
-            graph, root_vertex, search_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit
-        );
+    using vertex_stack_type = std::stack<search_vertex_info>;
+
+    if (not search_vertex_pred(root_vertex))
+        return;
+
+    vertex_stack_type vertex_stack;
+    vertex_stack.emplace(root_vertex.id());
+
+    while (not vertex_stack.empty()) {
+        const search_vertex_info sv = vertex_stack.top();
+        vertex_stack.pop();
+
+        const auto& vertex = graph.get_vertex(sv.id);
+        if (not search_vertex_pred(vertex))
+            continue;
+
+        if constexpr (not type_traits::is_empty_callback_v<PreVisitCallback>)
+            pre_visit(vertex);
+
+        visit(vertex, sv.source_id);
+
+        for (const auto& edge : graph.adjacent_edges(sv.id)) {
+            const auto& incident_vertex = edge.incident_vertex(vertex);
+            if (enque_vertex_pred(incident_vertex, edge))
+                vertex_stack.emplace(incident_vertex.id(), sv.id);
+        }
+
+        if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
+            post_visit(vertex);
+    }
 }
 
 } // namespace gl::algorithm::detail

--- a/include/gl/algorithm/detail/search_algorithm_util.hpp
+++ b/include/gl/algorithm/detail/search_algorithm_util.hpp
@@ -117,4 +117,46 @@ void dfs_impl(
     }
 }
 
+template <
+    type_traits::c_graph GraphType,
+    type_traits::c_vertex_callback<GraphType, void> PreVisitCallback = empty_callback,
+    type_traits::c_vertex_callback<GraphType, void> PostVisitCallback = empty_callback>
+void rdfs_impl(
+    const GraphType& graph,
+    const typename GraphType::vertex_type& vertex,
+    const types::id_type source_id,
+    const vertex_callback<GraphType, bool>& search_vertex_pred,
+    const vertex_callback<GraphType, void, types::id_type>& visit,
+    const vertex_callback<GraphType, bool, const typename GraphType::edge_type&>& enque_vertex_pred,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    if (not search_vertex_pred(vertex))
+        return;
+
+    if constexpr (not type_traits::is_empty_callback_v<PreVisitCallback>)
+        pre_visit(vertex);
+
+    visit(vertex, source_id);
+
+    const auto vertex_id = vertex.id();
+    for (const auto& edge : graph.adjacent_edges(vertex_id)) {
+        const auto& incident_vertex = edge.incident_vertex(vertex);
+        if (enque_vertex_pred(incident_vertex, edge))
+            rdfs_impl(
+                graph,
+                incident_vertex,
+                vertex_id,
+                search_vertex_pred,
+                visit,
+                enque_vertex_pred,
+                pre_visit,
+                post_visit
+            );
+    }
+
+    if constexpr (not type_traits::is_empty_callback_v<PostVisitCallback>)
+        post_visit(vertex);
+}
+
 } // namespace gl::algorithm::detail

--- a/include/gl/algorithms.hpp
+++ b/include/gl/algorithms.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 #include "algorithm/breadth_first_search.hpp"
+#include "algorithm/deapth_first_search.hpp"

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -99,7 +99,7 @@ public:
         return this->_vertices.first == this->_vertices.second;
     }
 
-    [[no_unique_address]] properties_type properties{};
+    [[no_unique_address]] mutable properties_type properties{};
 
 private:
     types::homogeneous_pair<const vertex_type&> _vertices;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -7,7 +7,6 @@
 #include "gl/types/types.hpp"
 #include "specialized/adjacency_list.hpp"
 
-#include <iostream>
 #include <vector>
 
 namespace gl::impl {

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -57,7 +57,7 @@ public:
         return this->_id;
     }
 
-    [[no_unique_address]] properties_type properties{};
+    [[no_unique_address]] mutable properties_type properties{};
 
 private:
     types::id_type _id;

--- a/tests/source/test_algorithm.cpp
+++ b/tests/source/test_algorithm.cpp
@@ -9,6 +9,33 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_algorithm");
 
+namespace common {
+
+template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>
+[[nodiscard]] auto are_vertices_equivalent(const GraphType1& g1, const GraphType2& g2) {
+    return [&](const lib_t::id_type vertex_id) {
+        const auto adj_edges_1 = g1.adjacent_edges(vertex_id);
+        const auto adj_edges_2 = g2.adjacent_edges(vertex_id);
+
+        if (adj_edges_2.distance() != adj_edges_1.distance())
+            return false;
+
+        for (const auto& edge : adj_edges_1) {
+            if (not g2.has_edge(edge.first().id(), edge.second().id()))
+                return false;
+        }
+
+        for (const auto& edge : adj_edges_2) {
+            if (not g1.has_edge(edge.first().id(), edge.second().id()))
+                return false;
+        }
+
+        return true;
+    };
+}
+
+} // namespace common
+
 // --- bfs tests ---
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -103,11 +130,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
         root_vertex_id.emplace(constants::vertex_id_3);
 
-        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
-            expected_previsit_order.push_back(id);
-        expected_previsit_order.erase(
-            std::next(expected_previsit_order.begin(), constants::vertex_id_3)
-        );
+        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++) {
+            if (id != constants::vertex_id_3)
+                expected_previsit_order.push_back(id);
+        }
         expected_previsit_order.push_front(constants::vertex_id_3);
     }
 
@@ -157,29 +183,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
 
     // verify that for each vertex the edges are equivalent to those in the original graph
-    CHECK(std::ranges::all_of(vertex_id_view, [&](const lib_t::id_type id) {
-        const auto adj_edges_graph = graph.adjacent_edges(id);
-        const auto adj_edges_search_tree = search_tree.adjacent_edges(id);
-
-        if (adj_edges_search_tree.distance() != adj_edges_graph.distance())
-            return false;
-
-        for (auto [graph_edge_it, search_tree_edge_it] =
-                 std::make_pair(adj_edges_graph.begin(), adj_edges_search_tree.begin());
-             graph_edge_it != adj_edges_graph.end();
-             graph_edge_it++, search_tree_edge_it++) {
-            // verify that the edges match
-            const auto search_tree_incident_vertex_id =
-                search_tree_edge_it->incident_vertex(search_tree.get_vertex(id)).id();
-            const auto graph_incident_vertex_id =
-                graph_edge_it->incident_vertex(graph.get_vertex(id)).id();
-
-            if (search_tree_incident_vertex_id != graph_incident_vertex_id)
-                return false;
-        }
-
-        return true;
-    }));
+    CHECK(std::ranges::all_of(vertex_id_view, common::are_vertices_equivalent(graph, search_tree)));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -263,6 +267,91 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     dfs_no_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "depth_first_search no return with root vertex should properly traverse the graph",
+    GraphType,
+    dfs_no_return_with_root_graph_template
+) {
+    using graph_type = GraphType;
+
+    graph_type graph;
+    std::optional<lib_t::id_type> root_vertex_id;
+    std::deque<lib_t::id_type> expected_previsit_order;
+
+    SUBCASE("single vertex graph") {
+        graph = lib::topology::clique<graph_type>(constants::one_element);
+        root_vertex_id.emplace(constants::vertex_id_1);
+        expected_previsit_order = {0};
+    }
+
+    SUBCASE("clique") {
+        graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
+        root_vertex_id.emplace(constants::vertex_id_3);
+
+        for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++) {
+            if (id != constants::vertex_id_3)
+                expected_previsit_order.push_front(id);
+        }
+        expected_previsit_order.push_front(constants::vertex_id_3);
+    }
+
+    CAPTURE(graph);
+    CAPTURE(root_vertex_id);
+    CAPTURE(expected_previsit_order);
+
+    std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
+
+    std::vector<lib_t::id_type> previsit_order, postvisit_order;
+    lib::algorithm::depth_first_search<lib::algorithm::no_return>(
+        graph,
+        root_vertex_id,
+        [&](const auto& vertex) { // previsit
+            previsit_order.push_back(vertex.id());
+        },
+        [&](const auto& vertex) { // postvisit
+            postvisit_order.push_back(vertex.id());
+        }
+    );
+
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    dfs_no_return_with_root_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "depth_first_search with return should properly traverse the graph",
+    GraphType,
+    dfs_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename graph_type::vertex_type;
+
+    const auto graph = lib::topology::complete_binary_tree<graph_type>(constants::three);
+    const auto search_tree = lib::algorithm::depth_first_search<graph_type>(graph);
+
+    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+
+    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+
+    // verify that for each vertex the edges are equivalent to those in the original graph
+    CHECK(std::ranges::all_of(vertex_id_view, common::are_vertices_equivalent(graph, search_tree)));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    dfs_return_graph_template,
     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix

--- a/tests/source/test_dereferencing_iterator.cpp
+++ b/tests/source/test_dereferencing_iterator.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <deque>
 #include <forward_list>
-#include <iostream>
 #include <list>
 
 namespace gl_testing {

--- a/tests/source/test_graph_topology_builders.cpp
+++ b/tests/source/test_graph_topology_builders.cpp
@@ -4,8 +4,6 @@
 
 #include <doctest.h>
 
-#include <iostream>
-
 namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_graph_topology_builders");

--- a/tests/source/test_search_algorithms.cpp
+++ b/tests/source/test_search_algorithms.cpp
@@ -95,7 +95,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
+    lib::algorithm::breadth_first_search(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
@@ -164,7 +164,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
+    lib::algorithm::breadth_first_search(
         graph,
         root_vertex_id,
         [&](const auto& vertex) { // previsit
@@ -271,7 +271,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::depth_first_search<lib::algorithm::no_return>(
+    lib::algorithm::depth_first_search(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
@@ -340,7 +340,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::depth_first_search<lib::algorithm::no_return>(
+    lib::algorithm::depth_first_search(
         graph,
         root_vertex_id,
         [&](const auto& vertex) { // previsit

--- a/tests/source/test_search_algorithms.cpp
+++ b/tests/source/test_search_algorithms.cpp
@@ -214,7 +214,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-// --- dfs tests ---
+// --- iterative dfs tests ---
 
 TEST_CASE_TEMPLATE_DEFINE(
     "depth_first_search no return should properly traverse the graph",
@@ -384,6 +384,182 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     dfs_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
+
+// --- recursive dfs tests ---
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "recursive_depth_first_search no return should properly traverse the graph",
+    GraphType,
+    rdfs_no_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename GraphType::vertex_type;
+
+    graph_type graph;
+    std::deque<lib_t::id_type> expected_previsit_order;
+
+    SUBCASE("empty graph") {
+        graph = lib::topology::clique<graph_type>(constants::zero_elements);
+        expected_previsit_order = {};
+    }
+
+    SUBCASE("single vertex graph") {
+        graph = lib::topology::clique<graph_type>(constants::one_element);
+        expected_previsit_order = {0};
+    }
+
+    // SUBCASE("clique") {
+    //     graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
+    //     for (auto id = lib::constants::initial_id + constants::one; id < constants::n_elements_alg;
+    //          id++)
+    //         expected_previsit_order.push_front(id);
+    //     expected_previsit_order.push_front(lib::constants::initial_id);
+    // }
+
+    // SUBCASE("path graph") {
+    //     graph = lib::topology::bidirectional_path<graph_type>(constants::n_elements_alg);
+    //     for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++)
+    //         expected_previsit_order.push_back(id);
+    // }
+
+    // SUBCASE("full bipartite graph") {
+    //     /*
+    //     A = {0, 1, 2}
+    //     B = {3, 4}
+    //     [s: <stack state without already visited vertices>]
+    //     -> root = 0 -> connected to B [s: 4 3]
+    //     -> 4 connected to A (root visited) [s: 2 1 3]
+    //     -> 2 connected to B (4 visited) [s: 3 1 3]
+    //     finally: 0 -> 4 -> 2 -> 1 -> 3
+    //     */
+    //     graph = lib::topology::full_bipartite<graph_type>(constants::three, constants::two);
+    //     expected_previsit_order = {0, 4, 2, 3, 1};
+    // }
+
+    CAPTURE(graph);
+    CAPTURE(expected_previsit_order);
+
+    std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
+
+    std::vector<lib_t::id_type> previsit_order, postvisit_order;
+    lib::algorithm::recursive_depth_first_search(
+        graph,
+        lib::algorithm::no_root_vertex,
+        [&](const auto& vertex) { // previsit
+            previsit_order.push_back(vertex.id());
+        },
+        [&](const auto& vertex) { // postvisit
+            postvisit_order.push_back(vertex.id());
+            vertex.properties.visited = true;
+        }
+    );
+
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::all_of(
+        graph.vertices(), std::identity{}, common::vertex_visited_projection<vertex_type>{}
+    ));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    rdfs_no_return_graph_template,
+    lib::graph<
+        lib::list_graph_traits<lib::directed_t, types::visited_property>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<
+        lib::undirected_t,
+        types::visited_property>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<
+        lib::directed_t,
+        types::visited_property>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<
+        lib::undirected_t,
+        types::visited_property>> // undirected adjacency matrix
+);
+
+// TEST_CASE_TEMPLATE_DEFINE(
+//     "recursive_depth_first_search no return with root vertex should properly traverse the graph",
+//     GraphType,
+//     rdfs_no_return_with_root_graph_template
+// ) {
+//     using graph_type = GraphType;
+
+//     graph_type graph;
+//     std::optional<lib_t::id_type> root_vertex_id;
+//     std::deque<lib_t::id_type> expected_previsit_order;
+
+//     SUBCASE("single vertex graph") {
+//         graph = lib::topology::clique<graph_type>(constants::one_element);
+//         root_vertex_id.emplace(constants::vertex_id_1);
+//         expected_previsit_order = {0};
+//     }
+
+//     SUBCASE("clique") {
+//         graph = lib::topology::clique<graph_type>(constants::n_elements_alg);
+//         root_vertex_id.emplace(constants::vertex_id_3);
+
+//         for (auto id = lib::constants::initial_id; id < constants::n_elements_alg; id++) {
+//             if (id != constants::vertex_id_3)
+//                 expected_previsit_order.push_front(id);
+//         }
+//         expected_previsit_order.push_front(constants::vertex_id_3);
+//     }
+
+//     CAPTURE(graph);
+//     CAPTURE(root_vertex_id);
+//     CAPTURE(expected_previsit_order);
+
+//     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
+
+//     std::vector<lib_t::id_type> previsit_order, postvisit_order;
+//     lib::algorithm::recursive_depth_first_search(
+//         graph,
+//         root_vertex_id,
+//         [&](const auto& vertex) { // previsit
+//             previsit_order.push_back(vertex.id());
+//         },
+//         [&](const auto& vertex) { // postvisit
+//             postvisit_order.push_back(vertex.id());
+//         }
+//     );
+
+//     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+//     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+// }
+
+// TEST_CASE_TEMPLATE_INSTANTIATE(
+//     rdfs_no_return_with_root_graph_template,
+//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+// );
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "recursive_depth_first_search with return should properly traverse the graph",
+    GraphType,
+    rdfs_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename graph_type::vertex_type;
+
+    const auto graph = lib::topology::complete_binary_tree<graph_type>(constants::three);
+    const auto search_tree = lib::algorithm::recursive_depth_first_search<graph_type>(graph);
+
+    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+
+    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+
+    // verify that for each vertex the edges are equivalent to those in the original graph
+    CHECK(std::ranges::all_of(vertex_id_view, common::are_vertices_equivalent(graph, search_tree)));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    rdfs_return_graph_template,
     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix

--- a/tests/source/test_search_algorithms.cpp
+++ b/tests/source/test_search_algorithms.cpp
@@ -7,7 +7,7 @@
 
 namespace gl_testing {
 
-TEST_SUITE_BEGIN("test_algorithm");
+TEST_SUITE_BEGIN("test_search_algorithms");
 
 namespace common {
 
@@ -34,6 +34,14 @@ template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>
     };
 }
 
+template <lib_tt::c_instantiation_of<lib::vertex> VertexType>
+requires(std::same_as<typename VertexType::properties_type, types::visited_property>)
+struct vertex_visited_projection {
+    [[nodiscard]] bool operator()(const VertexType& vertex) const {
+        return vertex.properties.visited;
+    }
+};
+
 } // namespace common
 
 // --- bfs tests ---
@@ -44,6 +52,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     bfs_no_return_graph_template
 ) {
     using graph_type = GraphType;
+    using vertex_type = typename GraphType::vertex_type;
 
     graph_type graph;
     std::vector<lib_t::id_type> expected_previsit_order;
@@ -94,19 +103,30 @@ TEST_CASE_TEMPLATE_DEFINE(
         },
         [&](const auto& vertex) { // postvisit
             postvisit_order.push_back(vertex.id());
+            vertex.properties.visited = true;
         }
     );
 
     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::all_of(
+        graph.vertices(), std::identity{}, common::vertex_visited_projection<vertex_type>{}
+    ));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     bfs_no_return_graph_template,
-    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+    lib::graph<
+        lib::list_graph_traits<lib::directed_t, types::visited_property>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<
+        lib::undirected_t,
+        types::visited_property>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<
+        lib::directed_t,
+        types::visited_property>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<
+        lib::undirected_t,
+        types::visited_property>> // undirected adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -202,6 +222,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     dfs_no_return_graph_template
 ) {
     using graph_type = GraphType;
+    using vertex_type = typename GraphType::vertex_type;
 
     graph_type graph;
     std::deque<lib_t::id_type> expected_previsit_order;
@@ -258,19 +279,30 @@ TEST_CASE_TEMPLATE_DEFINE(
         },
         [&](const auto& vertex) { // postvisit
             postvisit_order.push_back(vertex.id());
+            vertex.properties.visited = true;
         }
     );
 
     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::all_of(
+        graph.vertices(), std::identity{}, common::vertex_visited_projection<vertex_type>{}
+    ));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     dfs_no_return_graph_template,
-    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+    lib::graph<
+        lib::list_graph_traits<lib::directed_t, types::visited_property>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<
+        lib::undirected_t,
+        types::visited_property>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<
+        lib::directed_t,
+        types::visited_property>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<
+        lib::undirected_t,
+        types::visited_property>> // undirected adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -358,6 +390,6 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-TEST_SUITE_END(); // test_algorithm
+TEST_SUITE_END(); // test_search_algorithms
 
 } // namespace gl_testing

--- a/tests/source/test_search_algorithms.cpp
+++ b/tests/source/test_search_algorithms.cpp
@@ -34,7 +34,7 @@ template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>
     };
 }
 
-template <lib_tt::c_instantiation_of<lib::vertex> VertexType>
+template <lib_tt::c_instantiation_of<lib::vertex_descriptor> VertexType>
 requires(std::same_as<typename VertexType::properties_type, types::visited_property>)
 struct vertex_visited_projection {
     [[nodiscard]] bool operator()(const VertexType& vertex) const {


### PR DESCRIPTION
Added the implementation of the depth-first search algorithm in two variants (iterative and recursive) for any graph type and with options to specify the source vertex and pre/post_visit callbacks