### PR TITLE
YT-CPPGL-25: Add the vertex_ids method to the edge and graph classes

### DIFF
--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -71,6 +71,19 @@ public:
 
     // clang-format on
 
+    [[nodiscard]] gl_attr_force_inline types::homogeneous_pair<types::id_type> incident_vertex_ids(
+    ) const {
+        return std::make_pair(this->_vertices.first.id(), this->_vertices.second.id());
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::id_type first_id() const {
+        return this->first().id();
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::id_type second_id() const {
+        return this->second().id();
+    }
+
     [[nodiscard]] const vertex_type& incident_vertex(const vertex_type& vertex) const {
         if (&vertex == &this->_vertices.first)
             return this->_vertices.second;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -171,6 +171,11 @@ public:
         return make_iterator_range(deref_cbegin(this->_vertices), deref_cend(this->_vertices));
     }
 
+    [[nodiscard]] gl_attr_force_inline std::ranges::iota_view<types::id_type, types::id_type>
+    vertex_ids() const {
+        return std::views::iota(constants::initial_id, this->n_vertices());
+    }
+
     // --- edge methods ---
 
     // clang-format off

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -398,8 +398,8 @@ private:
         if (not this->has_edge(edge))
             throw std::invalid_argument(std::format(
                 "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-                edge.first().id(),
-                edge.second().id(),
+                edge.first_id(),
+                edge.second_id(),
                 types::formatter(&edge)
             ));
     }

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -6,18 +6,6 @@
 
 #include <memory>
 
-#ifdef GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_EAGER
-#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::eager
-#elif defined(GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_LAZY)
-#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::lazy
-#elif defined(GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_NONE)
-#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::none
-#endif
-
-#ifndef _GL_GRAPH_DEFAULT_CACHE_MODE
-#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::lazy
-#endif
-
 namespace gl {
 
 template <

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -6,6 +6,18 @@
 
 #include <memory>
 
+#ifdef GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_EAGER
+#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::eager
+#elif defined(GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_LAZY)
+#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::lazy
+#elif defined(GL_CONFIG_GRAPH_DEFAULT_CACHE_MODE_NONE)
+#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::none
+#endif
+
+#ifndef _GL_GRAPH_DEFAULT_CACHE_MODE
+#define _GL_GRAPH_DEFAULT_CACHE_MODE gl::type_traits::cache_mode::lazy
+#endif
+
 namespace gl {
 
 template <

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -99,10 +99,9 @@ public:
     }
 
     [[nodiscard]] bool has_edge(const edge_type& edge) const {
-        const auto first_id = edge.first().id();
+        const auto first_id = edge.first_id();
         if (not (
-                this->_is_valid_vertex_id(first_id)
-                and this->_is_valid_vertex_id(edge.second().id())
+                this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(edge.second_id())
             ))
             return false;
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -109,8 +109,8 @@ public:
     }
 
     [[nodiscard]] bool has_edge(const edge_type& edge) const {
-        const auto first_id = edge.first().id();
-        const auto second_id = edge.second().id();
+        const auto first_id = edge.first_id();
+        const auto second_id = edge.second_id();
 
         if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
             return false;

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -27,8 +27,8 @@ requires std::is_invocable_r_v<
     if (it == edge_set.end())
         throw std::invalid_argument(std::format(
             "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-            edge->first().id(),
-            edge->second().id(),
+            edge->first_id(),
+            edge->second_id(),
             types::formatter(edge)
         ));
 
@@ -77,7 +77,7 @@ struct directed_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list[edge->first().id()];
+        auto& adjacent_edges_first = self._list[edge->first_id()];
         adjacent_edges_first.push_back(std::move(edge));
         self._n_unique_edges++;
         return *adjacent_edges_first.back();
@@ -100,15 +100,15 @@ struct directed_adjacency_list {
     ) {
         /*
         there is no need to check source_id because the implementation will not allow
-        adding an edge for which first().id() is not the index in the adjacency
+        adding an edge for which first_id() is not the index in the adjacency
         list at which the edge is located, but the parameter is necessary to match the
         function signature for undirected adjacency list
         */
-        return edge->second().id() == vertex_id;
+        return edge->second_id() == vertex_id;
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {
-        auto& adj_edges = self._list.at(edge.first().id());
+        auto& adj_edges = self._list.at(edge.first_id());
         adj_edges.erase(detail::strict_find<impl_type, address_projection>(adj_edges, &edge));
         self._n_unique_edges--;
     }
@@ -157,10 +157,10 @@ struct undirected_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list[edge->first().id()];
+        auto& adjacent_edges_first = self._list[edge->first_id()];
 
         if (not edge->is_loop())
-            self._list[edge->second().id()].push_back(edge);
+            self._list[edge->second_id()].push_back(edge);
         adjacent_edges_first.push_back(std::move(edge));
 
         self._n_unique_edges++;
@@ -175,7 +175,7 @@ struct undirected_adjacency_list {
 
         for (auto& edge : new_edges) {
             if (not edge->is_loop())
-                self._list[edge->second().id()].push_back(edge);
+                self._list[edge->second_id()].push_back(edge);
             adjacent_edges_source.push_back(std::move(edge));
         }
 
@@ -185,23 +185,23 @@ struct undirected_adjacency_list {
     [[nodiscard]] inline static bool is_edge_incident_to(
         const edge_ptr_type& edge, const types::id_type vertex_id, const types::id_type source_id
     ) {
-        if (edge->first().id() == source_id)
-            return edge->second().id() == vertex_id;
-        else if (edge->second().id() == source_id)
-            return edge->first().id() == vertex_id;
+        if (edge->first_id() == source_id)
+            return edge->second_id() == vertex_id;
+        else if (edge->second_id() == source_id)
+            return edge->first_id() == vertex_id;
         return false;
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {
         if (edge.is_loop()) {
-            auto& adj_edges_first = self._list.at(edge.first().id());
+            auto& adj_edges_first = self._list.at(edge.first_id());
             adj_edges_first.erase(
                 detail::strict_find<impl_type, address_projection>(adj_edges_first, &edge)
             );
         }
         else {
-            auto& adj_edges_first = self._list.at(edge.first().id());
-            auto& adj_edges_second = self._list.at(edge.second().id());
+            auto& adj_edges_first = self._list.at(edge.first_id());
+            auto& adj_edges_second = self._list.at(edge.second_id());
 
             adj_edges_first.erase(
                 detail::strict_find<impl_type, address_projection>(adj_edges_first, &edge)

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -17,12 +17,12 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 [[nodiscard]] typename AdjacencyMatrix::edge_ptr_type& strict_get(
     typename AdjacencyMatrix::type& matrix, const typename AdjacencyMatrix::edge_type* edge
 ) {
-    auto& matrix_element = matrix.at(edge->first().id()).at(edge->second().id());
+    auto& matrix_element = matrix.at(edge->first_id()).at(edge->second_id());
     if (edge != matrix_element.get())
         throw std::invalid_argument(std::format(
             "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-            edge->first().id(),
-            edge->second().id(),
+            edge->first_id(),
+            edge->second_id(),
             types::formatter(edge)
         ));
 
@@ -53,7 +53,7 @@ struct directed_adjacency_matrix {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& matrix_element = self._matrix[edge->first().id()][edge->second().id()];
+        auto& matrix_element = self._matrix[edge->first_id()][edge->second_id()];
         matrix_element = std::move(edge);
         self._n_unique_edges++;
         return *matrix_element;
@@ -64,7 +64,7 @@ struct directed_adjacency_matrix {
     ) {
         auto& matrix_row_source = self._matrix[source_id];
         for (auto& edge : new_edges)
-            matrix_row_source[edge->second().id()] = std::move(edge);
+            matrix_row_source[edge->second_id()] = std::move(edge);
         self._n_unique_edges += new_edges.size();
     }
 
@@ -93,8 +93,8 @@ struct undirected_adjacency_matrix {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        const auto first_id = edge->first().id();
-        const auto second_id = edge->second().id();
+        const auto first_id = edge->first_id();
+        const auto second_id = edge->second_id();
 
         if (not edge->is_loop())
             self._matrix[second_id][first_id] = edge;
@@ -112,8 +112,8 @@ struct undirected_adjacency_matrix {
 
         for (auto& edge : new_edges) {
             if (not edge->is_loop())
-                self._matrix[edge->second().id()][source_id] = edge;
-            matrix_row_source[edge->second().id()] = std::move(edge);
+                self._matrix[edge->second_id()][source_id] = edge;
+            matrix_row_source[edge->second_id()] = std::move(edge);
         }
 
         self._n_unique_edges += new_edges.size();
@@ -124,8 +124,8 @@ struct undirected_adjacency_matrix {
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
         }
         else {
-            const auto first_id = edge.first().id();
-            const auto second_id = edge.second().id();
+            const auto first_id = edge.first_id();
+            const auto second_id = edge.second_id();
 
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
             // if the edge was found in the first matrix cell, it will be in the second matrix cell

--- a/include/gl/types/traits/cache_mode.hpp
+++ b/include/gl/types/traits/cache_mode.hpp
@@ -1,7 +1,21 @@
 #pragma once
 
+#include "concepts.hpp"
+
 namespace gl::type_traits {
 
-enum class cache_mode { none, lazy, eager };
+enum class cache_mode_value { none, lazy, eager };
+
+template <cache_mode_value CacheModeValue>
+struct cache_mode {
+    static constexpr cache_mode_value value = CacheModeValue;
+};
+
+using no_cache = cache_mode<cache_mode_value::none>;
+using lazy_cache = cache_mode<cache_mode_value::lazy>;
+using eager_cache = cache_mode<cache_mode_value::eager>;
+
+template <typename T>
+concept c_cache_mode = c_one_of<T, no_cache, lazy_cache, eager_cache>;
 
 } // namespace gl::type_traits

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -18,9 +18,6 @@ template <
     type_traits::c_graph_impl_tag ImplTag>
 struct graph_traits;
 
-template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
-class graph;
-
 template <type_traits::c_properties Properties = types::empty_properties>
 class vertex_descriptor {
 public:

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -556,7 +556,7 @@ TEST_CASE_FIXTURE(
 
     const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
-    const auto second_id = edge_to_remove.second().id();
+    const auto second_id = edge_to_remove.second_id();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -450,7 +450,7 @@ TEST_CASE_FIXTURE(
 
     const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
-    const auto second_id = edge_to_remove.second().id();
+    const auto second_id = edge_to_remove.second_id();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -76,6 +76,23 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.second(), fixture.vd_2);
     }
 
+    SUBCASE("incident_vertex_ids should return the pair of ids of the vertices the edge was "
+            "initialized with") {
+        const auto& vertex_ids = sut.incident_vertex_ids();
+        CHECK_EQ(vertex_ids.first, fixture.vd_1.id());
+        CHECK_EQ(vertex_ids.second, fixture.vd_2.id());
+    }
+
+    SUBCASE("first_id should return the id of the first vertex descriptor the edge was initialized "
+            "with") {
+        CHECK_EQ(sut.first_id(), fixture.vd_1.id());
+    }
+
+    SUBCASE("second should return the id of the second vertex descriptor the edge was initialized "
+            "with") {
+        CHECK_EQ(sut.second_id(), fixture.vd_2.id());
+    }
+
     SUBCASE("incident_vertex should return throw if input vertex is not incident with the edge") {
         CHECK_THROWS_AS(
             func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -54,9 +54,7 @@ struct test_graph {
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     void validate_full_graph_edges(const GraphType& graph) {
         REQUIRE(std::ranges::all_of(
-            graph.vertices()
-                | std::views::transform(transforms::extract_vertex_id<
-                                        typename GraphType::vertex_type>),
+            graph.vertex_ids(),
             [this, &graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
                 const lib_t::id_type vertex_id
             ) { return graph.adjacent_edges(vertex_id).distance() == expected_n_edges; }
@@ -121,6 +119,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.vertices() | std::views::transform(transforms::extract_vertex_id<>),
             constants::vertex_id_view
         ));
+
+        REQUIRE(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
 
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_vertex(constants::out_of_range_elemenet_idx)),
@@ -239,6 +239,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         // clang-format on
     }
 
+    SUBCASE("vertex_ids should return the correct vertex list iterator range") {
+        sut_type sut{constants::n_elements};
+        CHECK(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
+    }
+
     SUBCASE("remove_vertex(vertex) should throw if the id of the given is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(sut.remove_vertex(fixture.out_of_range_vertex), std::out_of_range);
@@ -261,8 +266,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
 
-        const auto vertex_id_view =
-            sut.vertices() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
+        const auto vertex_id_view = sut.vertex_ids();
 
         REQUIRE(std::ranges::equal(
             vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)
@@ -296,8 +300,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
 
-        const auto vertex_id_view =
-            sut.vertices() | std::views::transform(transforms::extract_vertex_id<vertex_type>);
+        const auto vertex_id_view = sut.vertex_ids();
 
         REQUIRE(std::ranges::equal(
             vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)

--- a/tests/source/test_iterator_range.cpp
+++ b/tests/source/test_iterator_range.cpp
@@ -15,17 +15,17 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_iterator_range");
 
-template <typename Container, lib_tt::cache_mode CacheMode>
+template <typename Container, lib_tt::c_cache_mode CacheMode>
 struct test_iterator_range_type_params {
     using container_type = Container;
-    static constexpr lib_tt::cache_mode cache_mode = CacheMode;
+    using cache_mode = CacheMode;
 };
 
 template <typename TypeParams>
 struct test_iterator_range {
     using container_type = typename TypeParams::container_type;
     using iterator_type = typename container_type::iterator;
-    using sut_type = lib_t::iterator_range<iterator_type, TypeParams::cache_mode>;
+    using sut_type = lib_t::iterator_range<iterator_type, typename TypeParams::cache_mode>;
 
     test_iterator_range()
     : container(constants::n_elements), sut(container.begin(), container.end()) {
@@ -42,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
     using container_type = typename fixture_type::container_type;
     using iterator_type = typename fixture_type::iterator_type;
     using sut_type = typename fixture_type::sut_type;
-    constexpr lib_tt::cache_mode cache_mode = sut_type::cache_mode;
+    using cache_mode = typename sut_type::cache_mode;
 
     fixture_type fixture;
 
@@ -149,36 +149,36 @@ TEST_CASE_TEMPLATE_DEFINE("iterator_range tests", TypeParams, type_params_templa
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     type_params_template,
-    // cache_mode::none
+    // cache_mode_value::none
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib_tt::cache_mode::none>, // random access iterator
+        lib_tt::no_cache>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib_tt::cache_mode::none>, // bidirectional iterator
+        lib_tt::no_cache>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib_tt::cache_mode::none>, // forward iterator
-    // cache_mode::lazy
+        lib_tt::no_cache>, // forward iterator
+    // cache_mode_value::lazy
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib_tt::cache_mode::lazy>, // random access iterator
+        lib_tt::lazy_cache>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib_tt::cache_mode::lazy>, // bidirectional iterator
+        lib_tt::lazy_cache>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib_tt::cache_mode::lazy>, // forward iterator
-    // cache_mode::eager
+        lib_tt::lazy_cache>, // forward iterator
+    // cache_mode_value::eager
     test_iterator_range_type_params<
         std::vector<std::size_t>,
-        lib_tt::cache_mode::eager>, // random access iterator
+        lib_tt::eager_cache>, // random access iterator
     test_iterator_range_type_params<
         std::list<std::size_t>,
-        lib_tt::cache_mode::eager>, // bidirectional iterator
+        lib_tt::eager_cache>, // bidirectional iterator
     test_iterator_range_type_params<
         std::forward_list<std::size_t>,
-        lib_tt::cache_mode::eager> // forward iterator
+        lib_tt::eager_cache> // forward iterator
 );
 
 TEST_SUITE_END(); // test_iterator_range

--- a/tests/source/test_search_algorithms.cpp
+++ b/tests/source/test_search_algorithms.cpp
@@ -21,12 +21,12 @@ template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>
             return false;
 
         for (const auto& edge : adj_edges_1) {
-            if (not g2.has_edge(edge.first().id(), edge.second().id()))
+            if (not g2.has_edge(edge.first_id(), edge.second_id()))
                 return false;
         }
 
         for (const auto& edge : adj_edges_2) {
-            if (not g1.has_edge(edge.first().id(), edge.second().id()))
+            if (not g1.has_edge(edge.first_id(), edge.second_id()))
                 return false;
         }
 


### PR DESCRIPTION
- Added the `incident_vertex_ids`, `first_id` and `second_id` methods to the `edge_desciptor` class
- Added the `vertex_ids` method to the `graph` class which should return a view of the vertex ids in the graph
- Aligned existing code to use the new functionality
- Changed the `cache_mode` declaration to make cached structures compatible with `c_instantiation_of`