### PR TITLE
YT-CPPGL-48: Add final and virtual markers

### DIFF
--- a/docs/core_util_types.md
+++ b/docs/core_util_types.md
@@ -196,6 +196,17 @@ The table below contains the basic type aliases defined in the library.
     - Reads the weight property from an input stream.
     - *Constraints*: `weight_type` must be readable (`type_traits::c_readable<weight_type>`).
 
+### Deriving from the property types
+
+> [!IMPORTANT]
+> The `name_property`, `dynamic_properties` and `binary_color` classes are marked `final` by default. To be able to use them as base classes you have to add:
+>
+> ```cpp
+> #define GL_CONFIG_PROPERTY_TYPES_NOT_FINAL
+> ```
+>
+> in your program or add a `-DGL_CONFIG_PROPERTY_TYPES_NOT_FINAL` flag when compiling.
+
 ### Associated type traits
 
 This section describes the type traits that are associated with the property types defined in the library. These traits help ensure that properties meet specific requirements and can be used correctly within the library.
@@ -290,6 +301,15 @@ This section provides the description of types used to manage range/collection i
   - `element_at(types::size_type position) const -> const value_type&` - Returns a reference to the element at the specified position.
   - `operator[](types::size_type position) -> value_type&` - Provides access to the element at the specified position (equivalent to `element_at`).
   - `operator[](types::size_type position) const -> const value_type&` - Provides access to the element at the specified position (equivalent to `element_at`).
+
+> [!IMPORTANT]
+> The `iterator_range` class is marked `final` by default. To use this class as a base class you have to add:
+>
+> ```cpp
+> #define GL_CONFIG_IT_RANGE_NOT_FINAL
+> ```
+>
+> in your program or add a `-DGL_CONFIG_IT_RANGE_NOT_FINAL` flag when compiling.
 
 #### Associated functions
 

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -14,7 +14,7 @@ template <
     type_traits::c_instantiation_of<vertex_descriptor> VertexType,
     type_traits::c_edge_directional_tag DirectionalTag = directed_t,
     type_traits::c_properties Properties = types::empty_properties>
-class edge_descriptor {
+class edge_descriptor final {
 public:
     using type = edge_descriptor<VertexType, DirectionalTag, Properties>;
     using vertex_type = VertexType;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -15,7 +15,7 @@
 namespace gl {
 
 template <type_traits::c_instantiation_of<graph_traits> GraphTraits = graph_traits<>>
-class graph {
+class graph final {
 public:
     using traits_type = GraphTraits;
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -13,7 +13,7 @@
 namespace gl::impl {
 
 template <type_traits::c_list_graph_traits GraphTraits>
-class adjacency_list {
+class adjacency_list final {
 public:
     using vertex_type = typename GraphTraits::vertex_type;
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -14,7 +14,7 @@
 namespace gl::impl {
 
 template <type_traits::c_matrix_graph_traits GraphTraits>
-class adjacency_matrix {
+class adjacency_matrix final {
 public:
     using vertex_type = typename GraphTraits::vertex_type;
 

--- a/include/gl/types/iterator_range.hpp
+++ b/include/gl/types/iterator_range.hpp
@@ -21,6 +21,12 @@
 #define _GL_IT_RANGE_DEFAULT_CACHE_MODE gl::type_traits::lazy_cache
 #endif
 
+#ifdef GL_CONFIG_IT_RANGE_NOT_FINAL
+#define _GL_IT_RANGE_NOT_FINAL
+#else
+#undef _GL_IT_RANGE_NOT_FINAL
+#endif
+
 namespace gl {
 
 namespace types {
@@ -33,7 +39,11 @@ Designed to be compatible with the range-based loops and std algorithms.
 template <
     std::forward_iterator Iterator,
     type_traits::c_cache_mode CacheMode = _GL_IT_RANGE_DEFAULT_CACHE_MODE>
-class iterator_range {
+class iterator_range
+#ifndef _GL_IT_RANGE_NOT_FINAL
+    final
+#endif
+{
 public:
     using iterator = Iterator;
 #if __cplusplus >= 202302L
@@ -72,7 +82,11 @@ public:
     iterator_range& operator=(const iterator_range&) = default;
     iterator_range& operator=(iterator_range&&) = default;
 
+#ifndef _GL_IT_RANGE_NOT_FINAL
     ~iterator_range() = default;
+#else
+    virtual ~iterator_range() = default;
+#endif
 
     bool operator==(const iterator_range&) const = default;
 

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -13,6 +13,12 @@
 #include <unordered_map>
 #include <variant>
 
+#ifdef GL_CONFIG_PROPERTY_TYPES_NOT_FINAL
+#define _GL_PROPERTY_TYPES_NOT_FINAL
+#else
+#undef _GL_PROPERTY_TYPES_NOT_FINAL
+#endif
+
 namespace gl {
 
 namespace types {
@@ -21,7 +27,11 @@ namespace types {
 
 using empty_properties = std::monostate;
 
-class name_property {
+class name_property
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
+    final
+#endif
+{
 public:
     using value_type = std::string;
 
@@ -35,7 +45,11 @@ public:
     name_property& operator=(const name_property&) = default;
     name_property& operator=(name_property&&) = default;
 
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
     ~name_property() = default;
+#else
+    virtual ~name_property() = default;
+#endif
 
     // clang-format off
     // gl_attr_force_inline misplacement
@@ -63,7 +77,11 @@ private:
     std::string _name;
 };
 
-class dynamic_properties {
+class dynamic_properties
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
+    final
+#endif
+{
 public:
     using key_type = std::string;
     using value_type = std::any;
@@ -77,7 +95,11 @@ public:
     dynamic_properties& operator=(const dynamic_properties&) = default;
     dynamic_properties& operator=(dynamic_properties&&) = default;
 
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
     ~dynamic_properties() = default;
+#else
+    virtual ~dynamic_properties() = default;
+#endif
 
     [[nodiscard]] gl_attr_force_inline bool is_present(const key_type& key) const {
         return this->_property_map.contains(key);
@@ -119,7 +141,11 @@ private:
 
 // --- vertex properties ---
 
-class binary_color {
+class binary_color
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
+    final
+#endif
+{
 public:
     enum class value : std::uint16_t {
         black = static_cast<std::uint16_t>(0),
@@ -137,7 +163,11 @@ public:
     binary_color& operator=(const binary_color&) = default;
     binary_color& operator=(binary_color&&) = default;
 
+#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
     ~binary_color() = default;
+#else
+    virtual ~binary_color() = default;
+#endif
 
     binary_color& operator=(value value) {
         this->_value = this->_restrict(value);

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -16,7 +16,7 @@
 namespace gl {
 
 template <type_traits::c_properties Properties = types::empty_properties>
-class vertex_descriptor {
+class vertex_descriptor final {
 public:
     using type = std::type_identity_t<vertex_descriptor<Properties>>;
     using properties_type = Properties;


### PR DESCRIPTION
- Added the `final` keyword to the following classes: 
  - `{vertex/edge}_descriptor`
  - `adjacency_{list/matrix}`
  - `graph`
- Marked the destructors of the property classes and the `iterator_range` class as `virtual` (if they are explicitly configured not to be final)