### PR TITLE
NONE: Modified the basic search algorithms to return a predecessors descriptor instead of a search tree

### DIFF
--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -29,7 +29,7 @@ This section covers the specific types and type traits used for the algorithm im
 ### Types
 
 > [!NOTE]
-> All types listed below are defined in the `gl::types` namespace
+> All types listed below are defined in the `gl::algorithm` namespace
 
 - `no_return` - A placeholder type to represent algorithms that do not return a value. It is primarily used in type traits to conditionally handle return types.
 - `empty_callback` - Represents an empty callback, used as a default value where no callback functionality is needed.
@@ -74,10 +74,10 @@ This section covers the specific types and type traits used for the algorithm im
 > All concepts listed below are defined in the `gl::type_traits` namespace
 
 - `c_alg_no_return_type`
-  - *Description*: Checks if the type `T` is `types::no_return`. Used to identify algorithms that do not return a value.
+  - *Description*: Checks if the type `T` is `algorithm::no_return`. Used to identify algorithms that do not return a value.
   - *Template parameters*:
     - `T` - the type to check.
-  - *Equivalent to*: `std::same_as<T, types::no_return>`
+  - *Equivalent to*: `std::same_as<T, algorithm::no_return>`
 
 - `c_alg_return_graph_type`
   - *Description*: Checks if the type `T` is a valid return type for graph algorithms, i.e., either a graph type or `no_return`.
@@ -86,13 +86,13 @@ This section covers the specific types and type traits used for the algorithm im
   - *Equivalent to*: `c_graph<T> or c_alg_no_return_type<T>`
 
 - `c_empty_callback`
-  - *Description*: Checks if a callback type is `types::empty_callback`. Used to determine when no callback is needed for an algorithm.
+  - *Description*: Checks if a callback type is `algorithm::empty_callback`. Used to determine when no callback is needed for an algorithm.
   - *Template parameters*:
     - `F` - the callback type to check.
-  - *Equivalent to*: `std::same_as<F, types::empty_callback>`
+  - *Equivalent to*: `std::same_as<F, algorithm::empty_callback>`
 
 - `c_optional_callback`
-  - *Description*: Checks if the given type is a valid callback or `types::empty_callback`.
+  - *Description*: Checks if the given type is a valid callback or `algorithm::empty_callback`.
   - *Template parameters*:
     - `F` - the callback type to check.
     - `ReturnType` - the expected return type of the callback type.
@@ -149,10 +149,10 @@ This section covers the specific types and type traits used for the algorithm im
   - *Description*: Performs an iterative depth-first search (DFS) on the specified graph.
 
   - *Template parameters*:
-    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `types::no_return`) - The type of the search tree to return, or `types::no_return`.
+    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `algorithm::no_return`) - The type of the search tree to return, or `algorithm::no_return`.
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -161,7 +161,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `algorithm::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
 
   - *Defined in*: [gl/algorithm/depth_first_search.hpp](/include/gl/algorithm/deapth_first_search.hpp)
 
@@ -178,10 +178,10 @@ This section covers the specific types and type traits used for the algorithm im
   - *Description*: Performs an breadth-first search (BFS) on the specified graph.
 
   - *Template parameters*:
-    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `types::no_return`) - The type of the search tree to return, or `types::no_return`.
+    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `algorithm::no_return`) - The type of the search tree to return, or `algorithm::no_return`.
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform BFS on.
@@ -190,7 +190,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `types::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `algorithm::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
 
   - *Defined in*: [gl/algorithm/breadth_first_search.hpp](/include/gl/algorithm/breadth_first_search.hpp)
 
@@ -204,8 +204,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the coloring on.
@@ -247,8 +247,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
@@ -296,8 +296,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_directed_graph` - The type of the graph on which the sorting is performed (must be directed).
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the coloring on.
@@ -316,8 +316,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_undirected_graph` - The type of the graph on which the search is performed (must be undirected).
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
@@ -367,8 +367,8 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
     - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
     - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
     - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -389,8 +389,8 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
     - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
     - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
     - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -414,12 +414,12 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `InitQueueRangeType: type_traits::c_sized_range_of<types::vertex_info>` (default = `std::vector<types::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
