### PR TITLE
[NONE] Add a vertex-heap variant of the prim's MST finding algorithm

### DIFF
--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -360,23 +360,10 @@ This section covers the specific types and type traits used for the algorithm im
   - *Description*:
     - Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
     - Performs the Prim's algorithm using a minimum binary heap of vertices.
-    > **NOTE:** The binary heap implementation in C++ doesn't allow modifying a single node within the heap, therefore the `std::make_heap` - $O(n)$ - function has to be called to rebuild the heap.
 
-  - *Template parameters*:
-    - `GraphType: type_traits::c_undirected_graph` - The type of the graph on which the search is performed (must be undirected).
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
-
-  - *Parameters*:
-    - `graph: const GraphType&` - The graph to perform the search on.
-    - `root_id_opt: const std::optional<types::id_type>` - An optional root vertex ID. If set, the search will begin with edges adjacent to the vertex $v$ such that $v_{id} = \text{root-id-opt.value()}$. Otherwise the first vertex of the graph will be used as root.
-    - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
-    - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
-
-  - *Return type*:
-    - `algorithm::mst_descriptor<GraphType>` - An [MST](https://en.wikipedia.org/wiki/Minimum_spanning_tree) desciptor object (detailed information can be found in the note below).
-
-  - *Defined in*: [gl/algorithm/mst.hpp](/include/gl/algorithm/mst.hpp)
+    > **NOTE:**
+    > - This algoithm has the same template parameters, parameters and return type as the edge heap version (edge_heap_prim_mst), but it requires the edge weight type to have a specialization of `std::numeric_limits<WeightType>::max()`
+    > - The binary heap implementation in C++ doesn't allow modifying a single node within the heap, therefore the `std::make_heap` - $O(n)$ - function has to be called to rebuild the heap.
 
 > [!NOTE]
 > The `algorithm::mst_descriptor` structure is defined as follows:

--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -335,7 +335,7 @@ This section covers the specific types and type traits used for the algorithm im
 
 ### MST finding
 
-- `prim_mst(graph, pre_visit, post_visit)`
+- `mst(graph, pre_visit, post_visit)`
   - *Description*: Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
 
   - *Template parameters*:

--- a/docs/algoithms.md
+++ b/docs/algoithms.md
@@ -335,8 +335,32 @@ This section covers the specific types and type traits used for the algorithm im
 
 ### MST finding
 
-- `mst(graph, pre_visit, post_visit)`
-  - *Description*: Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
+- `edge_heap_prim_mst(graph, pre_visit, post_visit)`
+  - *Description*:
+    - Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
+    - Performs the Prim's algorithm using a minimum binary heap of edges.
+
+  - *Template parameters*:
+    - `GraphType: type_traits::c_undirected_graph` - The type of the graph on which the search is performed (must be undirected).
+    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+
+  - *Parameters*:
+    - `graph: const GraphType&` - The graph to perform the search on.
+    - `root_id_opt: const std::optional<types::id_type>` - An optional root vertex ID. If set, the search will begin with edges adjacent to the vertex $v$ such that $v_{id} = \text{root-id-opt.value()}$. Otherwise the first vertex of the graph will be used as root.
+    - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
+    - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
+
+  - *Return type*:
+    - `algorithm::mst_descriptor<GraphType>` - An [MST](https://en.wikipedia.org/wiki/Minimum_spanning_tree) desciptor object (detailed information can be found in the note below).
+
+  - *Defined in*: [gl/algorithm/mst.hpp](/include/gl/algorithm/mst.hpp)
+
+- `vertex_heap_prim_mst(graph, pre_visit, post_visit)`
+  - *Description*:
+    - Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
+    - Performs the Prim's algorithm using a minimum binary heap of vertices.
+    > **NOTE:** The binary heap implementation in C++ doesn't allow modifying a single node within the heap, therefore the `std::make_heap` - $O(n)$ - function has to be called to rebuild the heap.
 
   - *Template parameters*:
     - `GraphType: type_traits::c_undirected_graph` - The type of the graph on which the search is performed (must be undirected).

--- a/docs/graph_elements.md
+++ b/docs/graph_elements.md
@@ -166,15 +166,15 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
   - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex. Throws an error if the provided vertex is not incident with the edge.
   - *Returned value*: $\begin{cases} v & \text{: vertex} = u \\ u & \text{: vertex} = v  \\ \text{error} & \text{: otherwise} \end{cases}$
   - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex for which the opposite incident vertex is requested.
+    - `vertex: const vertex_type&` – the vertex for which the opposite vertex is requested.
   - *Return type*: `const vertex_type&`
 
 - **`incident_vertex_id(const types::id_type vertex_id) const`**:
   - *Description*: Returns the ID of the vertex on the other end of the edge relative to the provided vertex ID. Throws an error if the provided vertex ID is invalid.
   - *Returned value*: $\begin{cases} v_{id} & \text{: vertex-id} = u_{id} \\ u_{id} & \text{: vertex-id} = v_{id} \\ \text{error} & \text{: otherwise} \end{cases}$
   - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex for which the opposite incident vertex is requested.
-  - *Return type*: `const vertex_type&`
+    - `vertex_id: const types::id_type` – the vertex ID for which the opposite vertex ID is requested.
+  - *Return type*: `types::id_type`
 
 - **`is_incident_with(const vertex_type& vertex) const`**:
   - *Description*: Returns `true` if the provided vertex is connected to the edge.

--- a/docs/graph_elements.md
+++ b/docs/graph_elements.md
@@ -164,7 +164,14 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
 
 - **`incident_vertex(const vertex_type& vertex) const`**:
   - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex. Throws an error if the provided vertex is not incident with the edge.
-  - *Returned value*: $\begin{cases} v & \text{: vertex} = u \\ u & \text{: otherwise} \end{cases}$
+  - *Returned value*: $\begin{cases} v & \text{: vertex} = u \\ u & \text{: vertex} = v  \\ \text{error} & \text{: otherwise} \end{cases}$
+  - *Parameters*:
+    - `vertex: const vertex_type&` – the vertex for which the opposite incident vertex is requested.
+  - *Return type*: `const vertex_type&`
+
+- **`incident_vertex_id(const types::id_type vertex_id) const`**:
+  - *Description*: Returns the ID of the vertex on the other end of the edge relative to the provided vertex ID. Throws an error if the provided vertex ID is invalid.
+  - *Returned value*: $\begin{cases} v_{id} & \text{: vertex-id} = u_{id} \\ u_{id} & \text{: vertex-id} = v_{id} \\ \text{error} & \text{: otherwise} \end{cases}$
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which the opposite incident vertex is requested.
   - *Return type*: `const vertex_type&`

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -106,7 +106,9 @@ template <
         algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
-[[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
+requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
+[[nodiscard]] mst_descriptor<GraphType>
+vertex_heap_prim_mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -31,7 +31,7 @@ template <
         algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
-[[nodiscard]] mst_descriptor<GraphType> prim_mst(
+[[nodiscard]] mst_descriptor<GraphType> mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -7,7 +7,7 @@
 #include "constants.hpp"
 #include "impl/common.hpp"
 
-#include <iostream>
+#include <numeric>
 #include <queue>
 
 namespace gl::algorithm {
@@ -62,11 +62,6 @@ template <
     std::vector<bool> visited(n_vertices, false);
     queue_type edge_queue;
 
-    // TODO: replace with edge->incident_vertex_id(id) after it's been added to the edge_descriptor class
-    const auto get_other_vertex_id = [](const edge_type& edge, const types::id_type source_id) {
-        return edge.first_id() == source_id ? edge.second_id() : edge.first_id();
-    };
-
     // insert the edges adjacent to the root vertex to the queue
     const types::id_type root_id = root_id_opt.value_or(constants::zero);
 
@@ -85,7 +80,7 @@ template <
         const auto& min_edge = min_edge_info.edge.get();
         const auto min_weight = get_weight<GraphType>(min_edge);
 
-        const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
+        const auto& target_id = min_edge.incident_vertex_id(min_edge_info.source_id);
         if (visited[target_id])
             continue;
 
@@ -98,7 +93,7 @@ template <
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.adjacent_edges(target_id))
-            if (not visited[get_other_vertex_id(edge, target_id)])
+            if (not visited[edge.incident_vertex_id(target_id)])
                 edge_queue.emplace(edge, target_id);
     }
 
@@ -117,64 +112,48 @@ template <
     const PostVisitCallback& post_visit = {}
 ) {
     // type definitions
-    using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
-    using edge_info_type = algorithm::edge_info<edge_type>;
     using distance_type = types::vertex_distance_type<GraphType>;
-
-    struct prim_vertex_info {
-        distance_type min_cost = std::numeric_limits<distance_type>::max(
-        ); // the cost of the cheapest connection to the vertex
-        const edge_type* min_cost_edge =
-            nullptr; // the edge corresponding to the cheapest connection
-        bool in_mst = false;
-    };
 
     // prepare the necessary utility
     const auto n_vertices = graph.n_vertices();
-    std::vector<prim_vertex_info> vinfo_list(n_vertices);
     mst_descriptor<GraphType> mst(n_vertices);
 
-    // TODO: replace with edge->incident_vertex_id(id) after it's been added to the edge_descriptor class
-    const auto get_other_vertex_id = [](const edge_type& edge, const types::id_type source_id) {
-        return edge.first_id() == source_id ? edge.second_id() : edge.first_id();
-    };
+    std::vector<bool> in_mst(n_vertices, false);
+    std::vector<distance_type> min_cost(n_vertices, std::numeric_limits<distance_type>::max());
+    std::vector<const edge_type*> min_cost_edges(n_vertices, nullptr);
 
-    const auto find_min_cost_vertex = [&vinfo_list]() {
-        distance_type min_cost = std::numeric_limits<distance_type>::max();
+    const auto find_min_cost_vertex = [&in_mst, &min_cost, n_vertices]() {
+        distance_type min_cost_v = std::numeric_limits<distance_type>::max();
         types::id_type min_cost_vertex_id = 0;
 
-        types::size_type i = 0;
-        for (const auto& vinfo : vinfo_list) {
-            if (not vinfo.in_mst and vinfo.min_cost <= min_cost) {
-                min_cost = vinfo.min_cost;
-                min_cost_vertex_id = i;
+        for (types::size_type id = constants::initial_id; id < n_vertices; ++id) {
+            if (not in_mst[id] and min_cost[id] <= min_cost_v) {
+                min_cost_v = min_cost[id];
+                min_cost_vertex_id = id;
             }
-            ++i;
         }
 
-        return std::make_pair(min_cost_vertex_id, min_cost);
+        return std::make_pair(min_cost_vertex_id, min_cost_v);
     };
 
     for (types::size_type n = constants::zero; n < n_vertices; ++n) {
         // find a vertex with the cheapest connection which is not yet in the MST
-        const auto [min_cost_vertex_id, min_cost] = find_min_cost_vertex();
-        auto& min_cost_vertex = vinfo_list[min_cost_vertex_id];
+        const auto [min_cost_vertex_id, min_cost_v] = find_min_cost_vertex();
+        in_mst[min_cost_vertex_id] = true; // add the vertex to the MST
 
-        min_cost_vertex.in_mst = true; // add the vertex to the MST
-
-        const auto* min_cost_edge = min_cost_vertex.min_cost_edge;
+        const auto* min_cost_edge = min_cost_edges[min_cost_vertex_id];
         if (min_cost_edge != nullptr) { // add the edge to MST
             mst.edges.emplace_back(*min_cost_edge);
-            mst.weight += get_weight<GraphType>(*min_cost_edge);
+            mst.weight += min_cost_v;
         }
 
         for (const auto& edge : graph.adjacent_edges(min_cost_vertex_id)) {
             const auto edge_weight = get_weight<GraphType>(edge);
-            auto& incident_vinfo = vinfo_list[get_other_vertex_id(edge, min_cost_vertex_id)];
-            if (edge_weight < incident_vinfo.min_cost) {
-                incident_vinfo.min_cost = edge_weight;
-                incident_vinfo.min_cost_edge = &edge;
+            const auto incident_vertex_id = edge.incident_vertex_id(min_cost_vertex_id);
+            if (edge_weight < min_cost[incident_vertex_id]) {
+                min_cost[incident_vertex_id] = edge_weight;
+                min_cost_edges[incident_vertex_id] = &edge;
             }
         }
     }
@@ -194,73 +173,51 @@ template <
     const PostVisitCallback& post_visit = {}
 ) {
     // type definitions
-    using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
     using distance_type = types::vertex_distance_type<GraphType>;
 
-    struct prim_vertex_info {
-        prim_vertex_info(const types::id_type id)
-        : id(id),
-          min_cost(std::numeric_limits<distance_type>::max()),
-          min_cost_edge(nullptr),
-          in_mst(false) {}
-
-        types::id_type id; // ID of the vertex
-        distance_type min_cost; // cheapest connection
-        const edge_type* min_cost_edge; // edge for the cheapest connection
-        bool in_mst = false;
-    };
-
-    // Comparator for the binary heap
-    auto heap_comparator = [](const prim_vertex_info* a, const prim_vertex_info* b) {
-        return a->min_cost > b->min_cost; // Min-heap based on min_cost
-    };
-
     // Prepare the necessary utility
     const auto n_vertices = graph.n_vertices();
-    std::vector<prim_vertex_info> vinfo_list;
-    std::vector<prim_vertex_info*> heap; // min-heap storing pointers to vinfo_list elements
     mst_descriptor<GraphType> mst(n_vertices);
 
-    // Initialize the vertex info and the heap
-    vinfo_list.reserve(n_vertices);
-    for (types::id_type id = constants::initial_id; id < n_vertices; ++id) {
-        auto& vinfo = vinfo_list.emplace_back(id);
-        heap.push_back(&vinfo);
-    }
-    std::make_heap(heap.begin(), heap.end(), heap_comparator);
+    std::vector<bool> in_mst(n_vertices, false);
+    std::vector<distance_type> min_cost(n_vertices, std::numeric_limits<distance_type>::max());
+    std::vector<const edge_type*> min_cost_edges(n_vertices, nullptr);
 
-    // Helper to find the other vertex of an edge
-    const auto get_other_vertex_id = [](const edge_type& edge, const types::id_type source_id) {
-        return edge.first_id() == source_id ? edge.second_id() : edge.first_id();
+    auto heap_comparator = [&min_cost](const types::id_type lhs, const types::id_type rhs) {
+        return min_cost[lhs] > min_cost[rhs]; // min-heap based on min_cost
     };
+
+    // Initialize the vertex info and the heap
+    std::vector<types::id_type> heap(n_vertices);
+    std::iota(heap.begin(), heap.end(), constants::initial_id);
+    std::make_heap(heap.begin(), heap.end(), heap_comparator);
 
     while (not heap.empty()) {
         // Extract the vertex with the smallest cost
         std::pop_heap(heap.begin(), heap.end(), heap_comparator);
-        auto* min_vertex_info = heap.back();
+        const auto vertex_id = heap.back();
         heap.pop_back();
 
-        if (min_vertex_info->in_mst)
-            continue; // Skip if already in MST
-        min_vertex_info->in_mst = true; // Add vertex to MST
+        if (in_mst[vertex_id])
+            continue;
 
-        const auto vertex_id = min_vertex_info->id;
-        const auto* min_cost_edge = min_vertex_info->min_cost_edge;
+        in_mst[vertex_id] = true;
 
+        const auto* min_cost_edge = min_cost_edges[vertex_id];
         if (min_cost_edge != nullptr) { // Add the corresponding edge to MST
             mst.edges.emplace_back(*min_cost_edge);
-            mst.weight += get_weight<GraphType>(*min_cost_edge);
+            mst.weight += min_cost[vertex_id];
         }
 
         // Update adjacent vertices
         for (const auto& edge : graph.adjacent_edges(vertex_id)) {
             const auto edge_weight = get_weight<GraphType>(edge);
-            auto& incident_vinfo = vinfo_list[get_other_vertex_id(edge, vertex_id)];
+            const auto incident_vertex_id = edge.incident_vertex_id(vertex_id);
 
-            if (not incident_vinfo.in_mst && edge_weight < incident_vinfo.min_cost) {
-                incident_vinfo.min_cost = edge_weight;
-                incident_vinfo.min_cost_edge = &edge;
+            if (not in_mst[incident_vertex_id] && edge_weight < min_cost[incident_vertex_id]) {
+                min_cost[incident_vertex_id] = edge_weight;
+                min_cost_edges[incident_vertex_id] = &edge;
             }
         }
 

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -107,8 +107,7 @@ template <
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
 requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
-[[nodiscard]] mst_descriptor<GraphType>
-vertex_heap_prim_mst(
+[[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -85,14 +85,15 @@ template <
         const auto min_weight = get_weight<GraphType>(min_edge);
 
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
-        if (not visited[target_id]) {
-            // add the minimum weight edge to the mst
-            mst.edges.emplace_back(min_edge);
-            mst.weight += min_weight;
+        if (visited[target_id])
+            continue;
 
-            visited[target_id] = true;
-            ++n_vertices_in_mst;
-        }
+        // add the minimum weight edge to the mst
+        mst.edges.emplace_back(min_edge);
+        mst.weight += min_weight;
+
+        visited[target_id] = true;
+        ++n_vertices_in_mst;
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.adjacent_edges(target_id))

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -32,7 +32,7 @@ template <
         algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
-[[nodiscard]] mst_descriptor<GraphType> mst(
+[[nodiscard]] mst_descriptor<GraphType> edge_heap_prim_mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},
@@ -106,7 +106,7 @@ template <
         algorithm::empty_callback,
     type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
         algorithm::empty_callback>
-[[nodiscard]] mst_descriptor<GraphType> bin_heap_prim_mst(
+[[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
     const GraphType& graph,
     const std::optional<types::id_type> root_id_opt,
     const PreVisitCallback& pre_visit = {},

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -84,14 +84,6 @@ template <
         const auto& min_edge = min_edge_info.edge.get();
         const auto min_weight = get_weight<GraphType>(min_edge);
 
-        if (min_weight < constants::zero)
-            throw std::invalid_argument(std::format(
-                "[alg::prim_mst] Found an edge with a negative weight: [{}, {} | w={}]",
-                min_edge.first_id(),
-                min_edge.second_id(),
-                min_weight
-            ));
-
         const auto& target_id = get_other_vertex_id(min_edge, min_edge_info.source_id);
         if (not visited[target_id]) {
             // add the minimum weight edge to the mst

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -96,6 +96,16 @@ public:
         ));
     }
 
+    [[nodiscard]] const types::id_type incident_vertex_id(const types::id_type vertex_id) const {
+        if (vertex_id == this->first_id())
+            return this->second_id();
+
+        if (vertex_id == this->second_id())
+            return this->first_id();
+
+        throw std::invalid_argument(std::format("Got invalid vertex id: {}", vertex_id));
+    }
+
     [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_type& vertex) const {
         return &vertex == &this->_vertices.first or &vertex == &this->_vertices.second;
     }

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -96,7 +96,7 @@ public:
         ));
     }
 
-    [[nodiscard]] const types::id_type incident_vertex_id(const types::id_type vertex_id) const {
+    [[nodiscard]] types::id_type incident_vertex_id(const types::id_type vertex_id) const {
         if (vertex_id == this->first_id())
             return this->second_id();
 

--- a/include/gl/types/traits/concepts.hpp
+++ b/include/gl/types/traits/concepts.hpp
@@ -110,6 +110,11 @@ concept c_basic_arithmetic =
 // clang-format on
 
 template <typename T>
+concept c_has_numeric_limits_max = requires {
+    { std::numeric_limits<T>::max() } -> std::same_as<T>;
+};
+
+template <typename T>
 concept c_readable = requires(T value, std::istream& is) { is >> value; };
 
 template <typename T>

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -71,7 +71,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CAPTURE(expected_edges);
         CAPTURE(expected_weight);
 
-        const auto mst = lib::algorithm::mst(sut, source_id);
+        const auto mst = lib::algorithm::edge_heap_prim_mst(sut, source_id);
 
         REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
@@ -126,7 +126,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
-    const auto mst = lib::algorithm::mst(sut, source_id);
+    const auto mst = lib::algorithm::edge_heap_prim_mst(sut, source_id);
 
     REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);
@@ -209,7 +209,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CAPTURE(expected_edges);
         CAPTURE(expected_weight);
 
-        const auto mst = lib::algorithm::bin_heap_prim_mst(sut, source_id);
+        const auto mst = lib::algorithm::vertex_heap_prim_mst(sut, source_id);
 
         REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
@@ -264,7 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
-    const auto mst = lib::algorithm::bin_heap_prim_mst(sut, source_id);
+    const auto mst = lib::algorithm::vertex_heap_prim_mst(sut, source_id);
 
     REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -25,19 +25,6 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
-    SUBCASE("should throw if there is an edge with a negative weight") {
-        const auto sut = lib::topology::clique<sut_type>(constants::n_elements_alg);
-        sut.get_edge(constants::vertex_id_1, constants::vertex_id_2)
-            .value()
-            .get()
-            .properties.weight = -static_cast<weight_type>(constants::n_elements_alg);
-
-        CHECK_THROWS_AS(
-            func::discard_result(lib::algorithm::prim_mst(sut, constants::vertex_id_1)),
-            std::invalid_argument
-        );
-    }
-
     SUBCASE("should return a proper mst descriptor for a valid graph") {
         using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
 

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -15,9 +15,142 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_alg_mst");
 
 TEST_CASE_TEMPLATE_DEFINE(
+    "prim mst finding tests for graphs with explicitly weighted edges",
+    TraitsType,
+    prim_wieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using weight_type = typename sut_type::edge_properties_type::weight_type;
+    using distance_type = weight_type;
+
+    static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    SUBCASE("should return a proper mst descriptor for a valid graph") {
+        using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+        sut_type sut;
+        std::vector<vertex_id_pair> expected_edges;
+        distance_type expected_weight;
+
+        SUBCASE("regular binary tree") {
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+            const weight_type edge_weight = constants::three;
+            for (const auto vertex_id : sut.vertex_ids()) {
+                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
+                    edge.properties.weight = edge_weight;
+                    expected_edges.emplace_back(edge.first_id(), edge.second_id());
+                }
+            }
+
+            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
+        }
+
+        SUBCASE("custom graph") {
+            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
+
+            sut = lib::io::load<sut_type>(gsf_file_path);
+
+            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
+            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
+            const auto vertex_id_list =
+                alg_common::load_list<lib_t::id_type>(n_vertex_ids, edges_file_path);
+            for (lib_t::size_type i = 0; i < n_vertex_ids; i += constants::two)
+                expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
+
+            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
+            expected_weight =
+                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
+        }
+
+        CAPTURE(sut);
+        CAPTURE(expected_edges);
+        CAPTURE(expected_weight);
+
+        const auto mst = lib::algorithm::prim_mst(sut);
+
+        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+        REQUIRE_EQ(mst.weight, expected_weight);
+
+        CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+            const auto& edge = edge_ref.get();
+            const auto [first_id, second_id] = edge.incident_vertex_ids();
+            return std::find_if(
+                       expected_edges.begin(),
+                       expected_edges.end(),
+                       [&](const vertex_id_pair& vids) {
+                           return (first_id == vids.first && second_id == vids.second)
+                               or (first_id == vids.second && second_id == vids.first);
+                       }
+                   )
+                != expected_edges.end();
+        }));
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    prim_wieghted_edge_traits_type_template,
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::list_t>, // undirected adjacency list graph
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::matrix_t> // undirected adjacency matrix graph
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "prim mst finding tests for graphs with unweighted edges",
+    TraitsType,
+    prim_unwieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using distance_type = lib_t::default_vertex_distance_type;
+    using weight_type = distance_type;
+    using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+    static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+    std::vector<vertex_id_pair> expected_edges;
+    for (const auto vertex_id : sut.vertex_ids())
+        for (const auto& edge : sut.adjacent_edges(vertex_id))
+            expected_edges.emplace_back(edge.first_id(), edge.second_id());
+
+    const weight_type expected_weight = sut.n_vertices() - constants::one;
+
+    const auto mst = lib::algorithm::prim_mst(sut);
+
+    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+    REQUIRE_EQ(mst.weight, expected_weight);
+
+    CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+        const auto& edge = edge_ref.get();
+        const auto [first_id, second_id] = edge.incident_vertex_ids();
+        return std::find_if(
+                   expected_edges.begin(),
+                   expected_edges.end(),
+                   [&](const vertex_id_pair& vids) {
+                       return (first_id == vids.first && second_id == vids.second)
+                           or (first_id == vids.second && second_id == vids.first);
+                   }
+               )
+            != expected_edges.end();
+    }));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    prim_unwieghted_edge_traits_type_template,
+    lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
+    lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
     "mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
-    wieghted_edge_traits_type_template
+    custom_wieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using weight_type = typename sut_type::edge_properties_type::weight_type;
@@ -93,7 +226,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    wieghted_edge_traits_type_template,
+    custom_wieghted_edge_traits_type_template,
     lib::undirected_graph_traits<
         lib_t::empty_properties,
         lib_t::weight_property<>,
@@ -107,7 +240,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 TEST_CASE_TEMPLATE_DEFINE(
     "mst finding tests for graphs with unweighted edges",
     TraitsType,
-    unwieghted_edge_traits_type_template
+    custom_unwieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using distance_type = lib_t::default_vertex_distance_type;
@@ -147,7 +280,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    unwieghted_edge_traits_type_template,
+    custom_unwieghted_edge_traits_type_template,
     lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
     lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
 );
@@ -155,3 +288,17 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 TEST_SUITE_END(); // test_alg_mst
 
 } // namespace gl_testing
+
+/*
+
+- 0 : [0, 1] [0, 2]
+- 1 : [0, 1] [1, 3] [1, 4]
+- 2 : [0, 2] [2, 4] [2, 5]
+- 3 : [1, 3] [3, 6]
+- 4 : [1, 4] [2, 4] [4, 6] [4, 7]
+- 5 : [2, 5] [5, 7]
+- 6 : [3, 6] [4, 6] [6, 8]
+- 7 : [4, 7] [5, 7] [7, 8]
+- 8 : [6, 8] [7, 8]
+
+*/

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -15,139 +15,6 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_alg_mst");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with explicitly weighted edges",
-    TraitsType,
-    prim_wieghted_edge_traits_type_template
-) {
-    using sut_type = lib::graph<TraitsType>;
-    using weight_type = typename sut_type::edge_properties_type::weight_type;
-    using distance_type = weight_type;
-
-    static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
-
-    SUBCASE("should return a proper mst descriptor for a valid graph") {
-        using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
-
-        sut_type sut;
-        std::vector<vertex_id_pair> expected_edges;
-        distance_type expected_weight;
-
-        SUBCASE("regular binary tree") {
-            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
-
-            const weight_type edge_weight = constants::three;
-            for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
-                    edge.properties.weight = edge_weight;
-                    expected_edges.emplace_back(edge.first_id(), edge.second_id());
-                }
-            }
-
-            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
-        }
-
-        SUBCASE("custom graph") {
-            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
-
-            sut = lib::io::load<sut_type>(gsf_file_path);
-
-            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
-            const auto vertex_id_list =
-                alg_common::load_list<lib_t::id_type>(n_vertex_ids, edges_file_path);
-            for (lib_t::size_type i = 0; i < n_vertex_ids; i += constants::two)
-                expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
-
-            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight =
-                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
-        }
-
-        CAPTURE(sut);
-        CAPTURE(expected_edges);
-        CAPTURE(expected_weight);
-
-        const auto mst = lib::algorithm::prim_mst(sut);
-
-        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
-        REQUIRE_EQ(mst.weight, expected_weight);
-
-        CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
-            const auto& edge = edge_ref.get();
-            const auto [first_id, second_id] = edge.incident_vertex_ids();
-            return std::find_if(
-                       expected_edges.begin(),
-                       expected_edges.end(),
-                       [&](const vertex_id_pair& vids) {
-                           return (first_id == vids.first && second_id == vids.second)
-                               or (first_id == vids.second && second_id == vids.first);
-                       }
-                   )
-                != expected_edges.end();
-        }));
-    }
-}
-
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    prim_wieghted_edge_traits_type_template,
-    lib::undirected_graph_traits<
-        lib_t::empty_properties,
-        lib_t::weight_property<>,
-        lib_i::list_t>, // undirected adjacency list graph
-    lib::undirected_graph_traits<
-        lib_t::empty_properties,
-        lib_t::weight_property<>,
-        lib_i::matrix_t> // undirected adjacency matrix graph
-);
-
-TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with unweighted edges",
-    TraitsType,
-    prim_unwieghted_edge_traits_type_template
-) {
-    using sut_type = lib::graph<TraitsType>;
-    using distance_type = lib_t::default_vertex_distance_type;
-    using weight_type = distance_type;
-    using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
-
-    static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
-
-    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
-
-    std::vector<vertex_id_pair> expected_edges;
-    for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.adjacent_edges(vertex_id))
-            expected_edges.emplace_back(edge.first_id(), edge.second_id());
-
-    const weight_type expected_weight = sut.n_vertices() - constants::one;
-
-    const auto mst = lib::algorithm::prim_mst(sut);
-
-    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
-    REQUIRE_EQ(mst.weight, expected_weight);
-
-    CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
-        const auto& edge = edge_ref.get();
-        const auto [first_id, second_id] = edge.incident_vertex_ids();
-        return std::find_if(
-                   expected_edges.begin(),
-                   expected_edges.end(),
-                   [&](const vertex_id_pair& vids) {
-                       return (first_id == vids.first && second_id == vids.second)
-                           or (first_id == vids.second && second_id == vids.first);
-                   }
-               )
-            != expected_edges.end();
-    }));
-}
-
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    prim_unwieghted_edge_traits_type_template,
-    lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
-    lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
-);
-
-TEST_CASE_TEMPLATE_DEFINE(
     "mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
     custom_wieghted_edge_traits_type_template
@@ -285,20 +152,266 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
 );
 
