### PR TITLE
YT-CPPGL-44: Add vertex degree obtaining functionality

### DIFF
--- a/include/gl/decl/graph_traits.hpp
+++ b/include/gl/decl/graph_traits.hpp
@@ -9,8 +9,7 @@ template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag,
     type_traits::c_properties VertexProperties,
     type_traits::c_properties EdgeProperties,
-    type_traits::c_graph_impl_tag ImplTag,
-    type_traits::c_cache_mode VDegCacheMode>
+    type_traits::c_graph_impl_tag ImplTag>
 struct graph_traits;
 
 } // namespace gl

--- a/include/gl/decl/graph_traits.hpp
+++ b/include/gl/decl/graph_traits.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "gl/types/type_traits.hpp"
+#include "impl_tags.hpp"
+
+namespace gl {
+
+template <
+    type_traits::c_edge_directional_tag EdgeDirectionalTag,
+    type_traits::c_properties VertexProperties,
+    type_traits::c_properties EdgeProperties,
+    type_traits::c_graph_impl_tag ImplTag,
+    type_traits::c_cache_mode VDegCacheMode>
+struct graph_traits;
+
+} // namespace gl

--- a/include/gl/decl/impl_tags.hpp
+++ b/include/gl/decl/impl_tags.hpp
@@ -20,11 +20,4 @@ concept c_graph_impl_tag = c_one_of<T, impl::list_t, impl::matrix_t>;
 
 } // namespace type_traits
 
-template <
-    type_traits::c_edge_directional_tag EdgeDirectionalTag,
-    type_traits::c_properties VertexProperties,
-    type_traits::c_properties EdgeProperties,
-    type_traits::c_graph_impl_tag ImplTag>
-struct graph_traits;
-
 } // namespace gl

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -94,9 +94,9 @@ public:
         if (&vertex == &this->_vertices.second)
             return this->_vertices.first;
 
