### PR TITLE
YT-CPPGL-23: Add the array subscript operator to iterator_range

### DIFF
--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -119,6 +119,16 @@ public:
         return *std::ranges::next(this->begin(), position);
     }
 
+    [[nodiscard]] gl_attr_force_inline value_type& operator[](types::size_type position)
+    requires(not type_traits::c_const_iterator<iterator>)
+    {
+        return this->element_at(position);
+    }
+
+    [[nodiscard]] gl_attr_force_inline const value_type& operator[](types::size_type position) const {
+        return this->element_at(position);
+    }
+
 private:
     [[nodiscard]] gl_attr_force_inline bool _is_distance_uninitialized() const
     requires(cache_mode == type_traits::cache_mode::lazy)

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -125,9 +125,14 @@ public:
         return this->element_at(position);
     }
 
+    // clang-format off
+    // gl_attr_force_inline misplacement
+
     [[nodiscard]] gl_attr_force_inline const value_type& operator[](types::size_type position) const {
         return this->element_at(position);
     }
+
+    // clang-format on
 
 private:
     [[nodiscard]] gl_attr_force_inline bool _is_distance_uninitialized() const

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -119,7 +119,7 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
     CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
-    const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted = adjacent_edges_1[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted, &new_edge);
 }
 
@@ -272,7 +272,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
-    const auto& edge_to_remove = adjacent_edges.element_at(constants::first_element_idx);
+    const auto& edge_to_remove = adjacent_edges[constants::first_element_idx];
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
@@ -372,10 +372,10 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
 
-    const auto& new_edge_extracted_1 = adjacent_edges_1.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
-    const auto& new_edge_extracted_2 = adjacent_edges_2.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_2, &new_edge);
 }
 
@@ -391,7 +391,7 @@ TEST_CASE_FIXTURE(
     const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
-    const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_1 = adjacent_edges[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_1, &new_edge);
 }
 
@@ -554,7 +554,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
-    const auto& edge_to_remove = adjacent_edges_first.element_at(constants::first_element_idx);
+    const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
     const auto second_id = edge_to_remove.second().id();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -120,7 +120,7 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
     CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).distance(), constants::zero_elements);
 
-    const auto& new_edge_extracted = adjacent_edges_1.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted = adjacent_edges_1[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted, &new_edge);
 }
 
@@ -223,7 +223,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges.distance(), n_incident_edges_for_fully_connected_vertex);
 
-    const auto& edge_to_remove = adjacent_edges.element_at(constants::first_element_idx);
+    const auto& edge_to_remove = adjacent_edges[constants::first_element_idx];
 
     sut.remove_edge(edge_to_remove);
     REQUIRE_EQ(
@@ -323,10 +323,10 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(adjacent_edges_1.distance(), constants::one_element);
     REQUIRE_EQ(adjacent_edges_2.distance(), constants::one_element);
 
-    const auto& new_edge_extracted_1 = adjacent_edges_1.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
-    const auto& new_edge_extracted_2 = adjacent_edges_2.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_2, &new_edge);
 }
 
@@ -342,7 +342,7 @@ TEST_CASE_FIXTURE(
     const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
 
-    const auto& new_edge_extracted_1 = adjacent_edges.element_at(constants::first_element_idx);
+    const auto& new_edge_extracted_1 = adjacent_edges[constants::first_element_idx];
     CHECK_EQ(&new_edge_extracted_1, &new_edge);
 }
 
@@ -448,7 +448,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(sut.n_unique_edges(), n_incident_edges_for_fully_connected_vertex);
     REQUIRE_EQ(adjacent_edges_first.distance(), n_incident_edges_for_fully_connected_vertex);
 
-    const auto& edge_to_remove = adjacent_edges_first.element_at(constants::first_element_idx);
+    const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
     const auto second_id = edge_to_remove.second().id();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -367,9 +367,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         const auto vertices = sut.vertices();
