### PR TITLE
[None] IO functionality improvement

### DIFF
--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -453,23 +453,13 @@ private:
             this->n_unique_edges()
         );
 
-        if (io::is_option_set(os, io::option::with_vertex_properties)) {
-            /*
-            after each vertex disable the with_vertex_properties option so that
-            the vertex properties are not printed with the adjacent edges
-            */
-            for (const auto& vertex : this->vertices()) {
-                os << "- " << vertex << io::without_vertex_properties << "\n  adjacent edges:\n";
-                for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
-                    os << "\t- " << edge << '\n';
-                os << io::with_vertex_properties;
-            }
-        }
-        else {
-            for (const auto& vertex : this->vertices()) {
-                os << "- " << vertex << "\n  adjacent edges:\n";
-                for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
-                    os << "\t- " << edge << '\n';
+        constexpr bool within_context = true;
+        for (const auto& vertex : this->vertices()) {
+            os << "- " << vertex << "\n  adjacent edges:\n";
+            for (const auto& edge : this->_impl.adjacent_edges(vertex.id())) {
+                os << "\t- ";
+                edge._write(os, within_context);
+                os << '\n';
             }
         }
     }
@@ -479,25 +469,11 @@ private:
             "{} {} {}\n", _directed_type_str(), this->n_vertices(), this->n_unique_edges()
         );
 
-        if (io::is_option_set(os, io::option::with_vertex_properties)) {
-            /*
-            after each vertex disable the with_vertex_properties option so that
-            the vertex properties are not printed with the adjacent edges
-            */
-            for (const auto& vertex : this->vertices()) {
-                os << "- " << vertex << " :" << io::without_vertex_properties;
-                for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
-                    os << ' ' << edge;
-                os << '\n' << io::with_vertex_properties;
-            }
-        }
-        else {
-            for (const auto& vertex : this->vertices()) {
-                os << "- " << vertex << " :";
-                for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
-                    os << ' ' << edge;
-                os << '\n';
-            }
+        for (const auto& vertex : this->vertices()) {
+            os << "- " << vertex << " :";
+            for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
+                os << ' ' << edge;
+            os << '\n';
         }
     }
 

--- a/include/gl/io.hpp
+++ b/include/gl/io.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
 #include "io/format.hpp"
-#include "io/handlers.hpp"
 #include "io/options.hpp"
+#include "io/stream_options_manipulator.hpp"

--- a/include/gl/io/handlers.hpp
+++ b/include/gl/io/handlers.hpp
@@ -11,6 +11,8 @@ using index_type = int;
 using iword_type = long;
 using bit_position_type = unsigned;
 
