### PR TITLE
[NONE] MST finding algorithm fix

### DIFF
--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -335,7 +335,7 @@ This section covers the specific types and type traits used for the algorithm im
 
 ### MST finding
 
-- `prim_mst(graph, pre_visit, post_visit)`
+- `mst(graph, pre_visit, post_visit)`
   - *Description*: Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
 
   - *Template parameters*:

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -31,7 +31,7 @@ template <
         algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
-[[nodiscard]] mst_descriptor<GraphType> prim_mst(
+[[nodiscard]] mst_descriptor<GraphType> mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -85,14 +85,15 @@ template <
         const auto min_weight = get_weight<GraphType>(min_edge);
 
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
-        if (not visited[target_id]) {
-            // add the minimum weight edge to the mst
-            mst.edges.emplace_back(min_edge);
-            mst.weight += min_weight;
+        if (visited[target_id])
+            continue;
 
-            visited[target_id] = true;
-            ++n_vertices_in_mst;
-        }
+        // add the minimum weight edge to the mst
+        mst.edges.emplace_back(min_edge);
+        mst.weight += min_weight;
+
+        visited[target_id] = true;
+        ++n_vertices_in_mst;
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.adjacent_edges(target_id))

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -84,14 +84,6 @@ template <
         const auto& min_edge = min_edge_info.edge.get();
         const auto min_weight = get_weight<GraphType>(min_edge);
 
-        if (min_weight < constants::zero)
-            throw std::invalid_argument(std::format(
-                "[alg::prim_mst] Found an edge with a negative weight: [{}, {} | w={}]",
-                min_edge.first_id(),
-                min_edge.second_id(),
-                min_weight
-            ));
-
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
         if (not visited[target_id]) {
             // add the minimum weight edge to the mst

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -25,19 +25,6 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
-    SUBCASE("should throw if there is an edge with a negative weight") {
-        const auto sut = lib::topology::clique<sut_type>(constants::n_elements_alg);
-        sut.get_edge(constants::vertex_id_1, constants::vertex_id_2)
-            .value()
-            .get()
-            .properties.weight = -static_cast<weight_type>(constants::n_elements_alg);
-
-        CHECK_THROWS_AS(
-            func::discard_result(lib::algorithm::prim_mst(sut, constants::vertex_id_1)),
-            std::invalid_argument
-        );
-    }
-
     SUBCASE("should return a proper mst descriptor for a valid graph") {
         using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
 

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -15,7 +15,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_alg_mst");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with explicitly weighted edges",
+    "mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
     wieghted_edge_traits_type_template
 ) {
@@ -71,7 +71,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CAPTURE(expected_edges);
         CAPTURE(expected_weight);
 
-        const auto mst = lib::algorithm::prim_mst(sut, source_id);
+        const auto mst = lib::algorithm::mst(sut, source_id);
 
         REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
@@ -105,7 +105,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with unweighted edges",
+    "mst finding tests for graphs with unweighted edges",
     TraitsType,
     unwieghted_edge_traits_type_template
 ) {
@@ -126,7 +126,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
-    const auto mst = lib::algorithm::prim_mst(sut, source_id);
+    const auto mst = lib::algorithm::mst(sut, source_id);
 
     REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);


### PR DESCRIPTION
In the MST finding algorithm:
- Removed the negative weight check
- Enqueuing edges adjacent to target only if target has not yet been visited in the current iteration