### PR TITLE
[YT-CPPGL-52#2] Naming cleanup

### DIFF
--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -77,7 +77,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/cycle.hpp](/include/gl/topology/cycle.hpp)
 
-- `perfect_binary_tree(depth)`
+- `regular_binary_tree(depth)`
   - *Description*: Generates a [perfect binary tree graph](https://en.wikipedia.org/wiki/Binary_tree) of the specified type
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - the type of the generated graph
@@ -91,7 +91,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - the type of the generated graph
     - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* perfect binary tree, an additional edge is added - $(v_j, v_i)$
-    - For undirected edges: equivalent to `perfect_binary_tree(n_vertices)`
+    - For undirected edges: equivalent to `regular_binary_tree(n_vertices)`
   - *Parameters*:
     - `depth: types::size_type` - the leaf depth of the generated binary tree graph
   - *Return type*: `GraphType`
@@ -141,8 +141,8 @@ int main() {
     print_graph(bidir_cycle, "bidirectional_cycle");
 
     // perfect binary tree graphs of depth 3
-    const auto bin_tree = gl::topology::perfect_binary_tree<graph_type>(3);
-    print_graph(bin_tree, "perfect_binary_tree");
+    const auto bin_tree = gl::topology::regular_binary_tree<graph_type>(3);
+    print_graph(bin_tree, "regular_binary_tree");
 
     const auto bidir_bin_tree = gl::topology::bidirectional_perfect_binary_tree<graph_type>(3);
     print_graph(bidir_bin_tree, "bidirectional_perfect_binary_tree");
@@ -198,7 +198,7 @@ directed 5 10
 - 3 : [3, 2] [3, 4]
 - 4 : [4, 3] [4, 0]
 
-> perfect_binary_tree:
+> regular_binary_tree:
 directed 7 6
 - 0 : [0, 1] [0, 2]
 - 1 : [1, 3] [1, 4]

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -78,7 +78,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Defined in*: [gl/topology/cycle.hpp](/include/gl/topology/cycle.hpp)
 
 - `regular_binary_tree(depth)`
-  - *Description*: Generates a [perfect binary tree graph](https://en.wikipedia.org/wiki/Binary_tree) of the specified type
+  - *Description*: Generates a [regular binary tree](#regular_dary_tree) of the specified type
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - the type of the generated graph
   - *Parameters*:
@@ -86,16 +86,20 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/binary_tree.hpp](/include/gl/topology/binary_tree.hpp)
 
-- `bidirectional_perfect_binary_tree(depth)`
-  - *Description*: Generates a bidirectional [perfect binary tree graph](https://en.wikipedia.org/wiki/Binary_tree) of the specified type:
+- `bidirectional_regular_binary_tree(depth)`
+  - *Description*: Generates a bidirectional [regular binary tree](#regular_dary_tree) of the specified type:
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - the type of the generated graph
-    - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* perfect binary tree, an additional edge is added - $(v_j, v_i)$
+    - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* regular binary tree, an additional edge is added - $(v_j, v_i)$
     - For undirected edges: equivalent to `regular_binary_tree(n_vertices)`
   - *Parameters*:
     - `depth: types::size_type` - the leaf depth of the generated binary tree graph
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/binary_tree.hpp](/include/gl/topology/binary_tree.hpp)
+
+> [!NOTE]
+> <a id="regular_dary_tree"></a>
+> A **regular d-ary tree** is a d-ary tree such that all nodes have exaclty 0 or d children and all leaves of such tree are at the same depth/level.
 
 <br />
 <br />
@@ -140,12 +144,12 @@ int main() {
     const auto bidir_cycle = gl::topology::bidirectional_cycle<graph_type>(5);
     print_graph(bidir_cycle, "bidirectional_cycle");
 
-    // perfect binary tree graphs of depth 3
+    // regular binary tree graphs of depth 3
     const auto bin_tree = gl::topology::regular_binary_tree<graph_type>(3);
     print_graph(bin_tree, "regular_binary_tree");
 
-    const auto bidir_bin_tree = gl::topology::bidirectional_perfect_binary_tree<graph_type>(3);
-    print_graph(bidir_bin_tree, "bidirectional_perfect_binary_tree");
+    const auto bidir_bin_tree = gl::topology::bidirectional_regular_binary_tree<graph_type>(3);
+    print_graph(bidir_bin_tree, "bidirectional_regular_binary_tree");
 }
 ```
 
@@ -208,7 +212,7 @@ directed 7 6
 - 5 :
 - 6 :
 
-> bidirectional_perfect_binary_tree:
+> bidirectional_regular_binary_tree:
 directed 7 12
 - 0 : [0, 1] [0, 2]
 - 1 : [1, 0] [1, 3] [1, 4]

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -23,7 +23,7 @@ constexpr types::size_type min_non_trivial_bin_tree_depth = constants::two;
 } // namespace detail
 
 template <type_traits::c_graph GraphType>
-[[nodiscard]] GraphType perfect_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType regular_binary_tree(const types::size_type depth) {
     if (depth < detail::min_non_trivial_bin_tree_depth)
         return GraphType{depth};
 
@@ -74,7 +74,7 @@ template <type_traits::c_graph GraphType>
         return graph;
     }
     else {
-        return perfect_binary_tree<GraphType>(depth);
+        return regular_binary_tree<GraphType>(depth);
     }
 }
 

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -47,7 +47,7 @@ template <type_traits::c_graph GraphType>
 }
 
 template <type_traits::c_graph GraphType>
-[[nodiscard]] GraphType bidirectional_perfect_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType bidirectional_regular_binary_tree(const types::size_type depth) {
     if constexpr (type_traits::is_directed_v<GraphType>) {
         if (depth < detail::min_non_trivial_bin_tree_depth)
             return GraphType{depth};

--- a/tests/source/test_alg_bfs.cpp
+++ b/tests/source/test_alg_bfs.cpp
@@ -159,7 +159,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::perfect_binary_tree<graph_type>(constants::three);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
     const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
 
     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());

--- a/tests/source/test_alg_coloring.cpp
+++ b/tests/source/test_alg_coloring.cpp
@@ -36,7 +36,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
                 expected_coloring.emplace_back(lib::bin_color_value::white);
         }
 
-        SUBCASE("perfect binary tree") {
+        SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
 
             lib_t::size_type n_vertices = constants::one_element;
@@ -128,7 +128,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             );
         }
 
-        SUBCASE("perfect binary tree with an additional edge between siblings") {
+        SUBCASE("regular binary tree with an additional edge between siblings") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             sut.add_edge(constants::vertex_id_2, constants::vertex_id_3);
         }

--- a/tests/source/test_alg_coloring.cpp
+++ b/tests/source/test_alg_coloring.cpp
@@ -37,7 +37,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         }
 
         SUBCASE("perfect binary tree") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
 
             lib_t::size_type n_vertices = constants::one_element;
             lib_t::binary_color c{lib::bin_color_value::black};
@@ -129,7 +129,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         }
 
         SUBCASE("perfect binary tree with an additional edge between siblings") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             sut.add_edge(constants::vertex_id_2, constants::vertex_id_3);
         }
 

--- a/tests/source/test_alg_dfs.cpp
+++ b/tests/source/test_alg_dfs.cpp
@@ -167,7 +167,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::perfect_binary_tree<graph_type>(constants::three);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
     const auto search_tree = lib::algorithm::depth_first_search<graph_type>(graph);
 
     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
@@ -354,7 +354,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::perfect_binary_tree<graph_type>(constants::three);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
     const auto search_tree = lib::algorithm::recursive_depth_first_search<graph_type>(graph);
 
     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());

--- a/tests/source/test_alg_dijkstra.cpp
+++ b/tests/source/test_alg_dijkstra.cpp
@@ -64,7 +64,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             }
         }
 
-        SUBCASE("perfect binary tree") {
+        SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 
@@ -174,7 +174,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 expected_distances.push_back(constants::one);
         }
 
-        SUBCASE("perfect binary tree") {
+        SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 

--- a/tests/source/test_alg_dijkstra.cpp
+++ b/tests/source/test_alg_dijkstra.cpp
@@ -65,7 +65,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("perfect binary tree") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 
             for (const auto id : sut.vertex_ids()) {
@@ -175,7 +175,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("perfect binary tree") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 
             for (const auto id : sut.vertex_ids()) {

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -46,7 +46,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         std::vector<vertex_id_pair> expected_edges;
         distance_type expected_weight;
 
-        SUBCASE("perfect binary tree") {
+        SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -47,7 +47,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         distance_type expected_weight;
 
         SUBCASE("perfect binary tree") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_element_idx;
 
             const weight_type edge_weight = constants::three;
@@ -129,7 +129,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
-    const auto sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
     const lib_t::id_type source_id = constants::first_element_idx;
 
     std::vector<vertex_id_pair> expected_edges;

--- a/tests/source/test_alg_topological_sort.cpp
+++ b/tests/source/test_alg_topological_sort.cpp
@@ -41,7 +41,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 expected_topological_order.push_back(id);
         }
 
-        SUBCASE("perfect binary tree") {
+        SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
 
             for (const auto id : sut.vertex_ids())

--- a/tests/source/test_alg_topological_sort.cpp
+++ b/tests/source/test_alg_topological_sort.cpp
@@ -42,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("perfect binary tree") {
-            sut = lib::topology::perfect_binary_tree<sut_type>(constants::depth);
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
 
             for (const auto id : sut.vertex_ids())
                 expected_topological_order.push_back(id);

--- a/tests/source/test_graph_topology_builders.cpp
+++ b/tests/source/test_graph_topology_builders.cpp
@@ -238,17 +238,17 @@ TEST_CASE_TEMPLATE_DEFINE(
         ));
     }
 
-    SUBCASE("perfect_binary_tree(depth) should return a perfect binay tree with the given depth") {
+    SUBCASE("regular_binary_tree(depth) should return a perfect binay tree with the given depth") {
         SUBCASE("depth = 0 : empty graph") {
             const auto complete_bin_tree =
-                lib::topology::perfect_binary_tree<graph_type>(constants::zero);
+                lib::topology::regular_binary_tree<graph_type>(constants::zero);
             REQUIRE_EQ(complete_bin_tree.n_vertices(), constants::zero_elements);
             REQUIRE_EQ(complete_bin_tree.n_unique_edges(), constants::zero_elements);
         }
 
         SUBCASE("depth = 1 : graph with one vertex and no edges") {
             const auto complete_bin_tree =
-                lib::topology::perfect_binary_tree<graph_type>(constants::one);
+                lib::topology::regular_binary_tree<graph_type>(constants::one);
             REQUIRE_EQ(complete_bin_tree.n_vertices(), constants::one_element);
             REQUIRE_EQ(complete_bin_tree.n_unique_edges(), constants::zero_elements);
         }
@@ -323,9 +323,9 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
     }
 
-    SUBCASE("perfect_binary_tree(depth) should return a one-way perfect binay tree with the "
+    SUBCASE("regular_binary_tree(depth) should return a one-way perfect binay tree with the "
             "given depth") {
-        const auto bin_tree = lib::topology::perfect_binary_tree<graph_type>(constants::depth);
+        const auto bin_tree = lib::topology::regular_binary_tree<graph_type>(constants::depth);
 
         const auto expected_n_vertices =
             lib::util::upow_sum(constants::two, constants::zero, constants::depth - constants::one);
@@ -414,11 +414,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
     }
 
-    SUBCASE("perfect_binary_tree(depth) should return a perfect binay tree with the given depth") {
+    SUBCASE("regular_binary_tree(depth) should return a perfect binay tree with the given depth") {
         graph_type bin_tree;
 
-        SUBCASE("perfect_binary_tree builder") {
-            bin_tree = lib::topology::perfect_binary_tree<graph_type>(constants::depth);
+        SUBCASE("regular_binary_tree builder") {
+            bin_tree = lib::topology::regular_binary_tree<graph_type>(constants::depth);
         }
 
         SUBCASE("bidirectional_perfect_binary_tree builder") {

--- a/tests/source/test_graph_topology_builders.cpp
+++ b/tests/source/test_graph_topology_builders.cpp
@@ -238,7 +238,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         ));
     }
 
-    SUBCASE("regular_binary_tree(depth) should return a perfect binay tree with the given depth") {
+    SUBCASE("regular_binary_tree(depth) should return a regular binay tree with the given depth") {
         SUBCASE("depth = 0 : empty graph") {
             const auto complete_bin_tree =
                 lib::topology::regular_binary_tree<graph_type>(constants::zero);
@@ -323,7 +323,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
     }
 
-    SUBCASE("regular_binary_tree(depth) should return a one-way perfect binay tree with the "
+    SUBCASE("regular_binary_tree(depth) should return a one-way regular binay tree with the "
             "given depth") {
         const auto bin_tree = lib::topology::regular_binary_tree<graph_type>(constants::depth);
 
@@ -337,10 +337,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         ));
     }
 
-    SUBCASE("bidirectional_perfect_binary_tree(depth) should return a two-way perfect binay tree "
+    SUBCASE("bidirectional_regular_binary_tree(depth) should return a two-way regular binay tree "
             "with the given depth") {
         const auto bin_tree =
-            lib::topology::bidirectional_perfect_binary_tree<graph_type>(constants::depth);
+            lib::topology::bidirectional_regular_binary_tree<graph_type>(constants::depth);
 
         const auto expected_n_vertices =
             lib::util::upow_sum(constants::two, constants::zero, constants::depth - constants::one);
@@ -414,16 +414,16 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
     }
 
-    SUBCASE("regular_binary_tree(depth) should return a perfect binay tree with the given depth") {
+    SUBCASE("regular_binary_tree(depth) should return a regular binay tree with the given depth") {
         graph_type bin_tree;
 
         SUBCASE("regular_binary_tree builder") {
             bin_tree = lib::topology::regular_binary_tree<graph_type>(constants::depth);
         }
 
-        SUBCASE("bidirectional_perfect_binary_tree builder") {
+        SUBCASE("bidirectional_regular_binary_tree builder") {
             bin_tree =
-                lib::topology::bidirectional_perfect_binary_tree<graph_type>(constants::depth);
+                lib::topology::bidirectional_regular_binary_tree<graph_type>(constants::depth);
         }
 
         CAPTURE(bin_tree);


### PR DESCRIPTION
Renamed the `perfect` binary tree generator and corresponding documentation pages to use `regular`