+inline constexpr iword_type iword_bit = 1ul;
+
 namespace detail {
 
 template <typename T>
@@ -23,22 +25,22 @@ class stream_option_manipulator {
 public:
     stream_option_manipulator() = delete;
 
-    explicit stream_option_manipulator(bit_position_type bit_position, bool operation = set)
-    : _bit_position(bit_position), _operation(operation) {}
+    explicit stream_option_manipulator(iword_type bitmask, bool operation = set)
+    : _bitmask(bitmask), _operation(operation) {}
 
-    template <detail::c_bit_position_enum BitPosition>
-    explicit stream_option_manipulator(BitPosition bit_position, bool operation = set)
-    : _bit_position(_get_bit_position_value(bit_position)), _operation(operation) {}
+    [[nodiscard]] gl_attr_force_inline static stream_option_manipulator from_bit_position(
+        bit_position_type bit_position, bool operation = set
+    ) {
+        return stream_option_manipulator{iword_bit << bit_position, operation};
+    }
 
     friend std::ostream& operator<<(
         std::ostream& os, const stream_option_manipulator& property_manipulator
     ) {
         if (property_manipulator._operation == set)
-            os.iword(_iostream_property_map_index()) |=
-                (_iword_bit << property_manipulator._bit_position);
+            os.iword(_iostream_property_map_index()) |= property_manipulator._bitmask;
         else
-            os.iword(_iostream_property_map_index()) &=
-                ~(_iword_bit << property_manipulator._bit_position);
+            os.iword(_iostream_property_map_index()) &= ~property_manipulator._bitmask;
 
         return os;
     }
@@ -47,11 +49,9 @@ public:
         std::istream& is, const stream_option_manipulator& property_manipulator
     ) {
         if (property_manipulator._operation == set)
-            is.iword(_iostream_property_map_index()) |=
-                (_iword_bit << property_manipulator._bit_position);
+            is.iword(_iostream_property_map_index()) |= property_manipulator._bitmask;
         else
-            is.iword(_iostream_property_map_index()) &=
-                ~(_iword_bit << property_manipulator._bit_position);
+            is.iword(_iostream_property_map_index()) &= ~property_manipulator._bitmask;
 
         return is;
     }
@@ -59,16 +59,13 @@ public:
     [[nodiscard]] gl_attr_force_inline static bool is_option_set(
         std::ios_base& stream, bit_position_type bit_position
     ) {
-        return (stream.iword(_iostream_property_map_index()) & (_iword_bit << bit_position)) != 0;
+        return (stream.iword(_iostream_property_map_index()) & (iword_bit << bit_position)) != 0;
     }
 
-    template <detail::c_bit_position_enum BitPosition>
-    [[nodiscard]] gl_attr_force_inline static bool is_option_set(
-        std::ios_base& stream, BitPosition bit_position
+    [[nodiscard]] gl_attr_force_inline static bool are_options_set(
+        std::ios_base& stream, iword_type bitmask
     ) {
-        return (stream.iword(_iostream_property_map_index())
-                & (_iword_bit << _get_bit_position_value(bit_position)))
-            != 0;
+        return (stream.iword(_iostream_property_map_index()) & bitmask) == bitmask;
     }
 
     static constexpr bool set = true;
@@ -80,38 +77,111 @@ private:
         return index;
     }
 
-    template <detail::c_bit_position_enum BitPosition>
-    [[nodiscard]] gl_attr_force_inline static bit_position_type _get_bit_position_value(
-        BitPosition bit_position
-    ) {
-        return static_cast<bit_position_type>(util::to_underlying(bit_position));
-    }
-
-    static constexpr iword_type _iword_bit = 1ul;
-
-    bit_position_type _bit_position;
+    iword_type _bitmask;
     bool _operation;
 };
 
+namespace detail {
+
+[[nodiscard]] inline iword_type get_options_bitmask(const std::initializer_list<bit_position_type>& bit_positions) {
+    iword_type options_bitmask = 0ul;
+    for (const auto bit_position : bit_positions)
+        options_bitmask |= iword_bit << bit_position;
+    return options_bitmask;
+}
+
+template <detail::c_bit_position_enum BitPosition>
+[[nodiscard]] iword_type get_options_bitmask(const std::initializer_list<BitPosition>& bit_positions) {
+    iword_type options_bitmask = 0ul;
+    for (const auto bit_position : bit_positions)
+        options_bitmask |= iword_bit << static_cast<bit_position_type>(util::to_underlying(bit_position));
+    return options_bitmask;
+}
+
+} // namespace detail
+
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(iword_type bitmask) {
+    return stream_option_manipulator{bitmask, stream_option_manipulator::set};
+}
+
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(
+    const std::initializer_list<bit_position_type>& bit_positions
+) {
+    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::set};
+}
+
+template <detail::c_bit_position_enum BitPosition>
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(
+    const std::initializer_list<BitPosition>& bit_positions
+) {
+    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::set};
+}
+
 [[nodiscard]] gl_attr_force_inline stream_option_manipulator
 set_option(bit_position_type bit_position) {
-    return stream_option_manipulator{bit_position, stream_option_manipulator::set};
+    return stream_option_manipulator::from_bit_position(
+        bit_position, stream_option_manipulator::set
+    );
 }
 
 template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline stream_option_manipulator set_option(BitPosition bit_position) {
-    return stream_option_manipulator{bit_position, stream_option_manipulator::set};
+    return stream_option_manipulator::from_bit_position(
+        static_cast<bit_position_type>(util::to_underlying(bit_position)),
+        stream_option_manipulator::set
+    );
+}
+
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(iword_type bitmask) {
+    return stream_option_manipulator{bitmask, stream_option_manipulator::unset};
+}
+
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(
+    const std::initializer_list<bit_position_type>& bit_positions
+) {
+    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::unset};
+}
+
+template <detail::c_bit_position_enum BitPosition>
+[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(
+    const std::initializer_list<BitPosition>& bit_positions
+) {
+    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::unset};
 }
 
 [[nodiscard]] gl_attr_force_inline stream_option_manipulator
 unset_option(bit_position_type bit_position) {
-    return stream_option_manipulator{bit_position, stream_option_manipulator::unset};
+    return stream_option_manipulator::from_bit_position(
+        bit_position, stream_option_manipulator::unset
+    );
 }
 
 template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_option(BitPosition bit_position
 ) {
-    return stream_option_manipulator{bit_position, stream_option_manipulator::unset};
+    return stream_option_manipulator::from_bit_position(
+        static_cast<bit_position_type>(util::to_underlying(bit_position)),
+        stream_option_manipulator::unset
+    );
+}
+
+[[nodiscard]] gl_attr_force_inline bool are_option_set(
+    std::ios_base& stream, iword_type bitmask
+) {
+    return stream_option_manipulator::are_options_set(stream, bitmask);
+}
+
+[[nodiscard]] gl_attr_force_inline bool are_option_set(
+    std::ios_base& stream, const std::initializer_list<bit_position_type>& bit_positions
+) {
+    return stream_option_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
+}
+
+template <detail::c_bit_position_enum BitPosition>
+[[nodiscard]] gl_attr_force_inline bool are_option_set(
+    std::ios_base& stream, const std::initializer_list<BitPosition>& bit_positions
+) {
+    return stream_option_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
 }
 
 [[nodiscard]] gl_attr_force_inline bool is_option_set(
@@ -124,7 +194,9 @@ template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline bool is_option_set(
     std::ios_base& stream, BitPosition bit_position
 ) {
-    return stream_option_manipulator::is_option_set(stream, bit_position);
+    return stream_option_manipulator::is_option_set(
+        stream, static_cast<bit_position_type>(util::to_underlying(bit_position))
+    );
 }
 
 } // namespace gl::io

