### PR TITLE
YT-CPPGL-32: Adjacency matrix add_edge error handling

### DIFF
--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -44,11 +44,13 @@ namespace type_traits {
 
 template <typename T>
 concept c_list_graph_traits =
-    c_instantiation_of<T, graph_traits> and std::same_as<typename T::implementation_tag, impl::list_t>;
+    c_instantiation_of<T, graph_traits>
+    and std::same_as<typename T::implementation_tag, impl::list_t>;
 
 template <typename T>
 concept c_matrix_graph_traits =
-    c_instantiation_of<T, graph_traits> and std::same_as<typename T::implementation_tag, impl::matrix_t>;
+    c_instantiation_of<T, graph_traits>
+    and std::same_as<typename T::implementation_tag, impl::matrix_t>;
 
 } // namespace type_traits
 

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -40,4 +40,16 @@ template <
 using matrix_graph_traits =
     graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t>;
 
+namespace type_traits {
+
+template <typename T>
+concept c_list_graph_traits =
+    c_instantiation_of<T, graph_traits> and std::same_as<typename T::implementation_tag, impl::list_t>;
+
+template <typename T>
+concept c_matrix_graph_traits =
+    c_instantiation_of<T, graph_traits> and std::same_as<typename T::implementation_tag, impl::matrix_t>;
+
+} // namespace type_traits
+
 } // namespace gl

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -11,7 +11,7 @@
 
 namespace gl::impl {
 
-template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+template <type_traits::c_list_graph_traits GraphTraits>
 class adjacency_list {
 public:
     using vertex_type = typename GraphTraits::vertex_type;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -26,7 +26,7 @@ public:
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
-    using type = std::vector<edge_list_type>;
+    using list_type = std::vector<edge_list_type>;
 
     adjacency_list(const adjacency_list&) = delete;
     adjacency_list& operator=(const adjacency_list&) = delete;
@@ -169,7 +169,7 @@ private:
         return vertex_id < this->_list.size();
     }
 
-    type _list{};
+    list_type _list{};
     types::size_type _n_unique_edges{constants::default_size};
 };
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -11,7 +11,7 @@
 
 namespace gl::impl {
 
-template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+template <type_traits::c_matrix_graph_traits GraphTraits>
 class adjacency_matrix {
 public:
     using vertex_type = typename GraphTraits::vertex_type;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -26,7 +26,7 @@ public:
 
     // TODO: reverese iterators should be available for bidirectional ranges
 
-    using type = std::vector<edge_list_type>;
+    using matrix_type = std::vector<edge_list_type>;
 
     adjacency_matrix(const adjacency_matrix&) = delete;
     adjacency_matrix& operator=(const adjacency_matrix&) = delete;
@@ -158,7 +158,7 @@ private:
         return vertex_id < this->_matrix.size();
     }
 
-    type _matrix{};
+    matrix_type _matrix{};
     types::size_type _n_unique_edges{constants::default_size};
 };
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -86,17 +86,19 @@ struct directed_adjacency_list {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
-        auto& adjacent_edges_source = self._list[source_id];
-        adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
-
-        for (auto& edge : new_edges) {
+        // validate new edges
+        for (auto& edge : new_edges)
             // TODO: add tests
             if (edge->first_id() != source_id)
                 throw std::invalid_argument(
                     std::format("All edges must be incident from the source vertex ({})", source_id)
                 );
+
+        auto& adjacent_edges_source = self._list[source_id];
+        adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
+
+        for (auto& edge : new_edges)
             adjacent_edges_source.push_back(std::move(edge));
-        }
 
         self._n_unique_edges += new_edges.size();
     }