+TEST_CASE_TEMPLATE_DEFINE(
+    "prim mst finding tests for graphs with explicitly weighted edges",
+    TraitsType,
+    prim_wieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using weight_type = typename sut_type::edge_properties_type::weight_type;
+    using distance_type = weight_type;
+
+    static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    SUBCASE("should return a proper mst descriptor for a valid graph") {
+        using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+        sut_type sut;
+        std::vector<vertex_id_pair> expected_edges;
+        distance_type expected_weight;
+
+        SUBCASE("regular binary tree") {
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+            const weight_type edge_weight = constants::three;
+            for (const auto vertex_id : sut.vertex_ids()) {
+                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
+                    edge.properties.weight = edge_weight;
+                    expected_edges.emplace_back(edge.first_id(), edge.second_id());
+                }
+            }
+
+            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
+        }
+
+        SUBCASE("custom graph") {
+            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
+
+            sut = lib::io::load<sut_type>(gsf_file_path);
+
+            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
+            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
+            const auto vertex_id_list =
+                alg_common::load_list<lib_t::id_type>(n_vertex_ids, edges_file_path);
+            for (lib_t::size_type i = 0; i < n_vertex_ids; i += constants::two)
+                expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
+
+            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
+            expected_weight =
+                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
+        }
+
+        CAPTURE(sut);
+        CAPTURE(expected_edges);
+        CAPTURE(expected_weight);
+
+        const auto mst = lib::algorithm::prim_mst(sut);
+
+        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+        REQUIRE_EQ(mst.weight, expected_weight);
+
+        CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+            const auto& edge = edge_ref.get();
+            const auto [first_id, second_id] = edge.incident_vertex_ids();
+            return std::find_if(
+                       expected_edges.begin(),
+                       expected_edges.end(),
+                       [&](const vertex_id_pair& vids) {
+                           return (first_id == vids.first && second_id == vids.second)
+                               or (first_id == vids.second && second_id == vids.first);
+                       }
+                   )
+                != expected_edges.end();
+        }));
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    prim_wieghted_edge_traits_type_template,
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::list_t>, // undirected adjacency list graph
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::matrix_t> // undirected adjacency matrix graph
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "prim mst finding tests for graphs with unweighted edges",
+    TraitsType,
+    prim_unwieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using distance_type = lib_t::default_vertex_distance_type;
+    using weight_type = distance_type;
+    using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+    static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+    std::vector<vertex_id_pair> expected_edges;
+    for (const auto vertex_id : sut.vertex_ids())
+        for (const auto& edge : sut.adjacent_edges(vertex_id))
+            expected_edges.emplace_back(edge.first_id(), edge.second_id());
+
+    const weight_type expected_weight = sut.n_vertices() - constants::one;
+
+    const auto mst = lib::algorithm::prim_mst(sut);
+
+    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+    REQUIRE_EQ(mst.weight, expected_weight);
+
+    CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+        const auto& edge = edge_ref.get();
+        const auto [first_id, second_id] = edge.incident_vertex_ids();
+        return std::find_if(
+                   expected_edges.begin(),
+                   expected_edges.end(),
+                   [&](const vertex_id_pair& vids) {
+                       return (first_id == vids.first && second_id == vids.second)
+                           or (first_id == vids.second && second_id == vids.first);
+                   }
+               )
+            != expected_edges.end();
+    }));
+}
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "binary-heap-based prim mst finding tests for graphs with explicitly weighted edges",
+    TraitsType,
+    bin_heap_prim_wieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using weight_type = typename sut_type::edge_properties_type::weight_type;
+    using distance_type = weight_type;
+
+    static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    SUBCASE("should return a proper mst descriptor for a valid graph") {
+        using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+        sut_type sut;
+        std::vector<vertex_id_pair> expected_edges;
+        distance_type expected_weight;
+
+        SUBCASE("regular binary tree") {
+            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+            const weight_type edge_weight = constants::three;
+            for (const auto vertex_id : sut.vertex_ids()) {
+                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
+                    edge.properties.weight = edge_weight;
+                    expected_edges.emplace_back(edge.first_id(), edge.second_id());
+                }
+            }
+
+            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
+        }
+
+        SUBCASE("custom graph") {
+            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
+
+            sut = lib::io::load<sut_type>(gsf_file_path);
+
+            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
+            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
+            const auto vertex_id_list =
+                alg_common::load_list<lib_t::id_type>(n_vertex_ids, edges_file_path);
+            for (lib_t::size_type i = 0; i < n_vertex_ids; i += constants::two)
+                expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
+
+            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
+            expected_weight =
+                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
+        }
+
+        CAPTURE(sut);
+        CAPTURE(expected_edges);
+        CAPTURE(expected_weight);
+
+        const auto mst = lib::algorithm::bin_heap_prim_mst(sut);
+
+        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+        REQUIRE_EQ(mst.weight, expected_weight);
+
+        CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+            const auto& edge = edge_ref.get();
+            const auto [first_id, second_id] = edge.incident_vertex_ids();
+            return std::find_if(
+                       expected_edges.begin(),
+                       expected_edges.end(),
+                       [&](const vertex_id_pair& vids) {
+                           return (first_id == vids.first && second_id == vids.second)
+                               or (first_id == vids.second && second_id == vids.first);
+                       }
+                   )
+                != expected_edges.end();
+        }));
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bin_heap_prim_wieghted_edge_traits_type_template,
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::list_t>, // undirected adjacency list graph
+    lib::undirected_graph_traits<
+        lib_t::empty_properties,
+        lib_t::weight_property<>,
+        lib_i::matrix_t> // undirected adjacency matrix graph
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "binary-heap-based prim mst finding tests for graphs with unweighted edges",
+    TraitsType,
+    bin_heap_prim_unwieghted_edge_traits_type_template
+) {
+    using sut_type = lib::graph<TraitsType>;
+    using distance_type = lib_t::default_vertex_distance_type;
+    using weight_type = distance_type;
+    using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
+
+    static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
+
+    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+
+    std::vector<vertex_id_pair> expected_edges;
+    for (const auto vertex_id : sut.vertex_ids())
+        for (const auto& edge : sut.adjacent_edges(vertex_id))
+            expected_edges.emplace_back(edge.first_id(), edge.second_id());
+
+    const weight_type expected_weight = sut.n_vertices() - constants::one;
+
+    const auto mst = lib::algorithm::bin_heap_prim_mst(sut);
+
+    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+    REQUIRE_EQ(mst.weight, expected_weight);
+
+    CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
+        const auto& edge = edge_ref.get();
+        const auto [first_id, second_id] = edge.incident_vertex_ids();
+        return std::find_if(
+                   expected_edges.begin(),
+                   expected_edges.end(),
+                   [&](const vertex_id_pair& vids) {
+                       return (first_id == vids.first && second_id == vids.second)
+                           or (first_id == vids.second && second_id == vids.first);
+                   }
+               )
+            != expected_edges.end();
+    }));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bin_heap_prim_unwieghted_edge_traits_type_template,
+    lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
+    lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
+);
+
 TEST_SUITE_END(); // test_alg_mst
 
 } // namespace gl_testing