+    - `InitQueueRangeType: type_traits::c_sized_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
     - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
     - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
     - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -430,7 +430,7 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
     - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
-  - *Queue type:* `std::queue<types::vertex_info>`
+  - *Queue type:* `std::queue<algorithm::vertex_info>`
 
   - *Return type*: `void`
 
@@ -444,13 +444,13 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PQCompare: std::predicate<types::vertex_info, types::vertex_info>` - The type of the vertex priority queue comparator.
-    - `InitQueueRangeType: type_traits::c_sized_range_of<types::vertex_info>` (default = `std::vector<types::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
+    - `PQCompare: std::predicate<algorithm::vertex_info, algorithm::vertex_info>` - The type of the vertex priority queue comparator.
+    - `InitQueueRangeType: type_traits::c_sized_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
     - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
     - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
     - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `types::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -462,7 +462,7 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
     - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
-  - *Queue type:* `std::priority_queue<types::vertex_info, std::vector<types::vertex_info>, PQCompare>`
+  - *Queue type:* `std::priority_queue<algorithm::vertex_info, std::vector<algorithm::vertex_info>, PQCompare>`
 
   - *Return type*: `void`
 

--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -53,7 +53,7 @@ This section covers the specific types and type traits used for the algorithm im
   - *Constructors*:
     - `vertex_info(types::id_type id)` - initializes the object with the same value for `id` and `source_id` representing a starting vertex
     - `vertex_info(types::id_type id, types::id_type source_id)`
-  - *Members*:
+  - *Member variables*:
     - `id: types::id_type` - the ID of the vertex.
     - `source_id: types::id_type` - the ID of the source vertex, typically used during algorithms.
 
@@ -64,9 +64,29 @@ This section covers the specific types and type traits used for the algorithm im
   - *Constructors*:
     - `vertex_info(types::id_type id)` - initializes the object with the same value for `id` and `source_id` representing a starting vertex
     - `vertex_info(types::id_type id, types::id_type source_id)`
-  - *Members*:
+  - *Member variables*:
     - `edge: types::const_ref_wrap<EdgeType>` - a constant reference wrapper for the edge.
     - `source_id: types::id_type` - the ID of the source vertex of the held edge.
+
+- `predecessors_descriptor`
+  - *Description*: A structure that holds a collection of predecessors for a set of vertices.
+  - *Type definitions*:
+    - `predecessor_type: std::optional<types::id_type>` - the type of the predecessor, which can either be a valid vertex ID or empty (no predecessor).
+
+    **NOTE:** An empty predecessor means that a vertex is nor reachable from the source vertex, while `predecessor[ID] == ID` means that the vertex with such ID is the source vertex.
+
+  - *Constructors*:
+    - `predecessors_descriptor(types::size_type n_vertices)` - initializes the object with a vector of optional predecessors, sized to `n_vertices`.
+  - *Destructor*:
+    - `virtual ~predecessors_descriptor()` - default destructor.
+  - *Member variables*:
+    - `predecessors: std::vector<std::optional<types::id_type>>` - a vector of optional IDs, where each element represents a predecessor for a vertex. If a vertex has no predecessor, the corresponding element is empty.
+  - *Member functions*:
+    - `is_reachable(types::id_type vertex_id) const -> bool` - checks if a vertex is reachable by verifying if its predecessor exists (i.e., if the optional value is set).
+    - `operator[](types::size_type i) const` - returns a constant reference to the predecessor at index `i`.
+    - `operator[](types::size_type i)` - returns a reference to the predecessor at index `i`.
+    - `at(types::size_type i) const` - returns a constant reference to the predecessor at index `i`, with bounds checking.
+    - `at(types::size_type i)` - returns a reference to the predecessor at index `i`, with bounds checking.
 
 ### Concepts
 
@@ -146,10 +166,10 @@ This section covers the specific types and type traits used for the algorithm im
 ### Depth-first search
 
 - `depth_first_search(graph, root_vertex_id_opt, pre_visit, post_visit)`
-  - *Description*: Performs an iterative depth-first search (DFS) on the specified graph.
+  - *Description*: Performs an iterative depth-first search (DFS) on the specified graph and conditionally returns a `predecessors_descriptor` instance.
 
   - *Template parameters*:
-    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `algorithm::no_return`) - The type of the search tree to return, or `algorithm::no_return`.
+    - `AlgReturnType: type_traits::c_alg_return_type` (default = `algorithm::default_return`) - Specifies whether the algorrithm should return the predecessors descriptor or not (can be eigher `algorithm::default_return` or `algorithm::no_return`).
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
     - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
@@ -161,12 +181,12 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `algorithm::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_type<AlgReturnType, predecessors_descriptor>` - If `AlgReturnType` is `algorithm::no_return` - nothing will be returned (`void`). Otherwise the algorithm will return an instance of `predecessors_descriptor`.
 
   - *Defined in*: [gl/algorithm/depth_first_search.hpp](/include/gl/algorithm/deapth_first_search.hpp)
 
 - `recursive_depth_first_search(graph, root_vertex_id_opt, pre_visit, post_visit)`
-  - *Description*: Performs a recursive depth-first search (DFS) on the specified graph.
+  - *Description*: Performs a recursive depth-first search (DFS) on the specified graph and conditionally returns a `predecessors_descriptor` instance.
 
     **NOTE:** This algoithm has the same template parameters, parameters and return type as the iterative version (`depth_first_search`)
 
@@ -175,10 +195,10 @@ This section covers the specific types and type traits used for the algorithm im
 ### Breadth-first search
 
 - `breadth_first_search(graph, root_vertex_id_opt, pre_visit, post_visit)`
-  - *Description*: Performs an breadth-first search (BFS) on the specified graph.
+  - *Description*: Performs an breadth-first search (BFS) on the specified graph and conditionally returns a `predecessors_descriptor` instance.
 
   - *Template parameters*:
-    - `SearchTreeType: type_traits::c_alg_return_graph_type` (default = `algorithm::no_return`) - The type of the search tree to return, or `algorithm::no_return`.
+    - `AlgReturnType: type_traits::c_alg_return_type` (default = `algorithm::default_return`) - Specifies whether the algorrithm should return the predecessors descriptor or not (can be eigher `algorithm::default_return` or `algorithm::no_return`).
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
     - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
@@ -190,7 +210,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `impl::alg_return_graph_type<SearchTreeType>` - If `SearchTreeType` is not `algorithm::no_return`, returns a search tree of type `SearchTreeType`. Otherwise, the return type is `void`.
+    - `impl::alg_return_type<AlgReturnType, predecessors_descriptor>` - If `AlgReturnType` is `algorithm::no_return` - nothing will be returned (`void`). Otherwise the algorithm will return an instance of `predecessors_descriptor`.
 
   - *Defined in*: [gl/algorithm/breadth_first_search.hpp](/include/gl/algorithm/breadth_first_search.hpp)
 
@@ -277,7 +297,11 @@ This section covers the specific types and type traits used for the algorithm im
 >     **NOTE:** If a predecessor at index $i$ is null, then the vertex $v$ in the graph such that $v_{id} = i$ is unreachable.
 >   - `distances: std::vector<distance_type>` - A list of vertex distances from a source vertex.
 > - *Member functions*:
->   - `is_reachable(vertex_id) const -> bool` - equivalent to `predecessors.at(vertex_id).has_value()`
+>   - `is_reachable(types::id_type vertex_id) const -> bool` - checks if a vertex is reachable by verifying if its predecessor exists (i.e., if the optional value is set).
+>   - `operator[](types::size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`.
+>   - `operator[](types::size_type i)` - returns a pair of references to the predecessor and distance at index `i`.
+>   - `at(types::size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`, with bounds checking.
+>   - `at(types::size_type i)` - returns a pair of references to the predecessor and distance at index `i`, with bounds checking.
 
 - `reconstruct_path(predecessor_map, vetex_id)`
   - *Description*: Reconstructs a path to the search vertex $v$ such that $v_{id} = \text{vertex-id}$ from the given predecessor map

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -11,13 +11,13 @@
 namespace gl::algorithm {
 
 template <
-    type_traits::c_alg_return_graph_type SearchTreeType = types::no_return,
+    type_traits::c_alg_return_type AlgReturnType = algorithm::default_return,
     type_traits::c_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
-impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
+        algorithm::empty_callback>
+impl::alg_return_type<AlgReturnType, predecessors_descriptor> breadth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -29,14 +29,14 @@ impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
+    auto pd = impl::init_return_value<AlgReturnType, predecessors_descriptor>(graph);
 
     if (root_vertex_id_opt) {
         impl::bfs(
             graph,
             impl::init_range(root_vertex_id_opt.value()),
             impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
             pre_visit,
             post_visit
@@ -48,15 +48,15 @@ impl::alg_return_graph_type<SearchTreeType> breadth_first_search(
                 graph,
                 impl::init_range(root_id),
                 impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
                 pre_visit,
                 post_visit
             );
     }
 
-    if constexpr (not type_traits::c_alg_no_return_type<SearchTreeType>)
-        return search_tree;
+    if constexpr (not type_traits::c_alg_no_return_type<AlgReturnType>)
+        return pd;
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -13,9 +13,9 @@ using bicoloring_type = std::vector<types::binary_color>;
 template <
     type_traits::c_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 [[nodiscard]] std::optional<bicoloring_type> bipartite_coloring(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -39,8 +39,8 @@ template <
         const bool is_bipartite = impl::bfs(
             graph,
             impl::init_range(root_id),
-            types::empty_callback{}, // visit predicate
-            types::empty_callback{}, // visit callback
+            algorithm::empty_callback{}, // visit predicate
+            algorithm::empty_callback{}, // visit callback
             [&coloring](const vertex_type& vertex, const edge_type& in_edge)
                 -> std::optional<bool> { // enqueue predicate
                 if (in_edge.is_loop())

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -10,13 +10,13 @@
 namespace gl::algorithm {
 
 template <
-    type_traits::c_alg_return_graph_type SearchTreeType = types::no_return,
+    type_traits::c_alg_return_type AlgReturnType = algorithm::default_return,
     type_traits::c_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
-impl::alg_return_graph_type<SearchTreeType> depth_first_search(
+        algorithm::empty_callback>
+impl::alg_return_type<AlgReturnType, predecessors_descriptor> depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -28,14 +28,14 @@ impl::alg_return_graph_type<SearchTreeType> depth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
+    auto pd = impl::init_return_value<AlgReturnType, predecessors_descriptor>(graph);
 
     if (root_vertex_id_opt) {
         impl::dfs(
             graph,
             graph.get_vertex(root_vertex_id_opt.value()),
             impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
@@ -47,25 +47,25 @@ impl::alg_return_graph_type<SearchTreeType> depth_first_search(
                 graph,
                 root_vertex,
                 impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit
             );
     }
 
-    if constexpr (not type_traits::c_alg_no_return_type<SearchTreeType>)
-        return search_tree;
+    if constexpr (not type_traits::c_alg_no_return_type<AlgReturnType>)
+        return pd;
 }
 
 template <
-    type_traits::c_alg_return_graph_type SearchTreeType = types::no_return,
+    type_traits::c_alg_return_type AlgReturnType = algorithm::default_return,
     type_traits::c_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
-impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
+        algorithm::empty_callback>
+impl::alg_return_type<AlgReturnType, predecessors_descriptor> recursive_depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
@@ -77,7 +77,7 @@ impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
-    auto search_tree = impl::init_search_tree<SearchTreeType>(graph);
+    auto pd = impl::init_return_value<AlgReturnType, predecessors_descriptor>(graph);
 
     if (root_vertex_id_opt) {
         const auto root_id = root_vertex_id_opt.value();
@@ -86,7 +86,7 @@ impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
             graph.get_vertex(root_id),
             root_id,
             impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType>(visited, search_tree),
+            impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
@@ -99,15 +99,15 @@ impl::alg_return_graph_type<SearchTreeType> recursive_depth_first_search(
                 root_vertex,
                 root_vertex.id(),
                 impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType>(visited, search_tree),
+                impl::default_visit_callback<GraphType, AlgReturnType>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit
             );
     }
 
-    if constexpr (not type_traits::c_alg_no_return_type<SearchTreeType>)
-        return search_tree;
+    if constexpr (not type_traits::c_alg_no_return_type<AlgReturnType>)
+        return pd;
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -12,17 +12,17 @@ namespace gl::algorithm::impl {
 
 template <
     type_traits::c_graph GraphType,
-    type_traits::c_sized_range_of<types::vertex_info> InitQueueRangeType =
-        std::vector<types::vertex_info>,
+    type_traits::c_sized_range_of<algorithm::vertex_info> InitQueueRangeType =
+        std::vector<algorithm::vertex_info>,
     type_traits::c_optional_vertex_callback<GraphType, bool> VisitVertexPredicate,
     type_traits::c_optional_vertex_callback<GraphType, bool, types::id_type> VisitCallback,
     type_traits::
         c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>
             EnqueueVertexPred,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 bool bfs(
     const GraphType& graph,
     const InitQueueRangeType& initial_queue_content,
@@ -36,7 +36,7 @@ bool bfs(
         return false;
 
     // prepare the vertex queue
-    using vertex_queue_type = std::queue<types::vertex_info>;
+    using vertex_queue_type = std::queue<algorithm::vertex_info>;
     vertex_queue_type vertex_queue;
 
     // TODO [C++23]: replace with push_range
@@ -45,7 +45,7 @@ bool bfs(
 
     // search the graph
     while (not vertex_queue.empty()) {
-        const types::vertex_info vinfo = vertex_queue.front();
+        const algorithm::vertex_info vinfo = vertex_queue.front();
         vertex_queue.pop();
 
         const auto& vertex = graph.get_vertex(vinfo.id);

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -10,19 +10,24 @@ namespace gl::algorithm::impl {
 
 // --- common functions ---
 
-template <type_traits::c_alg_return_graph_type SearchTreeType, type_traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline SearchTreeType init_search_tree(const GraphType& graph) {
-    if constexpr (type_traits::c_alg_no_return_type<SearchTreeType>)
-        return SearchTreeType{};
+template <
+    type_traits::c_alg_return_type AlgReturnType,
+    typename ReturnType,
+    type_traits::c_graph GraphType>
+[[nodiscard]] gl_attr_force_inline alg_return_type<AlgReturnType, ReturnType> init_return_value(
+    const GraphType& graph
+) {
+    if constexpr (type_traits::c_alg_no_return_type<AlgReturnType>)
+        return AlgReturnType{};
     else
-        return SearchTreeType(graph.n_vertices());
+        return ReturnType(graph.n_vertices());
 }
 
 template <
-    type_traits::c_sized_range_of<types::vertex_info> InitRangeType =
-        std::vector<types::vertex_info>>
+    type_traits::c_sized_range_of<algorithm::vertex_info> InitRangeType =
+        std::vector<algorithm::vertex_info>>
 [[nodiscard]] gl_attr_force_inline InitRangeType init_range(types::id_type root_vertex_id) {
-    return InitRangeType{types::vertex_info{root_vertex_id}};
+    return InitRangeType{algorithm::vertex_info{root_vertex_id}};
 }
 
 template <type_traits::c_graph GraphType>
@@ -32,17 +37,15 @@ template <type_traits::c_graph GraphType>
     };
 }
 
-template <type_traits::c_graph GraphType, type_traits::c_alg_return_graph_type SearchTreeType>
+template <type_traits::c_graph GraphType, type_traits::c_alg_return_type AlgReturnType>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
-    std::vector<bool>& visited, SearchTreeType& search_tree
+    std::vector<bool>& visited, alg_return_type<AlgReturnType, predecessors_descriptor>& pd
 ) {
     return [&](const typename GraphType::vertex_type& vertex, const types::id_type source_id) {
         const auto vertex_id = vertex.id();
         visited[vertex_id] = true;
-        if constexpr (not type_traits::c_alg_no_return_type<SearchTreeType>) {
-            if (source_id != vertex_id)
-                search_tree.add_edge(source_id, vertex_id);
-        }
+        if constexpr (type_traits::c_alg_default_return_type<AlgReturnType>)
+            pd[vertex_id].emplace(source_id);
         return true;
     };
 }

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -14,9 +14,8 @@ template <
     type_traits::c_alg_return_type AlgReturnType,
     typename ReturnType,
     type_traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline alg_return_type<AlgReturnType, ReturnType> init_return_value(
-    const GraphType& graph
-) {
+[[nodiscard]] gl_attr_force_inline alg_return_type_non_void<AlgReturnType, ReturnType>
+init_return_value(const GraphType& graph) {
     if constexpr (type_traits::c_alg_no_return_type<AlgReturnType>)
         return AlgReturnType{};
     else
@@ -39,7 +38,7 @@ template <type_traits::c_graph GraphType>
 
 template <type_traits::c_graph GraphType, type_traits::c_alg_return_type AlgReturnType>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
-    std::vector<bool>& visited, alg_return_type<AlgReturnType, predecessors_descriptor>& pd
+    std::vector<bool>& visited, alg_return_type_non_void<AlgReturnType, predecessors_descriptor>& pd
 ) {
     return [&](const typename GraphType::vertex_type& vertex, const types::id_type source_id) {
         const auto vertex_id = vertex.id();

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -18,9 +18,9 @@ template <
         c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>
             EnqueueVertexPred,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 void dfs(
     const GraphType& graph,
     const typename GraphType::vertex_type& root_vertex,
@@ -30,7 +30,7 @@ void dfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_stack_type = std::stack<types::vertex_info>;
+    using vertex_stack_type = std::stack<algorithm::vertex_info>;
 
     if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
         if (not visit_vertex_pred(root_vertex))
@@ -74,9 +74,9 @@ template <
         c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>
             EnqueueVertexPred,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 void r_dfs(
     const GraphType& graph,
     const typename GraphType::vertex_type& vertex,

--- a/include/gl/algorithm/impl/pfs.hpp
+++ b/include/gl/algorithm/impl/pfs.hpp
@@ -12,18 +12,18 @@ namespace gl::algorithm::impl {
 
 template <
     type_traits::c_graph GraphType,
-    std::predicate<types::vertex_info, types::vertex_info> PQCompare,
-    type_traits::c_sized_range_of<types::vertex_info> InitQueueRangeType =
-        std::vector<types::vertex_info>,
+    std::predicate<algorithm::vertex_info, algorithm::vertex_info> PQCompare,
+    type_traits::c_sized_range_of<algorithm::vertex_info> InitQueueRangeType =
+        std::vector<algorithm::vertex_info>,
     type_traits::c_optional_vertex_callback<GraphType, bool> VisitVertexPredicate,
     type_traits::c_optional_callback<GraphType, bool, types::id_type> VisitCallback,
     type_traits::
         c_vertex_callback<GraphType, std::optional<bool>, const typename GraphType::edge_type&>
             EnqueueVertexPred,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 bool pfs(
     const GraphType& graph,
     const PQCompare& pq_compare,
@@ -39,7 +39,7 @@ bool pfs(
 
     // prepare the vertex queue
     using vertex_queue_type =
-        std::priority_queue<types::vertex_info, std::vector<types::vertex_info>, PQCompare>;
+        std::priority_queue<algorithm::vertex_info, std::vector<algorithm::vertex_info>, PQCompare>;
     vertex_queue_type vertex_queue(pq_compare);
 
     // TODO [C++23]: replace with push_range

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -28,9 +28,9 @@ struct mst_descriptor {
 template <
     type_traits::c_undirected_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 [[nodiscard]] mst_descriptor<GraphType> prim_mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
@@ -41,7 +41,7 @@ template <
 
     using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
-    using edge_info_type = types::edge_info<edge_type>;
+    using edge_info_type = algorithm::edge_info<edge_type>;
     using distance_type = types::vertex_distance_type<GraphType>;
 
     struct edge_info_comparator {

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -11,9 +11,9 @@ namespace gl::algorithm {
 template <
     type_traits::c_directed_graph GraphType,
     type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        types::empty_callback,
+        algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        types::empty_callback>
+        algorithm::empty_callback>
 [[nodiscard]] std::optional<std::vector<types::id_type>> topological_sort(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -31,7 +31,7 @@ template <
         vertex_in_deg_list.push_back(graph.in_degree(id));
 
     // prepare the initial queue content (source vertices)
-    std::vector<types::vertex_info> source_vertex_list;
+    std::vector<algorithm::vertex_info> source_vertex_list;
     source_vertex_list.reserve(graph.n_vertices());
     for (const auto id : vertex_ids)
         if (vertex_in_deg_list[id] == constants::default_size)
@@ -45,7 +45,7 @@ template <
     impl::bfs(
         graph,
         source_vertex_list,
-        types::empty_callback{}, // visit predicate
+        algorithm::empty_callback{}, // visit predicate
         [&topological_order](
             const vertex_type& vertex, const types::id_type source_id
         ) { // visit callback

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -108,8 +108,12 @@ concept c_optional_edge_callback =
 namespace algorithm::impl {
 
 template <type_traits::c_alg_return_type AlgReturnType, typename DefaultReturnType>
-using alg_return_type = std::
-    conditional_t<type_traits::c_alg_default_return_type<AlgReturnType>, DefaultReturnType, void>;
+using alg_return_type =
+    std::conditional_t<type_traits::c_alg_no_return_type<AlgReturnType>, void, DefaultReturnType>;
+
+template <type_traits::c_alg_return_type AlgReturnType, typename DefaultReturnType>
+using alg_return_type_non_void = std::
+    conditional_t<type_traits::c_alg_no_return_type<AlgReturnType>, no_return, DefaultReturnType>;
 
 } // namespace algorithm::impl
 

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -10,7 +10,9 @@
 
 namespace gl {
 
-namespace types {
+namespace algorithm {
+
+struct default_return {};
 
 struct no_return {};
 
@@ -34,18 +36,53 @@ struct edge_info {
     types::id_type source_id;
 };
 
-} // namespace types
+struct predecessors_descriptor {
+    using predecessor_type = std::optional<types::id_type>;
+
+    predecessors_descriptor(const types::size_type n_vertices) : predecessors(n_vertices) {
+        predecessors.shrink_to_fit();
+    }
+
+    virtual ~predecessors_descriptor() = default;
+
+    [[nodiscard]] gl_attr_force_inline bool is_reachable(const types::id_type vertex_id) const {
+        return this->at(vertex_id).has_value();
+    }
+
+    [[nodiscard]] const predecessor_type& operator[](const types::size_type i) const {
+        return this->predecessors[i];
+    }
+
+    [[nodiscard]] predecessor_type& operator[](const types::size_type i) {
+        return this->predecessors[i];
+    }
+
+    [[nodiscard]] const predecessor_type& at(const types::size_type i) const {
+        return this->predecessors.at(i);
+    }
+
+    [[nodiscard]] predecessor_type& at(const types::size_type i) {
+        return this->predecessors.at(i);
+    }
+
+    std::vector<predecessor_type> predecessors;
+};
+
+} // namespace algorithm
 
 namespace type_traits {
 
 template <typename T>
-concept c_alg_no_return_type = std::same_as<T, types::no_return>;
+concept c_alg_default_return_type = std::same_as<T, algorithm::default_return>;
 
 template <typename T>
-concept c_alg_return_graph_type = c_graph<T> or c_alg_no_return_type<T>;
+concept c_alg_no_return_type = std::same_as<T, algorithm::no_return>;
+
+template <typename T>
+concept c_alg_return_type = c_alg_default_return_type<T> or c_alg_no_return_type<T>;
 
 template <typename F>
-concept c_empty_callback = std::same_as<F, types::empty_callback>;
+concept c_empty_callback = std::same_as<F, algorithm::empty_callback>;
 
 template <typename F, typename ReturnType, typename... Args>
 concept c_optional_callback = c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>;
@@ -70,9 +107,9 @@ concept c_optional_edge_callback =
 
 namespace algorithm::impl {
 
-template <type_traits::c_alg_return_graph_type ReturnGraphType>
-using alg_return_graph_type =
-    std::conditional_t<type_traits::c_alg_no_return_type<ReturnGraphType>, void, ReturnGraphType>;
+template <type_traits::c_alg_return_type AlgReturnType, typename DefaultReturnType>
+using alg_return_type = std::
+    conditional_t<type_traits::c_alg_default_return_type<AlgReturnType>, DefaultReturnType, void>;
 
 } // namespace algorithm::impl
 

--- a/tests/include/alg_common.hpp
+++ b/tests/include/alg_common.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "constants.hpp"
 #include "namespaces.hpp"
 #include "types.hpp"
 
+#include <gl/algorithms.hpp>
 #include <gl/graph.hpp>
 #include <gl/graph_file_io.hpp>
 
@@ -30,6 +32,20 @@ requires(lib_tt::c_readable<T>)
         file >> list[i];
 
     return list;
+}
+
+[[nodiscard]] inline auto has_correct_bin_predecessor(
+    const lib::algorithm::predecessors_descriptor& pd
+) {
+    return [&pd](const lib_t::id_type vertex_id) {
+        if (not pd.is_reachable(vertex_id))
+            return false;
+
+        if (vertex_id == constants::first_element_idx)
+            return pd[vertex_id] == vertex_id;
+
+        return pd[vertex_id] == ((vertex_id - constants::one) / constants::two);
+    };
 }
 
 template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>

--- a/tests/include/alg_common.hpp
+++ b/tests/include/alg_common.hpp
@@ -48,29 +48,6 @@ requires(lib_tt::c_readable<T>)
     };
 }
 
-template <lib_tt::c_graph GraphType1, lib_tt::c_graph GraphType2>
-[[nodiscard]] auto are_vertices_equivalent(const GraphType1& g1, const GraphType2& g2) {
-    return [&](const lib_t::id_type vertex_id) {
-        const auto adj_edges_1 = g1.adjacent_edges(vertex_id);
-        const auto adj_edges_2 = g2.adjacent_edges(vertex_id);
-
-        if (adj_edges_2.distance() != adj_edges_1.distance())
-            return false;
-
-        for (const auto& edge : adj_edges_1) {
-            if (not g2.has_edge(edge.first_id(), edge.second_id()))
-                return false;
-        }
-
-        for (const auto& edge : adj_edges_2) {
-            if (not g1.has_edge(edge.first_id(), edge.second_id()))
-                return false;
-        }
-
-        return true;
-    };
-}
-
 template <lib_tt::c_instantiation_of<lib::vertex_descriptor> VertexType>
 requires(std::same_as<typename VertexType::properties_type, types::visited_property>)
 struct vertex_visited_projection {

--- a/tests/source/test_alg_bfs.cpp
+++ b/tests/source/test_alg_bfs.cpp
@@ -59,7 +59,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::breadth_first_search(
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
@@ -128,7 +128,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::breadth_first_search(
+    lib::algorithm::breadth_first_search<lib::algorithm::no_return>(
         graph,
         root_vertex_id,
         [&](const auto& vertex) { // previsit
@@ -151,34 +151,33 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-// TEST_CASE_TEMPLATE_DEFINE(
-//     "breadth_first_search with return should properly traverse the graph",
-//     GraphType,
-//     bfs_return_graph_template
-// ) {
-//     using graph_type = GraphType;
-//     using vertex_type = typename graph_type::vertex_type;
+TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search with return should properly traverse the graph",
+    GraphType,
+    bfs_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename graph_type::vertex_type;
 
-//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-//     const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto pd =
+        lib::algorithm::breadth_first_search<lib::algorithm::default_return, graph_type>(graph);
 
-//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
 
-//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
 
-//     // verify that for each vertex the edges are equivalent to those in the original graph
-//     CHECK(
-//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-//     );
-// }
+    // verify the predecessors of each vertex
+    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
+}
 
-// TEST_CASE_TEMPLATE_INSTANTIATE(
-//     bfs_return_graph_template,
-//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-// );
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
 
 TEST_SUITE_END(); // test_alg_bfs
 

--- a/tests/source/test_alg_bfs.cpp
+++ b/tests/source/test_alg_bfs.cpp
@@ -151,34 +151,34 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-TEST_CASE_TEMPLATE_DEFINE(
-    "breadth_first_search with return should properly traverse the graph",
-    GraphType,
-    bfs_return_graph_template
-) {
-    using graph_type = GraphType;
-    using vertex_type = typename graph_type::vertex_type;
+// TEST_CASE_TEMPLATE_DEFINE(
+//     "breadth_first_search with return should properly traverse the graph",
+//     GraphType,
+//     bfs_return_graph_template
+// ) {
+//     using graph_type = GraphType;
+//     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-    const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
+//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+//     const auto search_tree = lib::algorithm::breadth_first_search<graph_type>(graph);
 
-    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
 
-    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
 
-    // verify that for each vertex the edges are equivalent to those in the original graph
-    CHECK(
-        std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-    );
-}
+//     // verify that for each vertex the edges are equivalent to those in the original graph
+//     CHECK(
+//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
+//     );
+// }
 
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    bfs_return_graph_template,
-    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-);
+// TEST_CASE_TEMPLATE_INSTANTIATE(
+//     bfs_return_graph_template,
+//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+// );
 
 TEST_SUITE_END(); // test_alg_bfs
 

--- a/tests/source/test_alg_bfs.cpp
+++ b/tests/source/test_alg_bfs.cpp
@@ -163,11 +163,8 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto pd =
         lib::algorithm::breadth_first_search<lib::algorithm::default_return, graph_type>(graph);
 
-    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
-
-    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
-
     // verify the predecessors of each vertex
+    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
     CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
 }
 

--- a/tests/source/test_alg_dfs.cpp
+++ b/tests/source/test_alg_dfs.cpp
@@ -159,34 +159,34 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-TEST_CASE_TEMPLATE_DEFINE(
-    "depth_first_search with return should properly traverse the graph",
-    GraphType,
-    dfs_return_graph_template
-) {
-    using graph_type = GraphType;
-    using vertex_type = typename graph_type::vertex_type;
+// TEST_CASE_TEMPLATE_DEFINE(
+//     "depth_first_search with return should properly traverse the graph",
+//     GraphType,
+//     dfs_return_graph_template
+// ) {
+//     using graph_type = GraphType;
+//     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-    const auto search_tree = lib::algorithm::depth_first_search<graph_type>(graph);
+//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+//     const auto search_tree = lib::algorithm::depth_first_search<graph_type>(graph);
 
-    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
 
-    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
 
-    // verify that for each vertex the edges are equivalent to those in the original graph
-    CHECK(
-        std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-    );
-}
+//     // verify that for each vertex the edges are equivalent to those in the original graph
+//     CHECK(
+//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
+//     );
+// }
 
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    dfs_return_graph_template,
-    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-);
+// TEST_CASE_TEMPLATE_INSTANTIATE(
+//     dfs_return_graph_template,
+//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+// );
 
 // --- recursive dfs tests ---
 
@@ -346,34 +346,34 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-TEST_CASE_TEMPLATE_DEFINE(
-    "recursive_depth_first_search with return should properly traverse the graph",
-    GraphType,
-    rdfs_return_graph_template
-) {
-    using graph_type = GraphType;
-    using vertex_type = typename graph_type::vertex_type;
+// TEST_CASE_TEMPLATE_DEFINE(
+//     "recursive_depth_first_search with return should properly traverse the graph",
+//     GraphType,
+//     rdfs_return_graph_template
+// ) {
+//     using graph_type = GraphType;
+//     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-    const auto search_tree = lib::algorithm::recursive_depth_first_search<graph_type>(graph);
+//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+//     const auto search_tree = lib::algorithm::recursive_depth_first_search<graph_type>(graph);
 
-    REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
 
-    const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
+//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
 
-    // verify that for each vertex the edges are equivalent to those in the original graph
-    CHECK(
-        std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-    );
-}
+//     // verify that for each vertex the edges are equivalent to those in the original graph
+//     CHECK(
+//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
+//     );
+// }
 
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    rdfs_return_graph_template,
-    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-);
+// TEST_CASE_TEMPLATE_INSTANTIATE(
+//     rdfs_return_graph_template,
+//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+// );
 
 TEST_SUITE_END(); // test_alg_dfs
 

--- a/tests/source/test_alg_dfs.cpp
+++ b/tests/source/test_alg_dfs.cpp
@@ -159,34 +159,30 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-// TEST_CASE_TEMPLATE_DEFINE(
-//     "depth_first_search with return should properly traverse the graph",
-//     GraphType,
-//     dfs_return_graph_template
-// ) {
-//     using graph_type = GraphType;
-//     using vertex_type = typename graph_type::vertex_type;
+TEST_CASE_TEMPLATE_DEFINE(
+    "depth_first_search with return should properly traverse the graph",
+    GraphType,
+    dfs_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename graph_type::vertex_type;
 
-//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-//     const auto search_tree = lib::algorithm::depth_first_search<graph_type>(graph);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto pd =
+        lib::algorithm::depth_first_search<lib::algorithm::default_return, graph_type>(graph);
 
-//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+    // verify the predecessors of each vertex
+    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
+    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
+}
 
-//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
-
-//     // verify that for each vertex the edges are equivalent to those in the original graph
-//     CHECK(
-//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-//     );
-// }
-
-// TEST_CASE_TEMPLATE_INSTANTIATE(
-//     dfs_return_graph_template,
-//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-// );
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    dfs_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
 
 // --- recursive dfs tests ---
 
@@ -346,34 +342,32 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
 );
 
-// TEST_CASE_TEMPLATE_DEFINE(
-//     "recursive_depth_first_search with return should properly traverse the graph",
-//     GraphType,
-//     rdfs_return_graph_template
-// ) {
-//     using graph_type = GraphType;
-//     using vertex_type = typename graph_type::vertex_type;
+TEST_CASE_TEMPLATE_DEFINE(
+    "recursive_depth_first_search with return should properly traverse the graph",
+    GraphType,
+    rdfs_return_graph_template
+) {
+    using graph_type = GraphType;
+    using vertex_type = typename graph_type::vertex_type;
 
-//     const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
-//     const auto search_tree = lib::algorithm::recursive_depth_first_search<graph_type>(graph);
+    const auto graph = lib::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto pd =
+        lib::algorithm::recursive_depth_first_search<lib::algorithm::default_return, graph_type>(
+            graph
+        );
 
-//     REQUIRE_EQ(search_tree.n_vertices(), graph.n_vertices());
+    // verify the predecessors of each vertex
+    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
+    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
+}
 
-//     const auto vertex_id_view = std::views::iota(constants::first_element_idx, graph.n_vertices());
-
-//     // verify that for each vertex the edges are equivalent to those in the original graph
-//     CHECK(
-//         std::ranges::all_of(vertex_id_view, alg_common::are_vertices_equivalent(graph, search_tree))
-//     );
-// }
-
-// TEST_CASE_TEMPLATE_INSTANTIATE(
-//     rdfs_return_graph_template,
-//     lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
-//     lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
-//     lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
-//     lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
-// );
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    rdfs_return_graph_template,
+    lib::graph<lib::list_graph_traits<lib::directed_t>>, // directed adjacency list
+    lib::graph<lib::list_graph_traits<lib::undirected_t>>, // undirected adjacency list
+    lib::graph<lib::matrix_graph_traits<lib::directed_t>>, // directed adjacency matrix
+    lib::graph<lib::matrix_graph_traits<lib::undirected_t>> // undirected adjacency matrix
+);
 
 TEST_SUITE_END(); // test_alg_dfs
 

--- a/tests/source/test_alg_dfs.cpp
+++ b/tests/source/test_alg_dfs.cpp
@@ -67,7 +67,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::depth_first_search(
+    lib::algorithm::depth_first_search<lib::algorithm::no_return>(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
@@ -136,7 +136,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<lib_t::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::depth_first_search(
+    lib::algorithm::depth_first_search<lib::algorithm::no_return>(
         graph,
         root_vertex_id,
         [&](const auto& vertex) { // previsit
@@ -245,7 +245,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto expected_postvisit_order = std::views::reverse(expected_previsit_order);
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::recursive_depth_first_search(
+    lib::algorithm::recursive_depth_first_search<lib::algorithm::no_return>(
         graph,
         lib::algorithm::no_root_vertex,
         [&](const auto& vertex) { // previsit
@@ -319,7 +319,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto expected_postvisit_order = std::views::reverse(expected_previsit_order);
 
     std::vector<lib_t::id_type> previsit_order, postvisit_order;
-    lib::algorithm::recursive_depth_first_search(
+    lib::algorithm::recursive_depth_first_search<lib::algorithm::no_return>(
         graph,
         root_vertex_id,
         [&](const auto& vertex) { // previsit


### PR DESCRIPTION
- Replaced the search tree type utility with a generic algorithm return type utility
- Added the `predecessors_descriptor` structure
- Modified the basic search algorithms to return a predecessors descriptor instead of a search tree
- Aligned tests and documentation