### PR TITLE
YT-CPPGL-38: Add the decrement operator to custom iterators with bidirectional tag

### DIFF
--- a/include/gl/types/dereferencing_iterator.hpp
+++ b/include/gl/types/dereferencing_iterator.hpp
@@ -78,6 +78,10 @@ public:
         return this->_it != other._it;
     }
 
+    [[nodiscard]] gl_attr_force_inline iterator_type base() const {
+        return this->_it;
+    }
+
 private:
     iterator_type _it;
 };

--- a/include/gl/types/dereferencing_iterator.hpp
+++ b/include/gl/types/dereferencing_iterator.hpp
@@ -55,6 +55,21 @@ public:
         return tmp;
     }
 
+    inline dereferencing_iterator& operator--()
+    requires(std::bidirectional_iterator<iterator_type>)
+    {
+        this->_it--;
+        return *this;
+    }
+
+    inline dereferencing_iterator operator--(int)
+    requires(std::bidirectional_iterator<iterator_type>)
+    {
+        dereferencing_iterator tmp = *this;
+        this->_it--;
+        return tmp;
+    }
+
     [[nodiscard]] gl_attr_force_inline bool operator==(const dereferencing_iterator& other) const {
         return this->_it == other._it;
     }

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -22,9 +22,17 @@ public:
 
     non_null_iterator() = default;
 
-    non_null_iterator(iterator_type current, iterator_type end) : _current(current), _end(end) {
+    non_null_iterator(iterator_type current, iterator_type end)
+    requires(not std::bidirectional_iterator<iterator_type>)
+    : _begin(), _current(current), _end(end) {
         if (this->_current != this->_end and not *this->_current)
-            this->_skip_null_elements();
+            this->_skip_null_elements_forward();
+    }
+
+    non_null_iterator(iterator_type begin, iterator_type current, iterator_type end)
+    : _begin(begin), _current(current), _end(end) {
+        if (this->_current != this->_end and not *this->_current)
+            this->_skip_null_elements_forward();
     }
 
     non_null_iterator(const non_null_iterator&) = default;
@@ -42,13 +50,28 @@ public:
     }
 
     inline non_null_iterator& operator++() {
-        this->_skip_null_elements();
+        this->_skip_null_elements_forward();
         return *this;
     }
 
     inline non_null_iterator operator++(int) {
         non_null_iterator tmp = *this;
-        this->_skip_null_elements();
+        this->_skip_null_elements_forward();
+        return tmp;
+    }
+
+    inline non_null_iterator& operator--()
+    requires(std::bidirectional_iterator<iterator_type>)
+    {
+        this->_skip_null_elements_backward();
+        return *this;
+    }
+
+    inline non_null_iterator operator--(int)
+    requires(std::bidirectional_iterator<iterator_type>)
+    {
+        non_null_iterator tmp = *this;
+        this->_skip_null_elements_backward();
         return tmp;
     }
 
@@ -61,14 +84,43 @@ public:
     }
 
 private:
-    void _skip_null_elements() {
-        constexpr auto is_null = [](const reference& ptr) { return ptr == nullptr; };
+    static constexpr bool _is_null(const reference& ptr) {
+        return ptr == nullptr;
+    }
 
+    inline void _skip_null_elements_forward() {
         if (this->_current == this->_end)
             return;
 
-        this->_current = std::find_if_not(++this->_current, this->_end, is_null);
+        this->_current = std::find_if_not(++this->_current, this->_end, _is_null);
     }
+
+    void _skip_null_elements_backward()
+    requires(std::bidirectional_iterator<iterator_type>)
+    {
+        if (this->_current == this->_begin)
+            return;
+
+        this->_current =
+            std::find_if_not(
+                ++std::make_reverse_iterator(this->_current),
+                std::make_reverse_iterator(this->_begin),
+                _is_null
+            )
+                .base();
+
+        /*
+        reverse_iterator.base() points to an element one past the position
+        the iterator points to in a forward sequence so to make sure the new
+        current iterator is valid it needs to be adjusted by one backward
+        */
+        if (this->_current != this->_begin)
+            --this->_current;
+    }
+
+    [[no_unique_address]] std::
+        conditional_t<std::bidirectional_iterator<iterator_type>, iterator_type, std::monostate>
+            _begin;
 
     iterator_type _current;
     iterator_type _end;
@@ -77,23 +129,67 @@ private:
 } // namespace types
 
 template <type_traits::c_range Range>