--- a/include/gl/io/options.hpp
+++ b/include/gl/io/options.hpp
@@ -24,6 +24,11 @@ inline const stream_option_manipulator with_edge_properties =
 inline const stream_option_manipulator without_edge_properties =
     unset_option(option::with_edge_properties);
 
+inline const stream_option_manipulator with_properties =
+    set_options({option::with_vertex_properties, option::with_edge_properties});
+inline const stream_option_manipulator without_properties =
+    unset_options({option::with_vertex_properties, option::with_edge_properties});
+
 inline const stream_option_manipulator enable_gsf = set_option(option::gsf);
 inline const stream_option_manipulator disable_gsf = unset_option(option::gsf);
 

--- a/include/gl/io/options.hpp
+++ b/include/gl/io/options.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "handlers.hpp"
+#include "stream_options_manipulator.hpp"
 
 namespace gl::io {
 
@@ -11,25 +11,25 @@ enum class option : bit_position_type {
     gsf = 3ul // graph specification format
 };
 
-inline const stream_option_manipulator verbose = set_option(option::verbose);
-inline const stream_option_manipulator concise = unset_option(option::verbose);
+inline const stream_options_manipulator verbose = set_option(option::verbose);
+inline const stream_options_manipulator concise = unset_option(option::verbose);
 
-inline const stream_option_manipulator with_vertex_properties =
+inline const stream_options_manipulator with_vertex_properties =
     set_option(option::with_vertex_properties);
-inline const stream_option_manipulator without_vertex_properties =
+inline const stream_options_manipulator without_vertex_properties =
     unset_option(option::with_vertex_properties);
 
-inline const stream_option_manipulator with_edge_properties =
+inline const stream_options_manipulator with_edge_properties =
     set_option(option::with_edge_properties);
-inline const stream_option_manipulator without_edge_properties =
+inline const stream_options_manipulator without_edge_properties =
     unset_option(option::with_edge_properties);
 
-inline const stream_option_manipulator with_properties =
+inline const stream_options_manipulator with_properties =
     set_options({option::with_vertex_properties, option::with_edge_properties});
-inline const stream_option_manipulator without_properties =
+inline const stream_options_manipulator without_properties =
     unset_options({option::with_vertex_properties, option::with_edge_properties});
 
-inline const stream_option_manipulator enable_gsf = set_option(option::gsf);
-inline const stream_option_manipulator disable_gsf = unset_option(option::gsf);
+inline const stream_options_manipulator enable_gsf = set_option(option::gsf);
+inline const stream_options_manipulator disable_gsf = unset_option(option::gsf);
 
 } // namespace gl::io

--- a/include/gl/io/stream_options_manipulator.hpp
+++ b/include/gl/io/stream_options_manipulator.hpp
@@ -21,21 +21,21 @@ concept c_bit_position_enum =
 
 } // namespace detail
 