-
-/*
-
-- 0 : [0, 1] [0, 2]
-- 1 : [0, 1] [1, 3] [1, 4]
-- 2 : [0, 2] [2, 4] [2, 5]
-- 3 : [1, 3] [3, 6]
-- 4 : [1, 4] [2, 4] [4, 6] [4, 7]
-- 5 : [2, 5] [5, 7]
-- 6 : [3, 6] [4, 6] [6, 8]
-- 7 : [4, 7] [5, 7] [7, 8]
-- 8 : [6, 8] [7, 8]
-
-*/

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -15,9 +15,9 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_alg_mst");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "mst finding tests for graphs with explicitly weighted edges",
+    "(edge heap) prim mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
-    custom_wieghted_edge_traits_type_template
+    edge_heap_prim_wieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using weight_type = typename sut_type::edge_properties_type::weight_type;
@@ -93,7 +93,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    custom_wieghted_edge_traits_type_template,
+    edge_heap_prim_wieghted_edge_traits_type_template,
     lib::undirected_graph_traits<
         lib_t::empty_properties,
         lib_t::weight_property<>,
@@ -105,9 +105,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "mst finding tests for graphs with unweighted edges",
+    "(edge heap) prim mst finding tests for graphs with unweighted edges",
     TraitsType,
-    custom_unwieghted_edge_traits_type_template
+    edge_heap_prim_unwieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using distance_type = lib_t::default_vertex_distance_type;
@@ -147,15 +147,15 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    custom_unwieghted_edge_traits_type_template,
+    edge_heap_prim_unwieghted_edge_traits_type_template,
     lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
     lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with explicitly weighted edges",