-[[nodiscard]] gl_attr_force_inline auto non_null_begin(Range& range) {
+[[nodiscard]] auto non_null_begin(Range& range)
+requires(not std::bidirectional_iterator<decltype(std::ranges::begin(range))>)
+{
     return types::non_null_iterator(std::ranges::begin(range), std::ranges::end(range));
 }
 
 template <type_traits::c_range Range>
-[[nodiscard]] gl_attr_force_inline auto non_null_end(Range& range) {
+[[nodiscard]] auto non_null_end(Range& range)
+requires(not std::bidirectional_iterator<decltype(std::ranges::end(range))>)
+{
     return types::non_null_iterator(std::ranges::end(range), std::ranges::end(range));
 }
 
 template <type_traits::c_const_range Range>
-[[nodiscard]] gl_attr_force_inline auto non_null_cbegin(Range& range) {
+[[nodiscard]] auto non_null_cbegin(Range& range)
+requires(not std::bidirectional_iterator<decltype(std::ranges::cbegin(range))>)
+{
     return types::non_null_iterator(std::ranges::cbegin(range), std::ranges::cend(range));
 }
 
 template <type_traits::c_const_range Range>
-[[nodiscard]] gl_attr_force_inline auto non_null_cend(Range& range) {
+[[nodiscard]] auto non_null_cend(Range& range)
+requires(not std::bidirectional_iterator<decltype(std::ranges::cend(range))>)
+{
     return types::non_null_iterator(std::ranges::cend(range), std::ranges::cend(range));
+}
+
+template <type_traits::c_range Range>
+[[nodiscard]] auto non_null_begin(Range& range)
+requires(std::bidirectional_iterator<decltype(std::ranges::begin(range))>)
+{
+    return types::non_null_iterator(
+        std::ranges::begin(range), std::ranges::begin(range), std::ranges::end(range)
+    );
+}
+
+template <type_traits::c_range Range>
+[[nodiscard]] auto non_null_end(Range& range)
+requires(std::bidirectional_iterator<decltype(std::ranges::end(range))>)
+{
+    return types::non_null_iterator(
+        std::ranges::begin(range), std::ranges::end(range), std::ranges::end(range)
+    );
+}
+
+template <type_traits::c_const_range Range>
+[[nodiscard]] auto non_null_cbegin(Range& range)
+requires(std::bidirectional_iterator<decltype(std::ranges::cbegin(range))>)
+{
+    return types::non_null_iterator(
+        std::ranges::cbegin(range), std::ranges::cbegin(range), std::ranges::cend(range)
+    );
+}
+
+template <type_traits::c_const_range Range>
+[[nodiscard]] auto non_null_cend(Range& range)
+requires(std::bidirectional_iterator<decltype(std::ranges::cend(range))>)
+{
+    return types::non_null_iterator(
+        std::ranges::cbegin(range), std::ranges::cend(range), std::ranges::cend(range)
+    );
 }
 
 } // namespace gl

--- a/include/gl/types/non_null_iterator.hpp
+++ b/include/gl/types/non_null_iterator.hpp
@@ -83,6 +83,10 @@ public:
         return this->_current != other._current;
     }
 
+    [[nodiscard]] gl_attr_force_inline iterator_type base() const {
+        return this->_current;
+    }
+
 private:
     static constexpr bool _is_null(const reference& ptr) {
         return ptr == nullptr;

--- a/tests/source/test_dereferencing_iterator.cpp
+++ b/tests/source/test_dereferencing_iterator.cpp
@@ -27,7 +27,7 @@ struct data {
 
 using data_uptr = std::unique_ptr<data>;
 using data_sptr = std::shared_ptr<data>;
-using data_rawptr = data*;
+using data_rptr = data*;
 
 template <typename Container>
 struct test_dereferencing_iterator {
@@ -110,13 +110,13 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     container_type_template,
     std::deque<data_uptr>, // random access iterator
     std::deque<data_sptr>, // random access iterator
-    std::deque<data_rawptr>, // random access iterator
+    std::deque<data_rptr>, // random access iterator
     std::list<data_uptr>, // bidirectional iterator
     std::list<data_sptr>, // bidirectional iterator
-    std::list<data_rawptr>, // bidirectional iterator
+    std::list<data_rptr>, // bidirectional iterator
     std::forward_list<data_uptr>, // forward iterator
     std::forward_list<data_sptr>, // forward iterator
-    std::forward_list<data_rawptr> // forward iterator
+    std::forward_list<data_rptr> // forward iterator
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -145,8 +145,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto exepcted_size = std::ranges::distance(ptr_begin, ptr_it);
 
         // Collect elements while iterating backwards
-        std::vector<data_rawptr> sut_elements;
-        std::vector<data_rawptr> ptr_elements;
+        std::vector<data_rptr> sut_elements;
+        std::vector<data_rptr> ptr_elements;
         const address_projection proj{};
 
         do {
@@ -174,14 +174,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto exepcted_size = std::ranges::distance(ptr_begin, ptr_it);
 
         // Collect elements while iterating backwards
-        std::vector<data_rawptr> sut_elements;
-        std::vector<data_rawptr> ptr_elements;
+        std::vector<data_rptr> sut_elements;
+        std::vector<data_rptr> ptr_elements;
         const address_projection proj{};
 
         do {
             sut_elements.push_back(proj(*(--sut_it)));
             ptr_elements.push_back(proj(*(--ptr_it)));
-        } while (sut_it != sut_begin && ptr_it != ptr_begin);
+        } while (sut_it != sut_begin and ptr_it != ptr_begin);
 
         REQUIRE_EQ(sut_it, sut_begin);
         REQUIRE_EQ(ptr_it, ptr_begin);
@@ -197,10 +197,10 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     bidir_container_type_template,
     std::deque<data_uptr>, // random access iterator
     std::deque<data_sptr>, // random access iterator
-    std::deque<data_rawptr>, // random access iterator
+    std::deque<data_rptr>, // random access iterator
     std::list<data_uptr>, // bidirectional iterator
     std::list<data_sptr>, // bidirectional iterator
-    std::list<data_rawptr> // bidirectional iterator
+    std::list<data_rptr> // bidirectional iterator
 );
 
 TEST_SUITE_END(); // test_dereferencing_iterator

--- a/tests/source/test_non_null_iterator.cpp
+++ b/tests/source/test_non_null_iterator.cpp
@@ -10,10 +10,13 @@
 #include <deque>
 #include <forward_list>
 #include <list>
+#include <vector>
 
 namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_non_null_iterator");
+
+// TODO: add specific tests covering the individual methods
 
 struct data {
     lib_t::id_type id;
@@ -33,7 +36,15 @@ struct test_non_null_iterator {
     using sut_type = lib_t::non_null_iterator<typename container_type::iterator>;
 
     struct reference_projection {
-        auto operator()(const data_ptr_type& data_ptr) {
+        auto& operator()(const data_ptr_type& data_ptr) const
+        requires(lib_tt::c_strong_smart_ptr<data_ptr_type>)
+        {
+            return *data_ptr;
+        }
+
+        auto& operator()(data_ptr_type data_ptr) const
+        requires(not lib_tt::c_strong_smart_ptr<data_ptr_type>)
+        {
             return *data_ptr;
         }
     };
@@ -109,12 +120,88 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     std::list<data_uptr>, // bidirectional iterator
     std::list<data_sptr>, // bidirectional iterator
     std::list<data_rptr>, // bidirectional iterator
-    std::forward_list<data_uptr>, // bidirectional iterator
-    std::forward_list<data_sptr>, // bidirectional iterator
-    std::forward_list<data_rptr> // bidirectional iterator
+    std::forward_list<data_uptr>, // forward iterator
+    std::forward_list<data_sptr>, // forward iterator
+    std::forward_list<data_rptr> // forward iterator
 );
 
-// TODO: add specific tests covering the individual methods
+TEST_CASE_TEMPLATE_DEFINE(
+    "non_null_iterator should provide an 'equivalent' decrementable iterator range as a non null "
+    "decrementable container",
+    ContainerType,
+    bidir_container_type_template
+) {
+    using container_type = ContainerType;
+    using fixture_type = test_non_null_iterator<container_type>;
+    using sut_type = typename fixture_type::sut_type;
+    using reference_projection = typename fixture_type::reference_projection;
+
+    static_assert(std::bidirectional_iterator<sut_type>);
+
+    fixture_type fixture;
+
+    SUBCASE("normal iterator") {
+        // Create non_null iterator range
+        auto sut_it = lib::non_null_end(fixture.container);
+        auto sut_begin = lib::non_null_begin(fixture.container);
+
+        auto ptr_it = std::ranges::end(fixture.non_null_container);
+        auto ptr_begin = std::ranges::begin(fixture.non_null_container);
+
+        const auto exepcted_size = std::ranges::distance(ptr_begin, ptr_it);
+
+        // Collect elements while iterating backwards
+        std::vector<std::reference_wrapper<data>> sut_elements;
+        std::vector<std::reference_wrapper<data>> ptr_elements;
+        const reference_projection proj{};
+
+        do {
+            sut_elements.push_back(proj(*(--sut_it)));
+            ptr_elements.push_back(proj(*(--ptr_it)));
+        } while (ptr_it != ptr_begin);
+
+        REQUIRE_EQ(sut_elements.size(), exepcted_size);
+        REQUIRE_EQ(ptr_elements.size(), exepcted_size);
+
+        CHECK_EQ(sut_elements, ptr_elements);
+    }
+
+    SUBCASE("const iterator") {
+        // Create non_null iterator range
+        auto sut_it = lib::non_null_cend(fixture.container);
+        auto sut_begin = lib::non_null_cbegin(fixture.container);
+
+        auto ptr_it = std::ranges::cend(fixture.non_null_container);
+        auto ptr_begin = std::ranges::cbegin(fixture.non_null_container);
+
+        const auto exepcted_size = std::ranges::distance(ptr_begin, ptr_it);
+
+        // Collect elements while iterating backwards
+        std::vector<std::reference_wrapper<data>> sut_elements;
+        std::vector<std::reference_wrapper<data>> ptr_elements;
+        const reference_projection proj{};
+
+        do {
+            sut_elements.push_back(proj(*(--sut_it)));
+            ptr_elements.push_back(proj(*(--ptr_it)));
+        } while (ptr_it != ptr_begin);
+
+        REQUIRE_EQ(sut_elements.size(), exepcted_size);
+        REQUIRE_EQ(ptr_elements.size(), exepcted_size);
+
+        CHECK_EQ(sut_elements, ptr_elements);
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bidir_container_type_template,
+    std::deque<data_uptr>, // random access iterator
+    std::deque<data_sptr>, // random access iterator
+    std::deque<data_rptr>, // random access iterator
+    std::list<data_uptr>, // bidirectional iterator
+    std::list<data_sptr>, // bidirectional iterator
+    std::list<data_rptr> // bidirectional iterator
+);
 
 TEST_SUITE_END(); // test_non_null_iterator
 


### PR DESCRIPTION
Added the the `operator--`, `operator--(int)` and `base() const` methods to both `dereferencing_iterator` and `non_null_iterator` classes