### PR TITLE
NONE: Prim's MST finding algorithm fix

### DIFF
--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -85,14 +85,15 @@ template <
         const auto min_weight = get_weight<GraphType>(min_edge);
 
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
-        if (not visited[target_id]) {
-            // add the minimum weight edge to the mst
-            mst.edges.emplace_back(min_edge);
-            mst.weight += min_weight;
+        if (visited[target_id])
+            continue;
 
-            visited[target_id] = true;
-            ++n_vertices_in_mst;
-        }
+        // add the minimum weight edge to the mst
+        mst.edges.emplace_back(min_edge);
+        mst.weight += min_weight;
+
+        visited[target_id] = true;
+        ++n_vertices_in_mst;
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.adjacent_edges(target_id))

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -84,14 +84,6 @@ template <
         const auto& min_edge = min_edge_info.edge.get();
         const auto min_weight = get_weight<GraphType>(min_edge);
 
-        if (min_weight < constants::zero)
-            throw std::invalid_argument(std::format(
-                "[alg::prim_mst] Found an edge with a negative weight: [{}, {} | w={}]",
-                min_edge.first_id(),
-                min_edge.second_id(),
-                min_weight
-            ));
-
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
         if (not visited[target_id]) {
             // add the minimum weight edge to the mst

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -25,19 +25,6 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
-    SUBCASE("should throw if there is an edge with a negative weight") {
-        const auto sut = lib::topology::clique<sut_type>(constants::n_elements_alg);
-        sut.get_edge(constants::vertex_id_1, constants::vertex_id_2)
-            .value()
-            .get()
-            .properties.weight = -static_cast<weight_type>(constants::n_elements_alg);
-
-        CHECK_THROWS_AS(
-            func::discard_result(lib::algorithm::prim_mst(sut, constants::vertex_id_1)),
-            std::invalid_argument
-        );
-    }
-
     SUBCASE("should return a proper mst descriptor for a valid graph") {
         using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
 


### PR DESCRIPTION
In the Prim's MST algorithm implementation:
- Removed the negative weight check
- Enqueueing edges only if the target vertex in a current iteration is not yet visited