+    "(vertex heap) prim mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
-    prim_wieghted_edge_traits_type_template
+    vertex_heap_prim_wieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using weight_type = typename sut_type::edge_properties_type::weight_type;
@@ -167,11 +167,13 @@ TEST_CASE_TEMPLATE_DEFINE(
         using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
 
         sut_type sut;
+        lib_t::id_type source_id;
         std::vector<vertex_id_pair> expected_edges;
         distance_type expected_weight;
 
         SUBCASE("regular binary tree") {
             sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+            source_id = constants::first_element_idx;
 
             const weight_type edge_weight = constants::three;
             for (const auto vertex_id : sut.vertex_ids()) {
@@ -188,6 +190,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
 
             sut = lib::io::load<sut_type>(gsf_file_path);
+            source_id = constants::first_element_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
@@ -202,10 +205,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         CAPTURE(sut);
+        CAPTURE(source_id);
         CAPTURE(expected_edges);
         CAPTURE(expected_weight);
 
-        const auto mst = lib::algorithm::prim_mst(sut);
+        const auto mst = lib::algorithm::bin_heap_prim_mst(sut, source_id);
 
         REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
@@ -227,7 +231,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    prim_wieghted_edge_traits_type_template,
+    vertex_heap_prim_wieghted_edge_traits_type_template,
     lib::undirected_graph_traits<
         lib_t::empty_properties,
         lib_t::weight_property<>,
@@ -239,9 +243,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with unweighted edges",
+    "(vertex heap) prim mst finding tests for graphs with unweighted edges",
     TraitsType,
-    prim_unwieghted_edge_traits_type_template
+    vertex_heap_prim_unwieghted_edge_traits_type_template
 ) {
     using sut_type = lib::graph<TraitsType>;
     using distance_type = lib_t::default_vertex_distance_type;
@@ -251,6 +255,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
+    const lib_t::id_type source_id = constants::first_element_idx;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
@@ -259,134 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
-    const auto mst = lib::algorithm::prim_mst(sut);
-
-    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
-    REQUIRE_EQ(mst.weight, expected_weight);
-
-    CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
-        const auto& edge = edge_ref.get();
-        const auto [first_id, second_id] = edge.incident_vertex_ids();
-        return std::find_if(
-                   expected_edges.begin(),
-                   expected_edges.end(),
-                   [&](const vertex_id_pair& vids) {
-                       return (first_id == vids.first && second_id == vids.second)
-                           or (first_id == vids.second && second_id == vids.first);
-                   }
-               )
-            != expected_edges.end();
-    }));
-}
-
-TEST_CASE_TEMPLATE_DEFINE(
-    "binary-heap-based prim mst finding tests for graphs with explicitly weighted edges",
-    TraitsType,
-    bin_heap_prim_wieghted_edge_traits_type_template
-) {
-    using sut_type = lib::graph<TraitsType>;
-    using weight_type = typename sut_type::edge_properties_type::weight_type;
-    using distance_type = weight_type;
-
-    static_assert(lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
-
-    SUBCASE("should return a proper mst descriptor for a valid graph") {
-        using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
-
-        sut_type sut;
-        std::vector<vertex_id_pair> expected_edges;
-        distance_type expected_weight;
-
-        SUBCASE("regular binary tree") {
-            sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
-
-            const weight_type edge_weight = constants::three;
-            for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
-                    edge.properties.weight = edge_weight;
-                    expected_edges.emplace_back(edge.first_id(), edge.second_id());
-                }
-            }
-
-            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
-        }
-
-        SUBCASE("custom graph") {
-            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
-
-            sut = lib::io::load<sut_type>(gsf_file_path);
-
-            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
-            const auto vertex_id_list =
-                alg_common::load_list<lib_t::id_type>(n_vertex_ids, edges_file_path);
-            for (lib_t::size_type i = 0; i < n_vertex_ids; i += constants::two)
-                expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
-
-            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight =
-                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
-        }
-
-        CAPTURE(sut);
-        CAPTURE(expected_edges);
-        CAPTURE(expected_weight);
-
-        const auto mst = lib::algorithm::bin_heap_prim_mst(sut);
-
-        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
-        REQUIRE_EQ(mst.weight, expected_weight);
-
-        CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
-            const auto& edge = edge_ref.get();
-            const auto [first_id, second_id] = edge.incident_vertex_ids();
-            return std::find_if(
-                       expected_edges.begin(),
-                       expected_edges.end(),
-                       [&](const vertex_id_pair& vids) {
-                           return (first_id == vids.first && second_id == vids.second)
-                               or (first_id == vids.second && second_id == vids.first);
-                       }
-                   )
-                != expected_edges.end();
-        }));
-    }
-}
-
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    bin_heap_prim_wieghted_edge_traits_type_template,
-    lib::undirected_graph_traits<
-        lib_t::empty_properties,
-        lib_t::weight_property<>,
-        lib_i::list_t>, // undirected adjacency list graph
-    lib::undirected_graph_traits<
-        lib_t::empty_properties,
-        lib_t::weight_property<>,
-        lib_i::matrix_t> // undirected adjacency matrix graph
-);
-
-TEST_CASE_TEMPLATE_DEFINE(
-    "binary-heap-based prim mst finding tests for graphs with unweighted edges",
-    TraitsType,
-    bin_heap_prim_unwieghted_edge_traits_type_template
-) {
-    using sut_type = lib::graph<TraitsType>;
-    using distance_type = lib_t::default_vertex_distance_type;
-    using weight_type = distance_type;
-    using vertex_id_pair = std::pair<lib_t::id_type, lib_t::id_type>;
-
-    static_assert(not lib_tt::c_weight_properties_type<typename sut_type::edge_properties_type>);
-
-    const auto sut = lib::topology::regular_binary_tree<sut_type>(constants::depth);
-
-    std::vector<vertex_id_pair> expected_edges;
-    for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.adjacent_edges(vertex_id))
-            expected_edges.emplace_back(edge.first_id(), edge.second_id());
-
-    const weight_type expected_weight = sut.n_vertices() - constants::one;
-
-    const auto mst = lib::algorithm::bin_heap_prim_mst(sut);
+    const auto mst = lib::algorithm::bin_heap_prim_mst(sut, source_id);
 
     REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);