-        const auto& vertex_1 = vertices.element_at(constants::vertex_id_1);
-        const auto& vertex_2 = vertices.element_at(constants::vertex_id_2);
-        const auto& vertex_3 = vertices.element_at(constants::vertex_id_3);
+        const auto& vertex_1 = vertices[constants::vertex_id_1];
+        const auto& vertex_2 = vertices[constants::vertex_id_2];
+        const auto& vertex_3 = vertices[constants::vertex_id_3];
 
         SUBCASE("add_edge(ids) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
@@ -384,22 +384,20 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge(ids) should properly add the new edge") {
             const auto& new_edge = sut.add_edge(constants::vertex_id_1, constants::vertex_id_2);
-            REQUIRE(new_edge.is_incident_from(vertices.element_at(constants::vertex_id_1)));
-            REQUIRE(new_edge.is_incident_to(vertices.element_at(constants::vertex_id_2)));
+            REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
+            REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
             const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-            const auto& new_edge_extracted_1 =
-                adjacent_edges_1.element_at(constants::first_element_idx);
+            const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
             CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
-                const auto& new_edge_extracted_2 =
-                    adjacent_edges_2.element_at(constants::first_element_idx);
+                const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
                 CHECK_EQ(&new_edge_extracted_2, &new_edge);
             }
             else {
@@ -424,15 +422,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-            const auto& new_edge_extracted_1 =
-                adjacent_edges_1.element_at(constants::first_element_idx);
+            const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
             CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
-                const auto& new_edge_extracted_2 =
-                    adjacent_edges_2.element_at(constants::first_element_idx);
+                const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
                 CHECK_EQ(&new_edge_extracted_2, &new_edge);
             }
             else {
@@ -582,9 +578,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         lib::graph<properties_traits_type> sut{constants::n_elements};
 
         const auto vertices = sut.vertices();
-        const auto& vertex_1 = vertices.element_at(constants::vertex_id_1);
-        const auto& vertex_2 = vertices.element_at(constants::vertex_id_2);
-        const auto& vertex_3 = vertices.element_at(constants::vertex_id_3);
+        const auto& vertex_1 = vertices[constants::vertex_id_1];
+        const auto& vertex_2 = vertices[constants::vertex_id_2];
+        const auto& vertex_3 = vertices[constants::vertex_id_3];
 
         SUBCASE("add_edge(ids) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
@@ -604,23 +600,21 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("add_edge(ids) should properly add the new edge") {
             const auto& new_edge =
                 sut.add_edge(constants::vertex_id_1, constants::vertex_id_2, constants::used);
-            REQUIRE(new_edge.is_incident_from(vertices.element_at(constants::vertex_id_1)));
-            REQUIRE(new_edge.is_incident_to(vertices.element_at(constants::vertex_id_2)));
+            REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
+            REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
             REQUIRE_EQ(new_edge.properties, constants::used);
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
             const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-            const auto& new_edge_extracted_1 =
-                adjacent_edges_1.element_at(constants::first_element_idx);
+            const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
             CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
-                const auto& new_edge_extracted_2 =
-                    adjacent_edges_2.element_at(constants::first_element_idx);
+                const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
                 CHECK_EQ(&new_edge_extracted_2, &new_edge);
             }
             else {
@@ -658,15 +652,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
-            const auto& new_edge_extracted_1 =
-                adjacent_edges_1.element_at(constants::first_element_idx);
+            const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
             CHECK_EQ(&new_edge_extracted_1, &new_edge);
 
             const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
             if constexpr (lib_tt::is_undirected_v<edge_type>) {
                 CHECK_EQ(adjacent_edges_2.distance(), constants::one_element);
-                const auto& new_edge_extracted_2 =
-                    adjacent_edges_2.element_at(constants::first_element_idx);
+                const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
                 CHECK_EQ(&new_edge_extracted_2, &new_edge);
             }
             else {

--- a/tests/source/test_graph_topology_builders.cpp
+++ b/tests/source/test_graph_topology_builders.cpp
@@ -164,9 +164,7 @@ template <lib_tt::c_graph GraphType>
             const auto adjacent_edges = graph.adjacent_edges(source_vertex);
 
             return adjacent_edges.distance() == constants::one
-               and adjacent_edges.element_at(constants::first_element_idx)
-                           .incident_vertex(source_vertex)
-                           .id()
+               and adjacent_edges[constants::first_element_idx].incident_vertex(source_vertex).id()
                        == parent_id;
         }
 
@@ -321,8 +319,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             path.vertices() | std::views::take(n_source_vertices),
             predicate::is_vertex_connected_to_next_only(path)
         ));
-        CHECK(predicate::is_vertex_not_connected(path)(path.vertices().element_at(n_source_vertices)
-        ));
+        CHECK(predicate::is_vertex_not_connected(path)(path.vertices()[n_source_vertices]));
     }
 
     SUBCASE("bidirectional_path(n_vertices) should build a two-way path graph of size n_vertices") {
@@ -339,9 +336,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             predicate::is_vertex_connected_to_id_adjacent(path)
         ));
         CHECK(predicate::is_vertex_connected_to_next_only(path)(*path.vertices().begin()));
-        CHECK(predicate::is_vertex_connected_to_prev_only(path)(
-            path.vertices().element_at(n_source_vertices)
-        ));
+        CHECK(predicate::is_vertex_connected_to_prev_only(path)(path.vertices()[n_source_vertices])
+        );
     }
 
     SUBCASE("complete_binary_tree(depth) should return a one-way complete binay tree with the "
@@ -432,9 +428,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             predicate::is_vertex_connected_to_id_adjacent(path)
         ));
         CHECK(predicate::is_vertex_connected_to_next_only(path)(*path.vertices().begin()));
-        CHECK(predicate::is_vertex_connected_to_prev_only(path)(
-            path.vertices().element_at(n_source_vertices)
-        ));
+        CHECK(predicate::is_vertex_connected_to_prev_only(path)(path.vertices()[n_source_vertices])
+        );
     }
 
     SUBCASE("complete_binary_tree(depth) should return a complete binay tree with the given depth"

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -119,9 +119,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
     }
 
     SUBCASE("subscript operator should throw when index is out of range") {
-        CHECK_THROWS_AS(
-            func::discard_result(sut[constants::n_elements]), std::out_of_range
-        );
+        CHECK_THROWS_AS(func::discard_result(sut[constants::n_elements]), std::out_of_range);
     }
 
     SUBCASE("subscript operator should return a reference to the correct element") {

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -118,6 +118,18 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
             CHECK_EQ(std::addressof(sut.element_at(n)), std::addressof(*it++));
     }
 
+    SUBCASE("subscript operator should throw when index is out of range") {
+        CHECK_THROWS_AS(
+            func::discard_result(sut[constants::n_elements]), std::out_of_range
+        );
+    }
+
+    SUBCASE("subscript operator should return a reference to the correct element") {
+        iterator_type it = container.begin();
+        for (std::size_t n = 0; n < constants::n_elements; n++)
+            CHECK_EQ(std::addressof(sut[n]), std::addressof(*it++));
+    }
+
     SUBCASE("make_iterator_range should return a properly initialized iterator_range") {
         const auto range =
             lib::make_iterator_range<iterator_type, cache_mode>(container.begin(), container.end());


### PR DESCRIPTION
- Added the array subscript operator to iterator range
- Replaced `element_at` usage in tests with the new operator