### PR TITLE
YT-CPPGL-53: Add a force inline option macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ While the `gl::graph` class is the key element of the library, it's not the only
 - [Graph topology generators](/docs/topologies.md)
 - [Algorithms](/docs/algoithms.md)
 - [Core utility types](/docs/core_util_types.md)
+- [Additional functionality](/docs/additional_functionality.md)
 
 <br />
 

--- a/docs/additional_functionality.md
+++ b/docs/additional_functionality.md
@@ -1,0 +1,18 @@
+# Additional functionality
+
+- [Force inlining](#force-inlining)
+
+<br />
+
+## Force inlining
+
+The `CPP-GL` library provides an option to enable force inlining of seleced functions and methods in the implementation. This is defined through the `gl_attr_force_inline` macro, which by default is equivalent to the `inline` keyword.
+
+To enable the force inlining functionality you have to add the following in your program:
+
+```c++
+#define GL_CONFIG_FORCE_INLINE
+```
+
+> [!NOTE]
+> Force inlining is supported only for the GNU G++ and CLang++ compilers.

--- a/include/gl/attributes/force_inline.hpp
+++ b/include/gl/attributes/force_inline.hpp
@@ -18,6 +18,6 @@
 
 #else
 
-#define gl_attr_force_inline
+#define gl_attr_force_inline inline
 
 #endif

--- a/include/gl/attributes/force_inline.hpp
+++ b/include/gl/attributes/force_inline.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#ifndef gl_attr_force_inline
+#undef gl_attr_force_inline
+
+#ifdef GL_CONFIG_FORCE_INLINE
 
 #if defined(__clang__)
 #define gl_attr_force_inline [[clang::always_inline]] inline
@@ -13,5 +15,9 @@
 #else
 #define gl_attr_force_inline inline
 #endif
+
+#else
+
+#define gl_attr_force_inline
 
 #endif


### PR DESCRIPTION
Added the `GL_CONFIG_FORCE_INLINE` configuration macro which enables the force inlining functionality