-        throw std::invalid_argument(
-            std::format("Got invalid vertex [id = {} | addr = ]", vertex.id(), io::format(&vertex))
-        );
+        throw std::invalid_argument(std::format(
+            "Got invalid vertex [id = {} | addr = {}]", vertex.id(), io::format(&vertex)
+        ));
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_type& vertex) const {

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -15,13 +15,6 @@
 namespace gl {
 
 template <
-    type_traits::c_edge_directional_tag EdgeDirectionalTag,
-    type_traits::c_properties VertexProperties,
-    type_traits::c_properties EdgeProperties,
-    type_traits::c_graph_impl_tag ImplTag>
-struct graph_traits;
-
-template <
     type_traits::c_instantiation_of<vertex_descriptor> VertexType,
     type_traits::c_edge_directional_tag DirectionalTag = directed_t,
     type_traits::c_properties Properties = types::empty_properties>

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -176,32 +176,36 @@ public:
             this->_remove_vertex_impl(vertex_ref.get());
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) {
+    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) const {
         this->_verify_vertex(vertex);
         return this->_impl.in_degree(vertex);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id) {
+    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id
+    ) const {
         return this->_impl.in_degree(this->get_vertex(vertex_id));
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex) {
+    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex
+    ) const {
         this->_verify_vertex(vertex);
         return this->_impl.out_degree(vertex);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const types::id_type vertex_id) {
+    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const types::id_type vertex_id
+    ) const {
         return this->_impl.out_degree(this->get_vertex(vertex_id));
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const vertex_type& vertex) {
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const vertex_type& vertex) const {
         if constexpr (type_traits::is_directed_v<edge_type>)
             return this->_impl.in_degree(vertex) + this->_impl.out_degree(vertex);
         else
             return this->out_degree(vertex);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id) {
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
+    ) const {
         if constexpr (type_traits::is_directed_v<edge_type>) {
             const auto& vertex = this->get_vertex(vertex_id);
             return this->_impl.in_degree(vertex) + this->_impl.out_degree(vertex);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -30,6 +30,8 @@ public:
     using vertex_iterator_type =
         types::dereferencing_iterator<typename vetex_list_type::const_iterator>;
 
+    using vertex_degree_cache_mode = typename traits_type::vertex_degree_cache_mode;
+
     // TODO: reverese iterators should be available for bidirectional ranges
 
     using edge_type = typename traits_type::edge_type;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -598,6 +598,17 @@ private:
 
     vetex_list_type _vertices{};
     implementation_type _impl{};
+
+    using vdeg_list_type = std::conditional_t<
+        vertex_degree_cache_mode::value == type_traits::cache_mode_value::none,
+        std::monostate,
+        std::conditional_t<
+            vertex_degree_cache_mode::value == type_traits::cache_mode_value::lazy,
+            std::vector<std::optional<types::size_type>>,
+            std::vector<types::size_type>>>;
+
+    [[no_unique_address]] mutable vdeg_list_type _vertex_in_deg_list{};
+    [[no_unique_address]] mutable vdeg_list_type _vertex_out_deg_list{};
 };
 
 namespace type_traits {

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -1,10 +1,22 @@
 #pragma once
 
+#include "decl/graph_traits.hpp"
+#include "decl/impl_tags.hpp"
 #include "edge_descriptor.hpp"
-#include "gl/impl/impl_tags_decl.hpp"
+#include "types/traits/cache_mode.hpp"
 #include "vertex_descriptor.hpp"
 
 #include <memory>
+
+#if defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_EAGER)
+#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::eager_cache
+#elif defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_LAZY)
+#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
+#elif defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_NONE)
+#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::no_cache
+#else
+#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
+#endif
 
 namespace gl {
 
@@ -12,7 +24,8 @@ template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
+    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
 struct graph_traits {
     using vertex_type = vertex_descriptor<VertexProperties>;
     using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
@@ -39,6 +52,19 @@ template <
     type_traits::c_properties EdgeProperties = types::empty_properties>
 using matrix_graph_traits =
     graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t>;
+
+template <
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
+using directed_graph_traits = graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag>;
+
+template <
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
+using undirected_graph_traits =
+    graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;
 
 namespace type_traits {
 

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -30,6 +30,7 @@ struct graph_traits {
     using vertex_type = vertex_descriptor<VertexProperties>;
     using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
+    using vertex_degree_cache_mode = VDegCacheMode;
 
     using edge_type = edge_descriptor<vertex_type, EdgeDirectionalTag, EdgeProperties>;
     using edge_ptr_type = types::edge_ptr_type<edge_type>;
@@ -42,29 +43,34 @@ struct graph_traits {
 template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties>
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
 using list_graph_traits =
-    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::list_t>;
+    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::list_t, VDegCacheMode>;
 
 template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties>
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
 using matrix_graph_traits =
-    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t>;
+    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t, VDegCacheMode>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
-using directed_graph_traits = graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag>;
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
+    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
+using directed_graph_traits =
+    graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag, VDegCacheMode>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
+    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
 using undirected_graph_traits =
-    graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;
+    graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag, VDegCacheMode>;
 
 namespace type_traits {
 

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -8,29 +8,17 @@
 
 #include <memory>
 
-#if defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_EAGER)
-#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::eager_cache
-#elif defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_LAZY)
-#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
-#elif defined(GL_CONFIG_VDEG_DEFAULT_CACHE_MODE_NONE)
-#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::no_cache
-#else
-#define _GL_VDEG_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
-#endif
-
 namespace gl {
 
 template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
-    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
 struct graph_traits {
     using vertex_type = vertex_descriptor<VertexProperties>;
     using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
-    using vertex_degree_cache_mode = VDegCacheMode;
 
     using edge_type = edge_descriptor<vertex_type, EdgeDirectionalTag, EdgeProperties>;
     using edge_ptr_type = types::edge_ptr_type<edge_type>;
@@ -43,34 +31,29 @@ struct graph_traits {
 template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
+    type_traits::c_properties EdgeProperties = types::empty_properties>
 using list_graph_traits =
-    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::list_t, VDegCacheMode>;
+    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::list_t>;
 
 template <
     type_traits::c_edge_directional_tag EdgeDirectionalTag = directed_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
+    type_traits::c_properties EdgeProperties = types::empty_properties>
 using matrix_graph_traits =
-    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t, VDegCacheMode>;
+    graph_traits<EdgeDirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
-    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
-using directed_graph_traits =
-    graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag, VDegCacheMode>;
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
+using directed_graph_traits = graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties EdgeProperties = types::empty_properties,
-    type_traits::c_graph_impl_tag ImplTag = impl::list_t,
-    type_traits::c_cache_mode VDegCacheMode = _GL_VDEG_DEFAULT_CACHE_MODE>
+    type_traits::c_graph_impl_tag ImplTag = impl::list_t>
 using undirected_graph_traits =
-    graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag, VDegCacheMode>;
+    graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;
 
 namespace type_traits {
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -62,6 +62,15 @@ public:
             this->_list.push_back(edge_list_type{});
     }
 
+    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) const {
+        return specialized_impl::in_degree(*this, vertex);
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex
+    ) const {
+        return this->_list[vertex.id()].size();
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         specialized_impl::remove_vertex(*this, vertex);
     }

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -81,6 +81,21 @@ public:
         }
     }
 
+    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) const {
+        return std::ranges::count_if(
+            this->_matrix,
+            [](const auto& edge) { return edge != nullptr; },
+            [col = vertex.id()](const auto& row) -> const edge_ptr_type& { return row[col]; }
+        );
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex
+    ) const {
+        return std::ranges::count_if(this->_matrix[vertex.id()], [](const auto& edge) {
+            return edge != nullptr;
+        });
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         specialized_impl::remove_vertex(*this, vertex);
     }

--- a/include/gl/impl/impl_tags.hpp
+++ b/include/gl/impl/impl_tags.hpp
@@ -2,7 +2,7 @@
 
 #include "adjacency_list.hpp"
 #include "adjacency_matrix.hpp"
-#include "impl_tags_decl.hpp"
+#include "gl/decl/impl_tags.hpp"
 
 namespace gl {
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -57,6 +57,25 @@ struct directed_adjacency_list {
         }
     };
 
+    [[nodiscard]] static types::size_type in_degree(
+        const impl_type& self, const vertex_type& vertex
+    ) {
+        types::size_type in_deg = constants::default_size;
+        const auto vertex_id = vertex.id();
+
+        for (types::id_type i = constants::initial_id; i < self._list.size(); i++) {
+            const auto& adj_edges = self._list[i];
+            if (adj_edges.empty())
+                continue;
+
+            in_deg += std::ranges::count(adj_edges, vertex_id, [](const auto& edge) {
+                return edge->second_id();
+            });
+        }
+
+        return in_deg;
+    }
+
     static void remove_vertex(impl_type& self, const vertex_type& vertex) {
         const auto vertex_id = vertex.id();
 
@@ -135,6 +154,12 @@ struct undirected_adjacency_list {
             return edge.get();
         }
     };
+
+    [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
+        const impl_type& self, const vertex_type& vertex
+    ) {
+        return self._list[vertex.id()].size();
+    }
 
     static void remove_vertex(impl_type& self, const vertex_type& vertex) {
         const auto vertex_id = vertex.id();

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gl/impl/impl_tags_decl.hpp"
+#include "gl/decl/impl_tags.hpp"
 
 #include <algorithm>
 #include <format>

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "gl/impl/impl_tags_decl.hpp"
+#include "gl/decl/impl_tags.hpp"
 
 #include <algorithm>
 

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -7,15 +7,13 @@
 #include <format>
 #include <iterator>
 
-#ifdef GL_CONFIG_IT_RANGE_DEFAULT_CACHE_MODE_EAGER
+#if defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_MODE_EAGER)
 #define _GL_IT_RANGE_DEFAULT_CACHE_MODE gl::type_traits::eager_cache
 #elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_MODE_LAZY)
 #define _GL_IT_RANGE_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
 #elif defined(GL_CONFIG_IT_RANGE_DEFAULT_CACHE_MODE_NONE)
 #define _GL_IT_RANGE_DEFAULT_CACHE_MODE gl::type_traits::no_cache
-#endif
-
-#ifndef _GL_IT_RANGE_DEFAULT_CACHE_MODE
+#else
 #define _GL_IT_RANGE_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
 #endif
 

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "attributes/force_inline.hpp"
+#include "decl/graph_traits.hpp"
 #include "edge_tags.hpp"
 #include "graph_io.hpp"
-#include "impl/impl_tags_decl.hpp"
 #include "types/properties.hpp"
 #include "types/type_traits.hpp"
 #include "types/types.hpp"
@@ -12,13 +12,6 @@
 #include <format>
 
 namespace gl {
-
-template <
-    type_traits::c_edge_directional_tag EdgeDirectionalTag,
-    type_traits::c_properties VertexProperties,
-    type_traits::c_properties EdgeProperties,
-    type_traits::c_graph_impl_tag ImplTag>
-struct graph_traits;
 
 template <type_traits::c_properties Properties = types::empty_properties>
 class vertex_descriptor {

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -8,6 +8,7 @@
 #include <doctest.h>
 
 #include <algorithm>
+#include <functional>
 
 namespace gl_testing {
 
@@ -290,6 +291,38 @@ TEST_CASE_FIXTURE(
             adjacent_edges, &edge_to_remove, transforms::address_projection<edge_type>{}
         ),
         adjacent_edges.end()
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
+) {
+    initialize_full_graph();
+
+    std::function<lib_t::size_type(const vertex_type&)> deg_proj;
+
+    SUBCASE("in_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.in_degree(vertex); };
+    }
+
+    SUBCASE("out_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.out_degree(vertex); };
+    }
+
+    CAPTURE(deg_proj);
+
+    CHECK(std::ranges::all_of(
+        vertices,
+        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+        deg_proj
+    ));
+
+    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+
+    CHECK_EQ(
+        deg_proj(vertices[constants::vertex_id_1]),
+        n_incident_edges_for_fully_connected_vertex + constants::one
     );
 }
 
@@ -585,6 +618,38 @@ TEST_CASE_FIXTURE(
             adjacent_edges_second, &edge_to_remove, transforms::address_projection<edge_type>{}
         ),
         adjacent_edges_second.end()
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
+) {
+    initialize_full_graph();
+
+    std::function<lib_t::size_type(const vertex_type&)> deg_proj;
+
+    SUBCASE("in_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.in_degree(vertex); };
+    }
+
+    SUBCASE("out_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.out_degree(vertex); };
+    }
+
+    CAPTURE(deg_proj);
+
+    CHECK(std::ranges::all_of(
+        vertices,
+        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+        deg_proj
+    ));
+
+    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+
+    CHECK_EQ(
+        deg_proj(vertices[constants::vertex_id_1]),
+        n_incident_edges_for_fully_connected_vertex + constants::one
     );
 }
 

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -292,6 +292,38 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
+    "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
+) {
+    initialize_full_graph();
+
+    std::function<lib_t::size_type(const vertex_type&)> deg_proj;
+
+    SUBCASE("in_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.in_degree(vertex); };
+    }
+
+    SUBCASE("out_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.out_degree(vertex); };
+    }
+
+    CAPTURE(deg_proj);
+
+    CHECK(std::ranges::all_of(
+        vertices,
+        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+        deg_proj
+    ));
+
+    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+
+    CHECK_EQ(
+        deg_proj(vertices[constants::vertex_id_1]),
+        n_incident_edges_for_fully_connected_vertex + constants::one
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
     initialize_full_graph();
@@ -525,6 +557,38 @@ TEST_CASE_FIXTURE(
             adjacent_edges_second, &edge_to_remove, transforms::address_projection<edge_type>{}
         ),
         adjacent_edges_second.end()
+    );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
+) {
+    initialize_full_graph();
+
+    std::function<lib_t::size_type(const vertex_type&)> deg_proj;
+
+    SUBCASE("in_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.in_degree(vertex); };
+    }
+
+    SUBCASE("out_degree") {
+        deg_proj = [this](const auto& vertex) { return sut.out_degree(vertex); };
+    }
+
+    CAPTURE(deg_proj);
+
+    CHECK(std::ranges::all_of(
+        vertices,
+        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+        deg_proj
+    ));
+
+    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+
+    CHECK_EQ(
+        deg_proj(vertices[constants::vertex_id_1]),
+        n_incident_edges_for_fully_connected_vertex + constants::one
     );
 }
 

--- a/tests/source/test_vertex_degree_getters.cpp
+++ b/tests/source/test_vertex_degree_getters.cpp
@@ -1,0 +1,166 @@
+#include "constants.hpp"
+#include "transforms.hpp"
+
+#include <gl/graph.hpp>
+#include <gl/topologies.hpp>
+
+#include <doctest.h>
+
+#include <deque>
+
+namespace gl_testing {
+
+TEST_SUITE_BEGIN("test_vertex_degree_getters");
+
+TEST_CASE("vertex degree getter tests for directed graphs") {
+    using traits_type =
+        lib::directed_graph_traits<lib_t::empty_properties, lib_t::empty_properties, lib_i::list_t>;
+    using sut_type = lib::graph<traits_type>;
+    using vertex_type = typename sut_type::vertex_type;
+
+    const auto n_vertices = constants::n_elements_top;
+
+    sut_type sut;
+    std::deque<lib_t::size_type> expected_in_deg_list, expected_out_deg_list;
+
+    SUBCASE("clique") {
+        sut = lib::topology::clique<sut_type>(n_vertices);
+        expected_in_deg_list =
+            std::deque<lib_t::size_type>(n_vertices, n_vertices - constants::one);
+        expected_out_deg_list = expected_in_deg_list;
+    }
+
+    SUBCASE("clique with an additional loop") {
+        sut = lib::topology::clique<sut_type>(n_vertices);
+        sut.add_edge(constants::first_element_idx, constants::first_element_idx);
+
+        expected_in_deg_list =
+            std::deque<lib_t::size_type>(n_vertices, n_vertices - constants::one);
+        expected_in_deg_list.front()++;
+
+        expected_out_deg_list = expected_in_deg_list;
+    }
+
+    SUBCASE("cycle") {
+        sut = lib::topology::cycle<sut_type>(n_vertices);
+        expected_in_deg_list = std::deque<lib_t::size_type>(n_vertices, constants::one);
+        expected_out_deg_list = expected_in_deg_list;
+    }
+
+    SUBCASE("path") {
+        sut = lib::topology::path<sut_type>(n_vertices);
+
+        expected_in_deg_list =
+            std::deque<lib_t::size_type>(n_vertices - constants::one, constants::one);
+        expected_in_deg_list.push_front(constants::zero);
+
+        expected_out_deg_list =
+            std::deque<lib_t::size_type>(n_vertices - constants::one, constants::one);
+        expected_out_deg_list.push_back(constants::zero);
+    }
+
+    CAPTURE(sut);
+    CAPTURE(expected_in_deg_list);
+    CAPTURE(expected_out_deg_list);
+
+    std::deque<lib_t::size_type> expected_deg_list(n_vertices);
+    std::ranges::transform(
+        expected_in_deg_list,
+        expected_out_deg_list,
+        expected_deg_list.begin(),
+        std::plus<lib_t::size_type>{}
+    );
+
+    lib_t::size_type i = constants::zero;
+    CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
+        const bool result =
+            sut.in_degree(vertex) == expected_in_deg_list[i]
+            and sut.out_degree(vertex) == expected_out_deg_list[i]
+            and sut.degree(vertex) == expected_deg_list[i];
+        i++;
+        return result;
+    }));
+
+    i = constants::zero;
+    CHECK(std::ranges::all_of(
+        sut.vertices(),
+        [&](const auto vertex_id) {
+            const bool result = sut.in_degree(vertex_id) == expected_in_deg_list[i]
+               and sut.out_degree(vertex_id) == expected_out_deg_list[i]
+               and sut.degree(vertex_id) == expected_deg_list[i];
+            i++;
+            return result;
+        },
+        transforms::extract_vertex_id<vertex_type>
+    ));
+}
+
+TEST_CASE("vertex degree getter tests for undirected graphs") {
+    using traits_type = lib::
+        undirected_graph_traits<lib_t::empty_properties, lib_t::empty_properties, lib_i::list_t>;
+    using sut_type = lib::graph<traits_type>;
+    using vertex_type = typename sut_type::vertex_type;
+
+    const auto n_vertices = constants::n_elements_top;
+
+    sut_type sut;
+    std::deque<lib_t::size_type> expected_deg_list;
+
+    SUBCASE("clique") {
+        sut = lib::topology::clique<sut_type>(n_vertices);
+        expected_deg_list = std::deque<lib_t::size_type>(n_vertices, n_vertices - constants::one);
+    }
+
+    SUBCASE("clique with an additional loop") {
+        sut = lib::topology::clique<sut_type>(n_vertices);
+        sut.add_edge(constants::first_element_idx, constants::first_element_idx);
+
+        expected_deg_list = std::deque<lib_t::size_type>(n_vertices, n_vertices - constants::one);
+        expected_deg_list.front()++;
+    }
+
+    SUBCASE("cycle") {
+        sut = lib::topology::cycle<sut_type>(n_vertices);
+        expected_deg_list = std::deque<lib_t::size_type>(n_vertices, constants::two);
+    }
+
+    SUBCASE("path") {
+        sut = lib::topology::path<sut_type>(n_vertices);
+
+        expected_deg_list =
+            std::deque<lib_t::size_type>(n_vertices - constants::two, constants::two);
+        expected_deg_list.push_front(constants::one);
+        expected_deg_list.push_back(constants::one);
+    }
+
+    CAPTURE(sut);
+    CAPTURE(expected_deg_list);
+
+    lib_t::size_type i = constants::zero;
+    CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
+        const auto expected_deg = expected_deg_list[i];
+        const bool result =
+            sut.in_degree(vertex) == expected_deg and sut.out_degree(vertex) == expected_deg
+            and sut.degree(vertex) == expected_deg;
+        i++;
+        return result;
+    }));
+
+    i = constants::zero;
+    CHECK(std::ranges::all_of(
+        sut.vertices(),
+        [&](const auto vertex_id) {
+            const auto expected_deg = expected_deg_list[i];
+            const bool result = sut.in_degree(vertex_id) == expected_deg
+               and sut.out_degree(vertex_id) == expected_deg
+               and sut.degree(vertex_id) == expected_deg;
+            i++;
+            return result;
+        },
+        transforms::extract_vertex_id<vertex_type>
+    ));
+}
+
+TEST_SUITE_END(); // test_vertex_degree_getters
+
+} // namespace gl_testing


### PR DESCRIPTION
Added the following `graph` class methods:
- `in_degree(vertex(_id))`
- `out_degree(vertex(_id))`
- `degree(vertex(_id))`
With implementation dependent on the graph implementation and directional tags 