@@ -407,7 +285,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    bin_heap_prim_unwieghted_edge_traits_type_template,
+    vertex_heap_prim_unwieghted_edge_traits_type_template,
     lib::list_graph_traits<lib::undirected_t>, // undirected adjacency list graph
     lib::matrix_graph_traits<lib::undirected_t> // undirected adjacency matrix graph
 );

--- a/tests/source/test_alg_mst.cpp
+++ b/tests/source/test_alg_mst.cpp
@@ -15,7 +15,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_alg_mst");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with explicitly weighted edges",
+    "mst finding tests for graphs with explicitly weighted edges",
     TraitsType,
     wieghted_edge_traits_type_template
 ) {
@@ -71,7 +71,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CAPTURE(expected_edges);
         CAPTURE(expected_weight);
 
-        const auto mst = lib::algorithm::prim_mst(sut, source_id);
+        const auto mst = lib::algorithm::mst(sut, source_id);
 
         REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
@@ -105,7 +105,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "prim mst finding tests for graphs with unweighted edges",
+    "mst finding tests for graphs with unweighted edges",
     TraitsType,
     unwieghted_edge_traits_type_template
 ) {
@@ -126,7 +126,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
-    const auto mst = lib::algorithm::prim_mst(sut, source_id);
+    const auto mst = lib::algorithm::mst(sut, source_id);
 
     REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);