-class stream_option_manipulator {
+class stream_options_manipulator {
 public:
-    stream_option_manipulator() = delete;
+    stream_options_manipulator() = delete;
 
-    explicit stream_option_manipulator(iword_type bitmask, bool operation = set)
+    explicit stream_options_manipulator(iword_type bitmask, bool operation = set)
     : _bitmask(bitmask), _operation(operation) {}
 
-    [[nodiscard]] gl_attr_force_inline static stream_option_manipulator from_bit_position(
+    [[nodiscard]] gl_attr_force_inline static stream_options_manipulator from_bit_position(
         bit_position_type bit_position, bool operation = set
     ) {
-        return stream_option_manipulator{iword_bit << bit_position, operation};
+        return stream_options_manipulator{iword_bit << bit_position, operation};
     }
 
     friend std::ostream& operator<<(
-        std::ostream& os, const stream_option_manipulator& property_manipulator
+        std::ostream& os, const stream_options_manipulator& property_manipulator
     ) {
         if (property_manipulator._operation == set)
             os.iword(_iostream_property_map_index()) |= property_manipulator._bitmask;
@@ -46,7 +46,7 @@ public:
     }
 
     friend std::istream& operator>>(
-        std::istream& is, const stream_option_manipulator& property_manipulator
+        std::istream& is, const stream_options_manipulator& property_manipulator
     ) {
         if (property_manipulator._operation == set)
             is.iword(_iostream_property_map_index()) |= property_manipulator._bitmask;
@@ -100,101 +100,101 @@ template <detail::c_bit_position_enum BitPosition>
 
 } // namespace detail
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(iword_type bitmask) {
-    return stream_option_manipulator{bitmask, stream_option_manipulator::set};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_options(iword_type bitmask) {
+    return stream_options_manipulator{bitmask, stream_options_manipulator::set};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_options(
     const std::initializer_list<bit_position_type>& bit_positions
 ) {
-    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::set};
+    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::set};
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_options(
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_options(
     const std::initializer_list<BitPosition>& bit_positions
 ) {
-    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::set};
+    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::set};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
 set_option(bit_position_type bit_position) {
-    return stream_option_manipulator::from_bit_position(
-        bit_position, stream_option_manipulator::set
+    return stream_options_manipulator::from_bit_position(
+        bit_position, stream_options_manipulator::set
     );
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator set_option(BitPosition bit_position) {
-    return stream_option_manipulator::from_bit_position(
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_option(BitPosition bit_position) {
+    return stream_options_manipulator::from_bit_position(
         static_cast<bit_position_type>(util::to_underlying(bit_position)),
-        stream_option_manipulator::set
+        stream_options_manipulator::set
     );
 }
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(iword_type bitmask) {
-    return stream_option_manipulator{bitmask, stream_option_manipulator::unset};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_options(iword_type bitmask) {
+    return stream_options_manipulator{bitmask, stream_options_manipulator::unset};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_options(
     const std::initializer_list<bit_position_type>& bit_positions
 ) {
-    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::unset};
+    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset};
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_options(
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_options(
     const std::initializer_list<BitPosition>& bit_positions
 ) {
-    return stream_option_manipulator{detail::get_options_bitmask(bit_positions), stream_option_manipulator::unset};
+    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
 unset_option(bit_position_type bit_position) {
-    return stream_option_manipulator::from_bit_position(
-        bit_position, stream_option_manipulator::unset
+    return stream_options_manipulator::from_bit_position(
+        bit_position, stream_options_manipulator::unset
     );
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_option_manipulator unset_option(BitPosition bit_position
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_option(BitPosition bit_position
 ) {
-    return stream_option_manipulator::from_bit_position(
+    return stream_options_manipulator::from_bit_position(
         static_cast<bit_position_type>(util::to_underlying(bit_position)),
-        stream_option_manipulator::unset
+        stream_options_manipulator::unset
     );
 }
 
 [[nodiscard]] gl_attr_force_inline bool are_option_set(
     std::ios_base& stream, iword_type bitmask
 ) {
-    return stream_option_manipulator::are_options_set(stream, bitmask);
+    return stream_options_manipulator::are_options_set(stream, bitmask);
 }
 
 [[nodiscard]] gl_attr_force_inline bool are_option_set(
     std::ios_base& stream, const std::initializer_list<bit_position_type>& bit_positions
 ) {
-    return stream_option_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
+    return stream_options_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
 }
 
 template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline bool are_option_set(
     std::ios_base& stream, const std::initializer_list<BitPosition>& bit_positions
 ) {
-    return stream_option_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
+    return stream_options_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
 }
 
 [[nodiscard]] gl_attr_force_inline bool is_option_set(
     std::ios_base& stream, bit_position_type bit_position
 ) {
-    return stream_option_manipulator::is_option_set(stream, bit_position);
+    return stream_options_manipulator::is_option_set(stream, bit_position);
 }
 
 template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline bool is_option_set(
     std::ios_base& stream, BitPosition bit_position
 ) {
-    return stream_option_manipulator::is_option_set(
+    return stream_options_manipulator::is_option_set(
         stream, static_cast<bit_position_type>(util::to_underlying(bit_position))
     );
 }

--- a/include/gl/io/stream_options_manipulator.hpp
+++ b/include/gl/io/stream_options_manipulator.hpp
@@ -83,7 +83,9 @@ private:
 
 namespace detail {
 
-[[nodiscard]] inline iword_type get_options_bitmask(const std::initializer_list<bit_position_type>& bit_positions) {
+[[nodiscard]] inline iword_type get_options_bitmask(
+    const std::initializer_list<bit_position_type>& bit_positions
+) {
     iword_type options_bitmask = 0ul;
     for (const auto bit_position : bit_positions)
         options_bitmask |= iword_bit << bit_position;
@@ -91,10 +93,12 @@ namespace detail {
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] iword_type get_options_bitmask(const std::initializer_list<BitPosition>& bit_positions) {
+[[nodiscard]] iword_type get_options_bitmask(const std::initializer_list<BitPosition>& bit_positions
+) {
     iword_type options_bitmask = 0ul;
     for (const auto bit_position : bit_positions)
-        options_bitmask |= iword_bit << static_cast<bit_position_type>(util::to_underlying(bit_position));
+        options_bitmask |=
+            iword_bit << static_cast<bit_position_type>(util::to_underlying(bit_position));
     return options_bitmask;
 }
 
@@ -104,17 +108,19 @@ template <detail::c_bit_position_enum BitPosition>
     return stream_options_manipulator{bitmask, stream_options_manipulator::set};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_options(
-    const std::initializer_list<bit_position_type>& bit_positions
-) {
-    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::set};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
+set_options(const std::initializer_list<bit_position_type>& bit_positions) {
+    return stream_options_manipulator{
+        detail::get_options_bitmask(bit_positions), stream_options_manipulator::set
+    };
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_options_manipulator set_options(
-    const std::initializer_list<BitPosition>& bit_positions
-) {
-    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::set};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
+set_options(const std::initializer_list<BitPosition>& bit_positions) {
+    return stream_options_manipulator{
+        detail::get_options_bitmask(bit_positions), stream_options_manipulator::set
+    };
 }
 
 [[nodiscard]] gl_attr_force_inline stream_options_manipulator
@@ -136,17 +142,19 @@ template <detail::c_bit_position_enum BitPosition>
     return stream_options_manipulator{bitmask, stream_options_manipulator::unset};
 }
 
-[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_options(
-    const std::initializer_list<bit_position_type>& bit_positions
-) {
-    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
+unset_options(const std::initializer_list<bit_position_type>& bit_positions) {
+    return stream_options_manipulator{
+        detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset
+    };
 }
 
 template <detail::c_bit_position_enum BitPosition>
-[[nodiscard]] gl_attr_force_inline stream_options_manipulator unset_options(
-    const std::initializer_list<BitPosition>& bit_positions
-) {
-    return stream_options_manipulator{detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset};
+[[nodiscard]] gl_attr_force_inline stream_options_manipulator
+unset_options(const std::initializer_list<BitPosition>& bit_positions) {
+    return stream_options_manipulator{
+        detail::get_options_bitmask(bit_positions), stream_options_manipulator::unset
+    };
 }
 
 [[nodiscard]] gl_attr_force_inline stream_options_manipulator
@@ -165,23 +173,25 @@ template <detail::c_bit_position_enum BitPosition>
     );
 }
 
-[[nodiscard]] gl_attr_force_inline bool are_option_set(
-    std::ios_base& stream, iword_type bitmask
-) {
+[[nodiscard]] gl_attr_force_inline bool are_option_set(std::ios_base& stream, iword_type bitmask) {
     return stream_options_manipulator::are_options_set(stream, bitmask);
 }
 
 [[nodiscard]] gl_attr_force_inline bool are_option_set(
     std::ios_base& stream, const std::initializer_list<bit_position_type>& bit_positions
 ) {
-    return stream_options_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
+    return stream_options_manipulator::are_options_set(
+        stream, detail::get_options_bitmask(bit_positions)
+    );
 }
 
 template <detail::c_bit_position_enum BitPosition>
 [[nodiscard]] gl_attr_force_inline bool are_option_set(
     std::ios_base& stream, const std::initializer_list<BitPosition>& bit_positions
 ) {
-    return stream_options_manipulator::are_options_set(stream, detail::get_options_bitmask(bit_positions));
+    return stream_options_manipulator::are_options_set(
+        stream, detail::get_options_bitmask(bit_positions)
+    );
 }
 
 [[nodiscard]] gl_attr_force_inline bool is_option_set(

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -58,40 +58,38 @@ public:
 
     [[no_unique_address]] mutable properties_type properties{};
 
-    friend std::ostream& operator<<(std::ostream& os, const vertex_descriptor& vertex) {
-        if constexpr (type_traits::c_writable<properties_type>) {
-            vertex._print_with_properties(os);
-        }
-        else {
-            vertex._print(os);
-        }
-
+    friend inline std::ostream& operator<<(std::ostream& os, const vertex_descriptor& vertex) {
+        vertex._write(os);
         return os;
     }
 
 private:
-    void _print(std::ostream& os) const {
+    void _write(std::ostream& os) const {
+        if constexpr (not type_traits::c_writable<properties_type>) {
+            this->_write_no_properties(os);
+            return;
+        }
+        else {
+            if (not io::is_option_set(os, io::option::with_vertex_properties)) {
+                this->_write_no_properties(os);
+                return;
+            }
+
+            if (io::is_option_set(os, io::option::verbose)) {
+                os << "[id: " << this->_id << " | properties: " << this->properties << "]";
+            }
+            else {
+                os << "[" << this->_id << " | " << this->properties << "]";
+            }
+        }
+    }
+
+    void _write_no_properties(std::ostream& os) const {
         if (io::is_option_set(os, io::option::verbose)) {
             os << std::format("[id: {}]", this->_id);
         }
         else {
             os << this->_id;
-        }
-    }
-
-    void _print_with_properties(std::ostream& os) const
-    requires(type_traits::c_writable<properties_type>)
-    {
-        if (not io::is_option_set(os, io::option::with_vertex_properties)) {
-            this->_print(os);
-            return;
-        }
-
-        if (io::is_option_set(os, io::option::verbose)) {
-            os << "[id: " << this->_id << " | properties: " << this->properties << "]";
-        }
-        else {
-            os << "[" << this->_id << " | " << this->properties << "]";
         }
     }
 

--- a/tests/source/test_stream_options_manipulator.cpp
+++ b/tests/source/test_stream_options_manipulator.cpp
@@ -1,6 +1,6 @@
 #include "constants.hpp"
 
-#include <gl/io/handlers.hpp>
+#include <gl/io/stream_options_manipulator.hpp>
 
 #include <doctest.h>
 
@@ -8,10 +8,10 @@
 
 namespace gl_testing {
 
-TEST_SUITE_BEGIN("test_io_handlers");
+TEST_SUITE_BEGIN("test_stream_options_manipulator");
 
-struct test_io_handlers {
-    test_io_handlers() {
+struct test_stream_options_manipulator {
+    test_stream_options_manipulator() {
         REQUIRE_FALSE(lib::io::is_option_set(ss1, property_bit_position));
         REQUIRE_FALSE(lib::io::is_option_set(ss2, property_bit_position));
     }
@@ -23,7 +23,7 @@ struct test_io_handlers {
 };
 
 TEST_CASE_FIXTURE(
-    test_io_handlers, "stream_option_manipulator should properly handle istream property operations"
+    test_stream_options_manipulator, "stream_options_manipulator should properly handle istream property operations"
 ) {
     ss1 >> lib::io::set_option(property_bit_position);
     CHECK(lib::io::is_option_set(ss1, property_bit_position));
@@ -43,7 +43,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_io_handlers, "stream_option_manipulator should properly handle ostream property operations"
+    test_stream_options_manipulator, "stream_options_manipulator should properly handle ostream property operations"
 ) {
     ss1 << lib::io::set_option(property_bit_position);
     CHECK(lib::io::is_option_set(ss1, property_bit_position));
@@ -62,6 +62,6 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(lib::io::is_option_set(ss2, property_bit_position));
 }
 
-TEST_SUITE_END(); // test_io_handlers
+TEST_SUITE_END(); // test_stream_options_manipulator
 
 } // namespace gl_testing

--- a/tests/source/test_stream_options_manipulator.cpp
+++ b/tests/source/test_stream_options_manipulator.cpp
@@ -26,8 +26,7 @@ struct test_stream_options_manipulator {
 };
 
 TEST_CASE_FIXTURE(
-    test_stream_options_manipulator,
-    "should properly handle istream option operations per stream"
+    test_stream_options_manipulator, "should properly handle istream option operations per stream"
 ) {
     ss1 >> lib::io::set_option(bit_position_1);
     CHECK(lib::io::is_option_set(ss1, bit_position_1));
@@ -47,8 +46,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_stream_options_manipulator,
-    "should properly handle ostream option operations per stream"
+    test_stream_options_manipulator, "should properly handle ostream option operations per stream"
 ) {
     ss1 << lib::io::set_option(bit_position_1);
     CHECK(lib::io::is_option_set(ss1, bit_position_1));

--- a/tests/source/test_stream_options_manipulator.cpp
+++ b/tests/source/test_stream_options_manipulator.cpp
@@ -12,54 +12,156 @@ TEST_SUITE_BEGIN("test_stream_options_manipulator");
 
 struct test_stream_options_manipulator {
     test_stream_options_manipulator() {
-        REQUIRE_FALSE(lib::io::is_option_set(ss1, property_bit_position));
-        REQUIRE_FALSE(lib::io::is_option_set(ss2, property_bit_position));
+        REQUIRE_FALSE(lib::io::is_option_set(ss1, bit_position_1));
+        REQUIRE_FALSE(lib::io::is_option_set(ss2, bit_position_1));
     }
 
     std::stringstream ss1;
     std::stringstream ss2;
 
-    const lib::io::bit_position_type property_bit_position = constants::first_element_idx;
+    static constexpr lib::io::bit_position_type bit_position_1 = constants::first_element_idx;
+    static constexpr lib::io::bit_position_type bit_position_2 = bit_position_1 + constants::one;
+    static constexpr lib::io::iword_type options_bitmask =
+        (lib::io::iword_bit << bit_position_1) | (lib::io::iword_bit << bit_position_2);
 };
 
 TEST_CASE_FIXTURE(
-    test_stream_options_manipulator, "stream_options_manipulator should properly handle istream property operations"
+    test_stream_options_manipulator,
+    "should properly handle istream option operations per stream"
 ) {
-    ss1 >> lib::io::set_option(property_bit_position);
-    CHECK(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK_FALSE(lib::io::is_option_set(ss2, property_bit_position));
+    ss1 >> lib::io::set_option(bit_position_1);
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK_FALSE(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss2 >> lib::io::set_option(property_bit_position);
-    CHECK(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK(lib::io::is_option_set(ss2, property_bit_position));
+    ss2 >> lib::io::set_option(bit_position_1);
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss1 >> lib::io::unset_option(property_bit_position);
-    CHECK_FALSE(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK(lib::io::is_option_set(ss2, property_bit_position));
+    ss1 >> lib::io::unset_option(bit_position_1);
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss2 >> lib::io::unset_option(property_bit_position);
-    CHECK_FALSE(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK_FALSE(lib::io::is_option_set(ss2, property_bit_position));
+    ss2 >> lib::io::unset_option(bit_position_1);
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK_FALSE(lib::io::is_option_set(ss2, bit_position_1));
 }
 
 TEST_CASE_FIXTURE(
-    test_stream_options_manipulator, "stream_options_manipulator should properly handle ostream property operations"
+    test_stream_options_manipulator,
+    "should properly handle ostream option operations per stream"
 ) {
-    ss1 << lib::io::set_option(property_bit_position);
-    CHECK(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK_FALSE(lib::io::is_option_set(ss2, property_bit_position));
+    ss1 << lib::io::set_option(bit_position_1);
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK_FALSE(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss2 << lib::io::set_option(property_bit_position);
-    CHECK(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK(lib::io::is_option_set(ss2, property_bit_position));
+    ss2 << lib::io::set_option(bit_position_1);
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss1 << lib::io::unset_option(property_bit_position);
-    CHECK_FALSE(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK(lib::io::is_option_set(ss2, property_bit_position));
+    ss1 << lib::io::unset_option(bit_position_1);
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::is_option_set(ss2, bit_position_1));
 
-    ss2 << lib::io::unset_option(property_bit_position);
-    CHECK_FALSE(lib::io::is_option_set(ss1, property_bit_position));
-    CHECK_FALSE(lib::io::is_option_set(ss2, property_bit_position));
+    ss2 << lib::io::unset_option(bit_position_1);
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK_FALSE(lib::io::is_option_set(ss2, bit_position_1));
+}
+
+enum class BitPositionEnum : lib::io::bit_position_type {
+    bit_position_1 = test_stream_options_manipulator::bit_position_1,
+    bit_position_2 = test_stream_options_manipulator::bit_position_2
+};
+
+TEST_CASE_FIXTURE(
+    test_stream_options_manipulator,
+    "should properly handle istream option operations for bit position lists"
+) {
+    const auto bit_positions = {bit_position_1, bit_position_2};
+
+    ss1 >> lib::io::set_options(bit_positions);
+    CHECK(lib::io::are_option_set(ss1, bit_positions));
+    CHECK(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 >> lib::io::unset_options(bit_positions);
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 >> lib::io::set_options({bit_position_1});
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::are_option_set(ss1, {bit_position_1}));
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_2));
+    CHECK_FALSE(lib::io::are_option_set(ss1, {bit_position_2}));
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+}
+
+TEST_CASE_FIXTURE(
+    test_stream_options_manipulator,
+    "should properly handle osream option operations for bit position lists"
+) {
+    const auto bit_positions = {bit_position_1, bit_position_2};
+
+    ss1 << lib::io::set_options(bit_positions);
+    CHECK(lib::io::are_option_set(ss1, bit_positions));
+    CHECK(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 << lib::io::unset_options(bit_positions);
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 << lib::io::set_options({bit_position_1});
+    CHECK(lib::io::is_option_set(ss1, bit_position_1));
+    CHECK(lib::io::are_option_set(ss1, {bit_position_1}));
+    CHECK_FALSE(lib::io::is_option_set(ss1, bit_position_2));
+    CHECK_FALSE(lib::io::are_option_set(ss1, {bit_position_2}));
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+}
+
+TEST_CASE_FIXTURE(
+    test_stream_options_manipulator,
+    "should properly handle istream option operations for enum bit position lists"
+) {
+    const auto bit_positions = {BitPositionEnum::bit_position_1, BitPositionEnum::bit_position_2};
+
+    ss1 >> lib::io::set_options(bit_positions);
+    CHECK(lib::io::are_option_set(ss1, bit_positions));
+    CHECK(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 >> lib::io::unset_options(bit_positions);
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 >> lib::io::set_options({BitPositionEnum::bit_position_1});
+    CHECK(lib::io::is_option_set(ss1, BitPositionEnum::bit_position_1));
+    CHECK(lib::io::are_option_set(ss1, {BitPositionEnum::bit_position_1}));
+    CHECK_FALSE(lib::io::is_option_set(ss1, BitPositionEnum::bit_position_2));
+    CHECK_FALSE(lib::io::are_option_set(ss1, {BitPositionEnum::bit_position_2}));
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+}
+
+TEST_CASE_FIXTURE(
+    test_stream_options_manipulator,
+    "should properly handle ostream option operations for enum bit position lists"
+) {
+    const auto bit_positions = {BitPositionEnum::bit_position_1, BitPositionEnum::bit_position_2};
+
+    ss1 << lib::io::set_options(bit_positions);
+    CHECK(lib::io::are_option_set(ss1, bit_positions));
+    CHECK(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 << lib::io::unset_options(bit_positions);
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
+
+    ss1 << lib::io::set_options({BitPositionEnum::bit_position_1});
+    CHECK(lib::io::is_option_set(ss1, BitPositionEnum::bit_position_1));
+    CHECK(lib::io::are_option_set(ss1, {BitPositionEnum::bit_position_1}));
+    CHECK_FALSE(lib::io::is_option_set(ss1, BitPositionEnum::bit_position_2));
+    CHECK_FALSE(lib::io::are_option_set(ss1, {BitPositionEnum::bit_position_2}));
+    CHECK_FALSE(lib::io::are_option_set(ss1, bit_positions));
+    CHECK_FALSE(lib::io::are_option_set(ss1, options_bitmask));
 }
 
 TEST_SUITE_END(); // test_stream_options_manipulator


### PR DESCRIPTION
- Modified the `stream_options_manipulator` class to work with bitmasks instead of single bit positions
- Renamed `io/handlers` to `io/stream_options_manipulator`
- Added the `with_properties` and `without_properties` stream options manipulators
- Added the `within_context` parameter to the `edge_descriptor::_write*` methods
- Aligned the `graph` class to use `edge_descriptor::_write(within_context = true)` instead of the ostream operator