### PR TITLE
YT-CPPGL-52: Naming cleanup

### DIFF
--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -161,7 +161,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `detail::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
 
   - *Defined in*: [gl/algorithm/depth_first_search.hpp](/include/gl/algorithm/deapth_first_search.hpp)
 
@@ -190,7 +190,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `detail::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
 
   - *Defined in*: [gl/algorithm/breadth_first_search.hpp](/include/gl/algorithm/breadth_first_search.hpp)
 
@@ -352,14 +352,14 @@ This section covers the specific types and type traits used for the algorithm im
 
 To write custom graph algorithms you can use the types and concepts described in the [Algorithm-specific types and concepts](#algorithm-specific-types-and-concepts) as well as the general graph utility described in the [graph class documentation page](/docs/graph.md#additional-utility).
 
-Additionaly you can use the depth-first/breadth-first search algorithm templates which are defined in the `gl::algorithm::detail` namespace:
+Additionaly you can use the depth-first/breadth-first search algorithm templates which are defined in the `gl::algorithm::impl` namespace:
 
 ### Depth-first search templates
 
 > [!NOTE]
-> The DFS algorithm templates are defined in the [gl/algorithm/detail/dfs_impl.hpp](/include/gl/algorithm/detail/dfs_impl.hpp) file.
+> The DFS algorithm templates are defined in the [gl/algorithm/impl/dfs.hpp](/include/gl/algorithm/impl/dfs.hpp) file.
 
-- `dfs_impl(graph, root_vertex, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `dfs(graph, root_vertex, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Desciption*: An iterative DFS algoithm template.
 
   - *Template parameters*:
@@ -381,7 +381,7 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 
   - *Return type*: `void`
 
-- `rdfs_impl(graph, vertex, source_id, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `r_dfs(graph, vertex, source_id, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Description*: A recursive DFS algorithm template.
 
   - *Template parameters*:
@@ -407,9 +407,9 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 ### Breadth-first search templates
 
 > [!NOTE]
-> The BFS algorithm templates are defined in the [gl/algorithm/detail/bfs_impl.hpp](/include/gl/algorithm/detail/bfs_impl.hpp) file.
+> The BFS algorithm templates are defined in the [gl/algorithm/impl/bfs.hpp](/include/gl/algorithm/impl/bfs.hpp) file.
 
-- `bfs_impl(graph, initial_queue_content, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `bfs(graph, initial_queue_content, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Desciption*: A *standard* BFS algorithm template.
 
   - *Template parameters*:
@@ -434,7 +434,7 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 
   - *Return type*: `void`
 
-- `pq_bfs_impl(graph, pq_compare, initial_queue_content, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `pq_bfs(graph, pq_compare, initial_queue_content, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Desciption*: A *priority queue* BFS algorithm template.
 
   - *Template parameters*:

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -320,29 +320,29 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Return type*: `const edge_type&`
   - *Requires*: non-default `edge_properties_type`
 
-- **`graph.add_edges_from(source_id, destination_id_range)`**:
-  - *Description*: Adds multiple edges from a source vertex (specified by ID) to a range of destination vertices (also specified by IDs).
+- **`graph.add_edges_from(source_id, target_id_range)`**:
+  - *Description*: Adds multiple edges from a source vertex (specified by ID) to a range of target vertices (also specified by IDs).
   - *Template parameters*:
     - `IdRange: type_traits::c_sized_range_of<types::id_type>` – a range of vertex IDs that must satisfy the size and type constraints.
   - *Parameters*:
     - `source_id: types::id_type` – the ID of the source vertex.
-    - `destination_id_range: const IdRange&` – a range of destination vertex IDs to connect to the source vertex.
+    - `target_id_range: const IdRange&` – a range of target vertex IDs to connect to the source vertex.
   - *Return type*: `void`
 
-- **`graph.add_edges_from(source, destination_range)`**:
-  - *Description*: Adds multiple edges from a specified source vertex to a range of destination vertices (specified by references).
+- **`graph.add_edges_from(source, target_range)`**:
+  - *Description*: Adds multiple edges from a specified source vertex to a range of target vertices (specified by references).
   - *Template parameters*:
     - `VertexRefRange: type_traits::c_sized_range_of<types::const_ref_wrap<vertex_type>>` – a range of vertex references that must satisfy the size and type constraints.
   - *Parameters*:
     - `source: const vertex_type&` – the source vertex.
-    - `destination_range: const VertexRefRange&` – a range of destination vertex references to connect to the source vertex.
+    - `target_range: const VertexRefRange&` – a range of target vertex references to connect to the source vertex.
   - *Return type*: `void`
 
 > [!IMPORTANT]
 > Behaviour of adding an edge between `first` and `second`:
 >
-> - for *directed* graphs: adds a one-directional edge where `first` is the source vertex and `second` is the destination vertex
-> - for *undirected* graphs: adds a bidirectional edge where both vertices are source and destination vertices
+> - for *directed* graphs: adds a one-directional edge where `first` is the source vertex and `second` is the target vertex
+> - for *undirected* graphs: adds a bidirectional edge where both vertices are source and target vertices
 
 - **`graph.has_edge(first_id, second_id) const`**:
   - *Description*: Returns true if there is an edge between the vertices with the specified IDs.

--- a/docs/graph_elements.md
+++ b/docs/graph_elements.md
@@ -186,12 +186,12 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
   - *Return type*: `bool`
 
 - **`is_incident_to(const vertex_type& vertex) const`**:
-  - *Description*: Returns `true` if the provided vertex is the destination of the edge (for directed edges).
+  - *Description*: Returns `true` if the provided vertex is the target vertex of the edge (for directed edges).
   - *Returned value*:
     - For directed edges: $\text{vertex} = v$
     - For undirected edges: `is_incident_with(vertex)`
   - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex to check if it is the destination.
+    - `vertex: const vertex_type&` – the vertex to check if it is the target.
   - *Return type*: `bool`
 
 - **`is_loop() const`**:

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "constants.hpp"
-#include "detail/bfs_impl.hpp"
+#include "impl/bfs_impl.hpp"
 #include "types.hpp"
 
 namespace gl::algorithm {
@@ -17,7 +17,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-detail::alg_return_graph_type<SearchTreeType> breadth_first_search(
+impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -29,27 +29,27 @@ detail::alg_return_graph_type<SearchTreeType> breadth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
+    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
 
     if (root_vertex_id_opt) {
-        detail::bfs_impl(
+        impl::bfs_impl(
             graph,
-            detail::init_range(root_vertex_id_opt.value()),
-            detail::default_visit_vertex_predicate<GraphType>(visited),
-            detail::default_visit_callback<GraphType>(visited, search_tree),
-            detail::default_enqueue_vertex_predicate<GraphType, true>(visited),
+            impl::init_range(root_vertex_id_opt.value()),
+            impl::default_visit_vertex_predicate<GraphType>(visited),
+            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
         for (const auto root_id : graph.vertex_ids())
-            detail::bfs_impl(
+            impl::bfs_impl(
                 graph,
-                detail::init_range(root_id),
-                detail::default_visit_vertex_predicate<GraphType>(visited),
-                detail::default_visit_callback<GraphType>(visited, search_tree),
-                detail::default_enqueue_vertex_predicate<GraphType, true>(visited),
+                impl::init_range(root_id),
+                impl::default_visit_vertex_predicate<GraphType>(visited),
+                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
                 pre_visit,
                 post_visit
             );

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "constants.hpp"
-#include "impl/bfs_impl.hpp"
+#include "impl/bfs.hpp"
 #include "types.hpp"
 
 namespace gl::algorithm {
@@ -32,7 +32,7 @@ impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
     auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
 
     if (root_vertex_id_opt) {
-        impl::bfs_impl(
+        impl::bfs(
             graph,
             impl::init_range(root_vertex_id_opt.value()),
             impl::default_visit_vertex_predicate<GraphType>(visited),
@@ -44,7 +44,7 @@ impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
     }
     else {
         for (const auto root_id : graph.vertex_ids())
-            impl::bfs_impl(
+            impl::bfs(
                 graph,
                 impl::init_range(root_id),
                 impl::default_visit_vertex_predicate<GraphType>(visited),

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "detail/bfs_impl.hpp"
+#include "impl/bfs_impl.hpp"
 
 namespace gl::algorithm {
 
@@ -36,9 +36,9 @@ template <
         // color the root vertex
         coloring[root_id] = bin_color_value::black;
 
-        const bool is_bipartite = detail::bfs_impl(
+        const bool is_bipartite = impl::bfs_impl(
             graph,
-            detail::init_range(root_id),
+            impl::init_range(root_id),
             types::empty_callback{}, // visit predicate
             types::empty_callback{}, // visit callback
             [&coloring](const vertex_type& vertex, const edge_type& in_edge)

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impl/bfs_impl.hpp"
+#include "impl/bfs.hpp"
 
 namespace gl::algorithm {
 
@@ -36,7 +36,7 @@ template <
         // color the root vertex
         coloring[root_id] = bin_color_value::black;
 
-        const bool is_bipartite = impl::bfs_impl(
+        const bool is_bipartite = impl::bfs(
             graph,
             impl::init_range(root_id),
             types::empty_callback{}, // visit predicate

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "constants.hpp"
-#include "impl/dfs_impl.hpp"
+#include "impl/dfs.hpp"
 
 namespace gl::algorithm {
 
@@ -31,7 +31,7 @@ impl::alg_return_graph_type<SearchTreeType> depth_first_search(
     auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
 
     if (root_vertex_id_opt) {
-        impl::dfs_impl(
+        impl::dfs(
             graph,
             graph.get_vertex(root_vertex_id_opt.value()),
             impl::default_visit_vertex_predicate<GraphType>(visited),
@@ -43,7 +43,7 @@ impl::alg_return_graph_type<SearchTreeType> depth_first_search(
     }
     else {
         for (const auto& root_vertex : graph.vertices())
-            impl::dfs_impl(
+            impl::dfs(
                 graph,
                 root_vertex,
                 impl::default_visit_vertex_predicate<GraphType>(visited),
@@ -81,7 +81,7 @@ impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
 
     if (root_vertex_id_opt) {
         const auto root_id = root_vertex_id_opt.value();
-        impl::rdfs_impl(
+        impl::r_dfs(
             graph,
             graph.get_vertex(root_id),
             root_id,
@@ -94,7 +94,7 @@ impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
     }
     else {
         for (const auto& root_vertex : graph.vertices())
-            impl::rdfs_impl(
+            impl::r_dfs(
                 graph,
                 root_vertex,
                 root_vertex.id(),

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "constants.hpp"
-#include "detail/dfs_impl.hpp"
+#include "impl/dfs_impl.hpp"
 
 namespace gl::algorithm {
 
@@ -16,7 +16,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-detail::alg_return_graph_type<SearchTreeType> depth_first_search(
+impl::alg_return_graph_type<SearchTreeType> depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -28,27 +28,27 @@ detail::alg_return_graph_type<SearchTreeType> depth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
+    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
 
     if (root_vertex_id_opt) {
-        detail::dfs_impl(
+        impl::dfs_impl(
             graph,
             graph.get_vertex(root_vertex_id_opt.value()),
-            detail::default_visit_vertex_predicate<GraphType>(visited),
-            detail::default_visit_callback<GraphType>(visited, search_tree),
-            detail::default_enqueue_vertex_predicate<GraphType>(visited),
+            impl::default_visit_vertex_predicate<GraphType>(visited),
+            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
         for (const auto& root_vertex : graph.vertices())
-            detail::dfs_impl(
+            impl::dfs_impl(
                 graph,
                 root_vertex,
-                detail::default_visit_vertex_predicate<GraphType>(visited),
-                detail::default_visit_callback<GraphType>(visited, search_tree),
-                detail::default_enqueue_vertex_predicate<GraphType>(visited),
+                impl::default_visit_vertex_predicate<GraphType>(visited),
+                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit
             );
@@ -65,7 +65,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-detail::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
+impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -77,30 +77,30 @@ detail::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = detail::init_search_tree<SearchTreeType>(graph);
+    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
 
     if (root_vertex_id_opt) {
         const auto root_id = root_vertex_id_opt.value();
-        detail::rdfs_impl(
+        impl::rdfs_impl(
             graph,
             graph.get_vertex(root_id),
             root_id,
-            detail::default_visit_vertex_predicate<GraphType>(visited),
-            detail::default_visit_callback<GraphType>(visited, search_tree),
-            detail::default_enqueue_vertex_predicate<GraphType>(visited),
+            impl::default_visit_vertex_predicate<GraphType>(visited),
+            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
         for (const auto& root_vertex : graph.vertices())
-            detail::rdfs_impl(
+            impl::rdfs_impl(
                 graph,
                 root_vertex,
                 root_vertex.id(),
-                detail::default_visit_vertex_predicate<GraphType>(visited),
-                detail::default_visit_callback<GraphType>(visited, search_tree),
-                detail::default_enqueue_vertex_predicate<GraphType>(visited),
+                impl::default_visit_vertex_predicate<GraphType>(visited),
+                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit
             );

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "gl/graph_utility.hpp"
-#include "impl/bfs_impl.hpp"
+#include "impl/bfs.hpp"
 
 #include <deque>
 
@@ -62,7 +62,7 @@ template <
 
     std::optional<types::const_ref_wrap<edge_type>> negative_edge;
 
-    impl::pq_bfs_impl(
+    impl::pq_bfs(
         graph,
         [&paths](const types::vertex_info& lhs, const types::vertex_info& rhs) {
             return paths.distances[lhs.id] > paths.distances[rhs.id];

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "detail/bfs_impl.hpp"
 #include "gl/graph_utility.hpp"
+#include "impl/bfs_impl.hpp"
 
 #include <deque>
 
@@ -29,18 +29,14 @@ struct paths_descriptor {
     std::vector<distance_type> distances;
 };
 
-namespace detail {
-
 template <type_traits::c_graph GraphType>
 using paths_descriptor_type = paths_descriptor<types::vertex_distance_type<GraphType>>;
 
-} // namespace detail
-
 template <type_traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline detail::paths_descriptor_type<GraphType> make_paths_descriptor(
+[[nodiscard]] gl_attr_force_inline paths_descriptor_type<GraphType> make_paths_descriptor(
     const GraphType& graph
 ) {
-    return detail::paths_descriptor_type<GraphType>{graph.n_vertices()};
+    return paths_descriptor_type<GraphType>{graph.n_vertices()};
 }
 
 template <
@@ -49,7 +45,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-[[nodiscard]] detail::paths_descriptor_type<GraphType> dijkstra_shortest_paths(
+[[nodiscard]] paths_descriptor_type<GraphType> dijkstra_shortest_paths(
     const GraphType& graph,
     const types::id_type source_id,
     const PreVisitCallback& pre_visit = {},
@@ -66,12 +62,12 @@ template <
 
     std::optional<types::const_ref_wrap<edge_type>> negative_edge;
 
-    detail::pq_bfs_impl(
+    impl::pq_bfs_impl(
         graph,
         [&paths](const types::vertex_info& lhs, const types::vertex_info& rhs) {
             return paths.distances[lhs.id] > paths.distances[rhs.id];
         },
-        detail::init_range(source_id),
+        impl::init_range(source_id),
         types::empty_callback{}, // visit predicate
         types::empty_callback{}, // visit callback
         [&paths, &negative_edge](const vertex_type& vertex, const edge_type& in_edge)

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -23,7 +23,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-bool bfs_impl(
+bool bfs(
     const GraphType& graph,
     const InitQueueRangeType& initial_queue_content,
     const VisitVertexPredicate& visit_vertex_pred = {},
@@ -92,7 +92,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-bool pq_bfs_impl(
+bool pq_bfs(
     const GraphType& graph,
     const PQCompare& pq_compare,
     const InitQueueRangeType& initial_queue_content,

--- a/include/gl/algorithm/impl/bfs_impl.hpp
+++ b/include/gl/algorithm/impl/bfs_impl.hpp
@@ -8,7 +8,7 @@
 
 #include <queue>
 
-namespace gl::algorithm::detail {
+namespace gl::algorithm::impl {
 
 template <
     type_traits::c_graph GraphType,
@@ -148,4 +148,4 @@ bool pq_bfs_impl(
     return true;
 }
 
-} // namespace gl::algorithm::detail
+} // namespace gl::algorithm::impl

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -6,7 +6,7 @@
 
 #include "gl/algorithm/types.hpp"
 
-namespace gl::algorithm::detail {
+namespace gl::algorithm::impl {
 
 // --- common functions ---
 
@@ -58,4 +58,4 @@ template <type_traits::c_graph GraphType, bool AsOptional = false>
     };
 }
 
-} // namespace gl::algorithm::detail
+} // namespace gl::algorithm::impl

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -21,7 +21,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-void dfs_impl(
+void dfs(
     const GraphType& graph,
     const typename GraphType::vertex_type& root_vertex,
     const VisitVertexPredicate& visit_vertex_pred,
@@ -77,7 +77,7 @@ template <
         types::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         types::empty_callback>
-void rdfs_impl(
+void r_dfs(
     const GraphType& graph,
     const typename GraphType::vertex_type& vertex,
     const types::id_type source_id,
@@ -101,7 +101,7 @@ void rdfs_impl(
     for (const auto& edge : graph.adjacent_edges(vertex_id)) {
         const auto& incident_vertex = edge.incident_vertex(vertex);
         if (enqueue_vertex_pred(incident_vertex, edge))
-            rdfs_impl(
+            r_dfs(
                 graph,
                 incident_vertex,
                 vertex_id,

--- a/include/gl/algorithm/impl/dfs_impl.hpp
+++ b/include/gl/algorithm/impl/dfs_impl.hpp
@@ -8,7 +8,7 @@
 
 #include <stack>
 
-namespace gl::algorithm::detail {
+namespace gl::algorithm::impl {
 
 template <
     type_traits::c_graph GraphType,
@@ -117,4 +117,4 @@ void rdfs_impl(
         post_visit(vertex);
 }
 
-} // namespace gl::algorithm::detail
+} // namespace gl::algorithm::impl

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -92,20 +92,20 @@ template <
                 min_weight
             ));
 
-        const auto& dest_vertex_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
-        if (not visited[dest_vertex_id]) {
+        const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
+        if (not visited[target_id]) {
             // add the minimum weight edge to the mst
             mst.edges.emplace_back(min_edge);
             mst.weight += min_weight;
 
-            visited[dest_vertex_id] = true;
+            visited[target_id] = true;
             ++n_vertices_in_mst;
         }
 
-        // enqueue all edges adjacent to the destination vertex if they lead to unvisited verties
-        for (const auto& edge : graph.adjacent_edges(dest_vertex_id))
-            if (not visited[get_other_vertex_id(edge, dest_vertex_id)])
-                edge_queue.emplace(edge, dest_vertex_id);
+        // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
+        for (const auto& edge : graph.adjacent_edges(target_id))
+            if (not visited[get_other_vertex_id(edge, target_id)])
+                edge_queue.emplace(edge, target_id);
     }
 
     return mst;

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "constants.hpp"
-#include "detail/common.hpp"
+#include "impl/common.hpp"
 
 #include <queue>
 

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impl/bfs_impl.hpp"
+#include "impl/bfs.hpp"
 
 namespace gl::algorithm {
 
@@ -42,7 +42,7 @@ template <
     auto& topological_order = topological_order_opt.value();
     topological_order.reserve(graph.n_vertices());
 
-    impl::bfs_impl(
+    impl::bfs(
         graph,
         source_vertex_list,
         types::empty_callback{}, // visit predicate

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "detail/bfs_impl.hpp"
+#include "impl/bfs_impl.hpp"
 
 namespace gl::algorithm {
 
@@ -42,7 +42,7 @@ template <
     auto& topological_order = topological_order_opt.value();
     topological_order.reserve(graph.n_vertices());
 
-    detail::bfs_impl(
+    impl::bfs_impl(
         graph,
         source_vertex_list,
         types::empty_callback{}, // visit predicate

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -68,12 +68,12 @@ concept c_optional_edge_callback =
 
 } // namespace type_traits
 
-namespace algorithm::detail {
+namespace algorithm::impl {
 
 template <type_traits::c_alg_return_graph_type ReturnGraphType>
 using alg_return_graph_type =
     std::conditional_t<type_traits::c_alg_no_return_type<ReturnGraphType>, void, ReturnGraphType>;
 
-} // namespace algorithm::detail
+} // namespace algorithm::impl
 
 } // namespace gl

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -105,7 +105,7 @@ public:
         return directional_tag::is_incident_from(*this, vertex);
     }
 
-    // true if the given vertex is the `destination` of the edge
+    // true if the given vertex is the `target` vertex of the edge
     [[nodiscard]] gl_attr_force_inline bool is_incident_to(const vertex_type& vertex) const {
         return directional_tag::is_incident_to(*this, vertex);
     }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -258,31 +258,29 @@ public:
     }
 
     template <type_traits::c_sized_range_of<types::id_type> IdRange>
-    void add_edges_from(const types::id_type source_id, const IdRange& destination_id_range) {
+    void add_edges_from(const types::id_type source_id, const IdRange& target_id_range) {
         const auto& source = this->get_vertex(source_id);
 
         std::vector<edge_ptr_type> new_edges;
-        new_edges.reserve(std::ranges::size(destination_id_range));
+        new_edges.reserve(std::ranges::size(target_id_range));
 
-        for (const auto destination_id : destination_id_range) {
-            new_edges.push_back(
-                detail::make_edge<edge_type>(source, this->get_vertex(destination_id))
-            );
+        for (const auto target_id : target_id_range) {
+            new_edges.push_back(detail::make_edge<edge_type>(source, this->get_vertex(target_id)));
         }
         this->_impl.add_edges_from(source_id, std::move(new_edges));
     }
 
     template <type_traits::c_sized_range_of<types::const_ref_wrap<vertex_type>> VertexRefRange>
-    void add_edges_from(const vertex_type& source, const VertexRefRange& destination_range) {
+    void add_edges_from(const vertex_type& source, const VertexRefRange& target_range) {
         this->_verify_vertex(source);
 
         std::vector<edge_ptr_type> new_edges;
-        new_edges.reserve(std::ranges::size(destination_range));
+        new_edges.reserve(std::ranges::size(target_range));
 
-        for (const auto& destination_ref : destination_range) {
-            const auto& destination = destination_ref.get();
-            this->_verify_vertex(destination);
-            new_edges.push_back(detail::make_edge<edge_type>(source, destination));
+        for (const auto& target_ref : target_range) {
+            const auto& target = target_ref.get();
+            this->_verify_vertex(target);
+            new_edges.push_back(detail::make_edge<edge_type>(source, target));
         }
         this->_impl.add_edges_from(source.id(), std::move(new_edges));
     }

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -12,8 +12,7 @@ namespace gl::topology {
 
 namespace detail {
 
-[[nodiscard]] gl_attr_force_inline auto get_binary_destination_ids(const types::size_type source_id
-) {
+[[nodiscard]] gl_attr_force_inline auto get_binary_target_ids(const types::size_type source_id) {
     return std::make_pair(
         constants::two * source_id + constants::one, constants::two * source_id + constants::two
     );
@@ -38,9 +37,9 @@ template <type_traits::c_graph GraphType>
     const auto n_source_vertices = n_vertices - util::upow(base, i_end);
 
     for (types::id_type source_id = constants::zero; source_id < n_source_vertices; ++source_id) {
-        const auto destination_ids = detail::get_binary_destination_ids(source_id);
+        const auto target_ids = detail::get_binary_target_ids(source_id);
         graph.add_edges_from(
-            source_id, std::vector<types::id_type>{destination_ids.first, destination_ids.second}
+            source_id, std::vector<types::id_type>{target_ids.first, target_ids.second}
         );
     }
 
@@ -64,13 +63,12 @@ template <type_traits::c_graph GraphType>
 
         for (types::id_type source_id = constants::zero; source_id < n_source_vertices;
              ++source_id) {
-            const auto destination_ids = detail::get_binary_destination_ids(source_id);
+            const auto target_ids = detail::get_binary_target_ids(source_id);
             graph.add_edges_from(
-                source_id,
-                std::vector<types::id_type>{destination_ids.first, destination_ids.second}
+                source_id, std::vector<types::id_type>{target_ids.first, target_ids.second}
             );
-            graph.add_edge(destination_ids.first, source_id);
-            graph.add_edge(destination_ids.second, source_id);
+            graph.add_edge(target_ids.first, source_id);
+            graph.add_edge(target_ids.second, source_id);
         }
 
         return graph;

--- a/include/gl/topology/bipartite.hpp
+++ b/include/gl/topology/bipartite.hpp
@@ -17,11 +17,10 @@ template <type_traits::c_graph GraphType>
     GraphType graph{n_vertices};
 
     for (types::id_type source_id = constants::initial_id; source_id < n_vertices_a; ++source_id) {
-        for (types::id_type destination_id = n_vertices_a; destination_id < n_vertices;
-             ++destination_id) {
-            graph.add_edge(source_id, destination_id);
+        for (types::id_type target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
+            graph.add_edge(source_id, target_id);
             if constexpr (type_traits::is_directed_v<GraphType>)
-                graph.add_edge(destination_id, source_id);
+                graph.add_edge(target_id, source_id);
         }
     }
 

--- a/include/gl/topology/clique.hpp
+++ b/include/gl/topology/clique.hpp
@@ -14,11 +14,10 @@ template <type_traits::c_graph GraphType>
     GraphType graph{n_vertices};
 
     for (types::id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
-        for (types::id_type destination_id = constants::initial_id; destination_id < source_id;
-             ++destination_id) {
-            graph.add_edge(source_id, destination_id);
+        for (types::id_type target_id = constants::initial_id; target_id < source_id; ++target_id) {
+            graph.add_edge(source_id, target_id);
             if constexpr (type_traits::is_directed_v<GraphType>)
-                graph.add_edge(destination_id, source_id);
+                graph.add_edge(target_id, source_id);
         }
     }
 

--- a/include/gl/topology/cycle.hpp
+++ b/include/gl/topology/cycle.hpp
@@ -26,9 +26,9 @@ template <type_traits::c_graph GraphType>
 
         for (types::id_type source_id = constants::initial_id; source_id < n_vertices;
              ++source_id) {
-            const auto destination_id = (source_id + constants::one) % n_vertices;
-            graph.add_edge(source_id, destination_id);
-            graph.add_edge(destination_id, source_id);
+            const auto target_id = (source_id + constants::one) % n_vertices;
+            graph.add_edge(source_id, target_id);
+            graph.add_edge(target_id, source_id);
         }
 
         return graph;

--- a/include/gl/topology/path.hpp
+++ b/include/gl/topology/path.hpp
@@ -28,9 +28,9 @@ template <type_traits::c_graph GraphType>
         for (types::id_type source_id = constants::initial_id;
              source_id < n_vertices - constants::one;
              ++source_id) {
-            const auto destination_id = source_id + constants::one;
-            graph.add_edge(source_id, destination_id);
-            graph.add_edge(destination_id, source_id);
+            const auto target_id = source_id + constants::one;
+            graph.add_edge(source_id, target_id);
+            graph.add_edge(target_id, source_id);
         }
 
         return graph;

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -85,18 +85,18 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto vertex_refs = {std::cref(v1), std::cref(v2), std::cref(v3)};
 
         std::vector<edge_ptr_type> new_edges;
-        for (const auto& destination : vertex_refs)
-            new_edges.push_back(lib::detail::make_edge<edge_type>(v1, destination.get()));
+        for (const auto& target : vertex_refs)
+            new_edges.push_back(lib::detail::make_edge<edge_type>(v1, target.get()));
 
         sut.add_edges_from(constants::vertex_id_1, std::move(new_edges));
 
-        REQUIRE(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto destination_id) {
-            return sut.has_edge(constants::vertex_id_1, destination_id);
+        REQUIRE(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto target_id) {
+            return sut.has_edge(constants::vertex_id_1, target_id);
         }));
 
-        std::ranges::for_each(vertex_refs, [&sut, &v1](const auto& destination) {
+        std::ranges::for_each(vertex_refs, [&sut, &v1](const auto& target) {
             std::vector<edge_ptr_type> new_edges;
-            new_edges.push_back(lib::detail::make_edge<edge_type>(v1, destination.get()));
+            new_edges.push_back(lib::detail::make_edge<edge_type>(v1, target.get()));
 
             CHECK_THROWS_AS(sut.add_edges_from(v1.id(), std::move(new_edges)), std::logic_error);
         });

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -462,14 +462,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             constexpr auto source_id = constants::vertex_id_1;
-            const std::vector<lib_t::id_type> destination_id_list{
+            const std::vector<lib_t::id_type> target_id_list{
                 constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
             };
 
-            sut.add_edges_from(source_id, destination_id_list);
+            sut.add_edges_from(source_id, target_id_list);
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements);
-            CHECK(std::ranges::all_of(destination_id_list, [&sut, source_id](const auto vertex_id) {
+            CHECK(std::ranges::all_of(target_id_list, [&sut, source_id](const auto vertex_id) {
                 return sut.has_edge(source_id, vertex_id);
             }));
         }
@@ -511,12 +511,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.n_unique_edges(), constants::zero_elements);
 
             const auto& source = vertex_1;
-            const vertex_ref_list<vertex_type> destination_list{vertex_1, vertex_2, vertex_3};
+            const vertex_ref_list<vertex_type> target_list{vertex_1, vertex_2, vertex_3};
 
-            sut.add_edges_from(source, destination_list);
+            sut.add_edges_from(source, target_list);
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements);
-            CHECK(std::ranges::all_of(destination_list, [&sut, &source](const auto& vertex) {
+            CHECK(std::ranges::all_of(target_list, [&sut, &source](const auto& vertex) {
                 return sut.has_edge(source, vertex);
             }));
         }


### PR DESCRIPTION
- Renamed 
  - The `algorithm::detail` namespace to `algorithm::impl`
  - The `{bds/dfs}_impl` functions to `{bfs/dfs}`
  - `destination` to `target` in the context of vertices
- Aligned the documentation