--- a/tests/source/test_edge_descriptor.cpp
+++ b/tests/source/test_edge_descriptor.cpp
@@ -93,7 +93,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(sut.second_id(), fixture.vd_2.id());
     }
 
-    SUBCASE("incident_vertex should return throw if input vertex is not incident with the edge") {
+    SUBCASE("incident_vertex should throw if input vertex is not incident with the edge") {
         CHECK_THROWS_AS(
             func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument
         );
@@ -102,6 +102,18 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {
         CHECK_EQ(sut.incident_vertex(fixture.vd_1), fixture.vd_2);
         CHECK_EQ(sut.incident_vertex(fixture.vd_2), fixture.vd_1);
+    }
+
+    SUBCASE("incident_vertex_id should throw if input vertex id is not valid") {
+        CHECK_THROWS_AS(
+            func::discard_result(sut.incident_vertex_id(fixture.vd_3.id())), std::invalid_argument
+        );
+    }
+
+    SUBCASE("incident_vertex_id should return the id of the vertex incident with the input vertex"
+    ) {
+        CHECK_EQ(sut.incident_vertex_id(fixture.vd_1.id()), fixture.vd_2.id());
+        CHECK_EQ(sut.incident_vertex_id(fixture.vd_2.id()), fixture.vd_1.id());
     }
 
     SUBCASE("is_incident_with should return true when the given vertex is one of the connected "


### PR DESCRIPTION
- Renamed the `prim_mst` function to `edge_heap_prim_mst`
- Added the `vertex_heap_prim_mst` function for finding the MST of a graph
- Added the `edge_descriptor::incident_vertex_id` method