@@ -178,19 +180,21 @@ struct undirected_adjacency_list {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
+        // validate new edges
+        for (auto& edge : new_edges) {
+            // TODO: add tests
+            if (not (edge->first_id() == source_id or edge->second_id() == source_id))
+                throw std::invalid_argument(
+                    std::format("All edges must be incident from the source vertex ({})", source_id)
+                );
+        }
+
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
 
         for (auto& edge : new_edges) {
-            const auto [first_id, second_id] = edge->incident_vertex_ids();
-            // TODO: add tests
-            if (not (first_id == source_id or second_id == source_id))
-                throw std::invalid_argument(
-                    std::format("All edges must be incident from the source vertex ({})", source_id)
-                );
-
             if (not edge->is_loop())
-                self._list[second_id].push_back(edge);
+                self._list[edge->second_id()].push_back(edge);
             adjacent_edges_source.push_back(std::move(edge));
         }
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -86,14 +86,6 @@ struct directed_adjacency_list {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
-        // validate new edges
-        for (auto& edge : new_edges)
-            // TODO: add tests
-            if (edge->first_id() != source_id)
-                throw std::invalid_argument(
-                    std::format("All edges must be incident from the source vertex ({})", source_id)
-                );
-
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
 
@@ -180,15 +172,6 @@ struct undirected_adjacency_list {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
-        // validate new edges
-        for (auto& edge : new_edges) {
-            // TODO: add tests
-            if (not (edge->first_id() == source_id or edge->second_id() == source_id))
-                throw std::invalid_argument(
-                    std::format("All edges must be incident from the source vertex ({})", source_id)
-                );
-        }
-
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -8,7 +8,7 @@
 
 namespace gl::impl {
 
-template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+template <type_traits::c_list_graph_traits GraphTraits>
 class adjacency_list;
 
 namespace specialized {

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -88,8 +88,16 @@ struct directed_adjacency_list {
     ) {
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
-        for (auto& edge : new_edges)
+
+        for (auto& edge : new_edges) {
+            // TODO: add tests
+            if (edge->first_id() != source_id)
+                throw std::invalid_argument(
+                    std::format("All edges must be incident from the source vertex ({})", source_id)
+                );
             adjacent_edges_source.push_back(std::move(edge));
+        }
+
         self._n_unique_edges += new_edges.size();
     }
 
@@ -174,8 +182,15 @@ struct undirected_adjacency_list {
         adjacent_edges_source.reserve(adjacent_edges_source.size() + new_edges.size());
 
         for (auto& edge : new_edges) {
+            const auto [first_id, second_id] = edge->incident_vertex_ids();
+            // TODO: add tests
+            if (not (first_id == source_id or second_id == source_id))
+                throw std::invalid_argument(
+                    std::format("All edges must be incident from the source vertex ({})", source_id)
+                );
+
             if (not edge->is_loop())
-                self._list[edge->second_id()].push_back(edge);
+                self._list[second_id].push_back(edge);
             adjacent_edges_source.push_back(std::move(edge));
         }
 

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -29,10 +29,16 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
     return matrix_element;
 }
 
-// template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
-// inline void check_edge_override(
-//     const typename AdjacencyMatrix
-// )
+template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+inline void check_edge_override(
+    const AdjacencyMatrix& adj_matrix,
+    const typename AdjacencyMatrix::edge_ptr_type& edge
+) {
+    const auto [first_id, second_id] = edge->incident_vertex_ids();
+
+    if (adj_matrix.has_edge(first_id, second_id))
+        throw std::logic_error(std::format("Cannot override an existing edge without remove: ({}, {})", first_id, second_id));
+}
 
 } // namespace detail
 
@@ -58,9 +64,12 @@ struct directed_adjacency_matrix {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
+        detail::check_edge_override<impl_type>(self, edge);
+
         auto& matrix_element = self._matrix[edge->first_id()][edge->second_id()];
         matrix_element = std::move(edge);
         self._n_unique_edges++;
+
         return *matrix_element;
     }
 
@@ -98,6 +107,8 @@ struct undirected_adjacency_matrix {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
+        detail::check_edge_override<impl_type>(self, edge);
+
         const auto first_id = edge->first_id();
         const auto second_id = edge->second_id();
 

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -76,7 +76,7 @@ struct directed_adjacency_matrix {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
-        auto& matrix_row_source = self._matrix[source_id];
+        // validate new edges
         for (auto& edge : new_edges) {
             // TODO: add tests
             if (edge->first_id() != source_id)
@@ -85,8 +85,12 @@ struct directed_adjacency_matrix {
                 );
 
             detail::check_edge_override(self, edge);
-            matrix_row_source[edge->second_id()] = std::move(edge);
         }
+
+        auto& matrix_row_source = self._matrix[source_id];
+        for (auto& edge : new_edges)
+            matrix_row_source[edge->second_id()] = std::move(edge);
+
         self._n_unique_edges += new_edges.size();
     }
 
@@ -132,21 +136,22 @@ struct undirected_adjacency_matrix {
     static void add_edges_from(
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
-        auto& matrix_row_source = self._matrix[source_id];
-
+        // validate new edges
         for (auto& edge : new_edges) {
-            const auto [first_id, second_id] = edge->incident_vertex_ids();
             // TODO: add tests
-            if (not (first_id == source_id or second_id == source_id))
+            if (not (edge->first_id() == source_id or edge->second_id() == source_id))
                 throw std::invalid_argument(
                     std::format("All edges must be incident from the source vertex ({})", source_id)
                 );
 
             detail::check_edge_override(self, edge);
+        }
 
+        auto& matrix_row_source = self._matrix[source_id];
+        for (auto& edge : new_edges) {
             if (not edge->is_loop())
-                self._matrix[second_id][source_id] = edge;
-            matrix_row_source[second_id] = std::move(edge);
+                self._matrix[edge->second_id()][source_id] = edge;
+            matrix_row_source[edge->second_id()] = std::move(edge);
         }
 
         self._n_unique_edges += new_edges.size();

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -31,13 +31,14 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 inline void check_edge_override(
-    const AdjacencyMatrix& adj_matrix,
-    const typename AdjacencyMatrix::edge_ptr_type& edge
+    const AdjacencyMatrix& adj_matrix, const typename AdjacencyMatrix::edge_ptr_type& edge
 ) {
     const auto [first_id, second_id] = edge->incident_vertex_ids();
 
     if (adj_matrix.has_edge(first_id, second_id))
-        throw std::logic_error(std::format("Cannot override an existing edge without remove: ({}, {})", first_id, second_id));
+        throw std::logic_error(std::format(
+            "Cannot override an existing edge without remove: ({}, {})", first_id, second_id
+        ));
 }
 
 } // namespace detail

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -15,7 +15,7 @@ namespace detail {
 
 template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 [[nodiscard]] typename AdjacencyMatrix::edge_ptr_type& strict_get(
-    typename AdjacencyMatrix::type& matrix, const typename AdjacencyMatrix::edge_type* edge
+    typename AdjacencyMatrix::matrix_type& matrix, const typename AdjacencyMatrix::edge_type* edge
 ) {
     auto& matrix_element = matrix.at(edge->first_id()).at(edge->second_id());
     if (edge != matrix_element.get())
@@ -28,6 +28,11 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 
     return matrix_element;
 }
+
+// template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
+// inline void check_edge_override(
+//     const typename AdjacencyMatrix
+// )
 
 } // namespace detail
 

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -6,7 +6,7 @@
 
 namespace gl::impl {
 
-template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
+template <type_traits::c_matrix_graph_traits GraphTraits>
 class adjacency_matrix;
 
 namespace specialized {

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -77,15 +77,8 @@ struct directed_adjacency_matrix {
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
         // validate new edges
-        for (auto& edge : new_edges) {
-            // TODO: add tests
-            if (edge->first_id() != source_id)
-                throw std::invalid_argument(
-                    std::format("All edges must be incident from the source vertex ({})", source_id)
-                );
-
+        for (auto& edge : new_edges)
             detail::check_edge_override(self, edge);
-        }
 
         auto& matrix_row_source = self._matrix[source_id];
         for (auto& edge : new_edges)
@@ -137,15 +130,8 @@ struct undirected_adjacency_matrix {
         impl_type& self, const types::id_type source_id, std::vector<edge_ptr_type> new_edges
     ) {
         // validate new edges
-        for (auto& edge : new_edges) {
-            // TODO: add tests
-            if (not (edge->first_id() == source_id or edge->second_id() == source_id))
-                throw std::invalid_argument(
-                    std::format("All edges must be incident from the source vertex ({})", source_id)
-                );
-
+        for (auto& edge : new_edges)
             detail::check_edge_override(self, edge);
-        }
 
         auto& matrix_row_source = self._matrix[source_id];
         for (auto& edge : new_edges) {

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -58,8 +58,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     edge_directional_tag_sut_template,
-    lib_i::adjacency_list<lib::graph_traits<lib::directed_t>>, // directed adj list
-    lib_i::adjacency_list<lib::graph_traits<lib::undirected_t>> // undirected adj list
+    lib_i::adjacency_list<lib::list_graph_traits<lib::directed_t>>, // directed adj list
+    lib_i::adjacency_list<lib::list_graph_traits<lib::undirected_t>> // undirected adj list
 );
 
 namespace {
@@ -73,7 +73,7 @@ struct test_directed_adjacency_list {
     using vertex_type = lib::vertex_descriptor<>;
     using edge_type = lib::directed_edge<vertex_type>;
     using edge_ptr_type = lib::directed_t::edge_ptr_type<edge_type>;
-    using sut_type = lib_i::adjacency_list<lib::graph_traits<lib::directed_t>>;
+    using sut_type = lib_i::adjacency_list<lib::list_graph_traits<lib::directed_t>>;
 
     test_directed_adjacency_list() {
         for (const auto id : constants::vertex_id_view)
@@ -323,7 +323,7 @@ struct test_undirected_adjacency_list {
     using vertex_type = lib::vertex_descriptor<>;
     using edge_type = lib::undirected_edge<vertex_type>;
     using edge_ptr_type = lib::undirected_t::edge_ptr_type<edge_type>;
-    using sut_type = lib_i::adjacency_list<lib::graph_traits<lib::undirected_t>>;
+    using sut_type = lib_i::adjacency_list<lib::list_graph_traits<lib::undirected_t>>;
 
     test_undirected_adjacency_list() {
         for (const auto id : constants::vertex_id_view)

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -59,8 +59,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     edge_directional_tag_sut_template,
-    lib_i::adjacency_matrix<lib::graph_traits<lib::directed_t>>, // directed adj list
-    lib_i::adjacency_matrix<lib::graph_traits<lib::undirected_t>> // undirected adj list
+    lib_i::adjacency_matrix<lib::matrix_graph_traits<lib::directed_t>>, // directed adj list
+    lib_i::adjacency_matrix<lib::matrix_graph_traits<lib::undirected_t>> // undirected adj list
 );
 
 namespace {
@@ -74,7 +74,7 @@ struct test_directed_adjacency_matrix {
     using vertex_type = lib::vertex_descriptor<>;
     using edge_type = lib::directed_edge<vertex_type>;
     using edge_ptr_type = lib::directed_t::edge_ptr_type<edge_type>;
-    using sut_type = lib_i::adjacency_matrix<lib::graph_traits<lib::directed_t>>;
+    using sut_type = lib_i::adjacency_matrix<lib::matrix_graph_traits<lib::directed_t>>;
 
     test_directed_adjacency_matrix() {
         for (const auto id : constants::vertex_id_view)
@@ -274,7 +274,7 @@ struct test_undirected_adjacency_matrix {
     using vertex_type = lib::vertex_descriptor<>;
     using edge_type = lib::undirected_edge<vertex_type>;
     using edge_ptr_type = lib::undirected_t::edge_ptr_type<edge_type>;
-    using sut_type = lib_i::adjacency_matrix<lib::graph_traits<lib::undirected_t>>;
+    using sut_type = lib_i::adjacency_matrix<lib::matrix_graph_traits<lib::undirected_t>>;
 
     test_undirected_adjacency_matrix() {
         for (const auto id : constants::vertex_id_view)

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 
 namespace gl_testing {
 
@@ -54,6 +55,21 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CHECK_EQ(sut.n_vertices(), constants::n_elements);
         CHECK_EQ(sut.n_unique_edges(), constants::zero_elements);
+    }
+
+    SUBCASE("add_edge should throw an error if the vertices are already incident") {
+        using vertex_type = typename SutType::vertex_type;
+        using edge_type = typename SutType::edge_type;
+
+        SutType sut{constants::n_elements};
+
+        const vertex_type v1{constants::vertex_id_1};
+        const vertex_type v2{constants::vertex_id_2};
+
+        sut.add_edge(lib::detail::make_edge<edge_type>(v1, v2));
+        REQUIRE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
+
+        CHECK_THROWS_AS(sut.add_edge(lib::detail::make_edge<edge_type>(v1, v2)), std::logic_error);
     }
 }
 

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -90,22 +90,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut.add_edges_from(constants::vertex_id_1, std::move(new_edges));
 
-        REQUIRE(std::ranges::all_of(
-            constants::vertex_id_view,
-            [&sut](const auto destination_id) {
-                return sut.has_edge(constants::vertex_id_1, destination_id);
-            }
-        ));
+        REQUIRE(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto destination_id) {
+            return sut.has_edge(constants::vertex_id_1, destination_id);
+        }));
 
-        std::ranges::for_each(
-            vertex_refs,
-            [&sut, &v1](const auto& destination) {
-                std::vector<edge_ptr_type> new_edges;
-                new_edges.push_back(lib::detail::make_edge<edge_type>(v1, destination.get()));
+        std::ranges::for_each(vertex_refs, [&sut, &v1](const auto& destination) {
+            std::vector<edge_ptr_type> new_edges;
+            new_edges.push_back(lib::detail::make_edge<edge_type>(v1, destination.get()));
 
-                CHECK_THROWS_AS(sut.add_edges_from(v1.id(), std::move(new_edges)), std::logic_error);
-            }
-        );
+            CHECK_THROWS_AS(sut.add_edges_from(v1.id(), std::move(new_edges)), std::logic_error);
+        });
     }
 }
 


### PR DESCRIPTION
- Modified the current `add_edge` and `add_edges_from` methods of the `adjacency_matrix` class to throw error when a given edge connects already incident vertices
- Added the `c_{list/matrix}_graph_traits` concept and aligned implementation types use these dedicated concepts