### PR TITLE
YT-CPPGL-54: Add vertex degree map getters

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -243,6 +243,10 @@ Based on the specified traits, the `graph` class defines the following types:
     - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the in-degree.
   - *Return type*: `types::size_type`
 
+- **`graph.in_degree_map() const`**:
+  - *Description*: Returns a vector containing the in-degrees of the corresponding vertices (in-degree at index `i` corresponds to the vertex with an ID equal `i`).
+  - *Return type*: `std::vector<types::size_type>`
+
 - **`graph.out_degree(vertex) const`**:
   - *Description*: Returns the out-degree (number of outgoing edges) of the specified vertex.
   - *Returned value*:
@@ -260,6 +264,10 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Parameters*:
     - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the out-degree.
   - *Return type*: `types::size_type`
+
+- **`graph.out_degree_map() const`**:
+  - *Description*: Returns a vector containing the out-degrees of the corresponding vertices (out-degree at index `i` corresponds to the vertex with an ID equal `i`).
+  - *Return type*: `std::vector<types::size_type>`
 
 - **`graph.degree(vertex) const`**:
   - *Description*: Returns the degree (number of incoming and outgoing edges) of the specified vertex.
@@ -283,6 +291,10 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Parameters*:
     - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the degree.
   - *Return type*: `types::size_type`
+
+- **`graph.degree_map() const`**:
+  - *Description*: Returns a vector containing the degrees of the corresponding vertices (degree at index `i` corresponds to the vertex with an ID equal `i`).
+  - *Return type*: `std::vector<types::size_type>`
 
 <br />
 

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -24,18 +24,14 @@ template <
 
     const auto vertex_ids = graph.vertex_ids();
 
-    // prepare the vertex in degree list
-    // !!! TODO: use the in_degree_map function
-    std::vector<types::size_type> vertex_in_deg_list;
-    vertex_in_deg_list.reserve(graph.n_vertices());
-    for (const auto id : vertex_ids)
-        vertex_in_deg_list.push_back(graph.in_degree(id));
+    // prepare the vertex in degree map
+    std::vector<types::size_type> in_degree_map = graph.in_degree_map();
 
     // prepare the initial queue content (source vertices)
     std::vector<algorithm::vertex_info> source_vertex_list;
     source_vertex_list.reserve(graph.n_vertices());
     for (const auto id : vertex_ids)
-        if (vertex_in_deg_list[id] == constants::default_size)
+        if (in_degree_map[id] == constants::default_size)
             source_vertex_list.emplace_back(id);
 
     std::optional<std::vector<types::id_type>> topological_order_opt =
@@ -53,11 +49,11 @@ template <
             topological_order.push_back(vertex.id());
             return true;
         },
-        [&vertex_in_deg_list](const vertex_type& vertex, const edge_type& in_edge)
+        [&in_degree_map](const vertex_type& vertex, const edge_type& in_edge)
             -> std::optional<bool> { // enqueue predicate
             if (in_edge.is_loop())
                 return false;
-            return --vertex_in_deg_list[vertex.id()] == constants::default_size;
+            return --in_degree_map[vertex.id()] == constants::default_size;
         },
         pre_visit,
         post_visit

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -25,6 +25,7 @@ template <
     const auto vertex_ids = graph.vertex_ids();
 
     // prepare the vertex in degree list
+    // !!! TODO: use the in_degree_map function
     std::vector<types::size_type> vertex_in_deg_list;
     vertex_in_deg_list.reserve(graph.n_vertices());
     for (const auto id : vertex_ids)

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -187,6 +187,10 @@ public:
         return this->_impl.in_degree(vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+        return this->_impl.in_degree_map();
+    }
+
     [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex
     ) const {
         this->_verify_vertex(vertex);
@@ -199,6 +203,10 @@ public:
         return this->_impl.out_degree(vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+        return this->_impl.out_degree_map();
+    }
+
     [[nodiscard]] gl_attr_force_inline types::size_type degree(const vertex_type& vertex) const {
         this->_verify_vertex(vertex);
         return this->_impl.degree(vertex.id());
@@ -208,14 +216,6 @@ public:
     ) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.degree(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
-        return this->_impl.in_degree_map();
-    }
-
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
-        return this->_impl.out_degree_map();
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -210,6 +210,18 @@ public:
         return this->_impl.degree(vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+        return this->_impl.in_degree_map();
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+        return this->_impl.out_degree_map();
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+        return this->_impl.degree_map();
+    }
+
     // --- edge methods ---
 
     // clang-format off

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -78,6 +78,24 @@ public:
         return specialized_impl::degree(*this, vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map(
+        const types::id_type vertex_id
+    ) const {
+        return specialized_impl::in_degree_map(*this, vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map(
+        const types::id_type vertex_id
+    ) const {
+        return specialized_impl::out_degree_map(*this, vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
+        const types::id_type vertex_id
+    ) const {
+        return specialized_impl::degree_map(*this, vertex_id);
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         specialized_impl::remove_vertex(*this, vertex);
     }

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -78,22 +78,16 @@ public:
         return specialized_impl::degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map(
-        const types::id_type vertex_id
-    ) const {
-        return specialized_impl::in_degree_map(*this, vertex_id);
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+        return specialized_impl::in_degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map(
-        const types::id_type vertex_id
-    ) const {
-        return specialized_impl::out_degree_map(*this, vertex_id);
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+        return specialized_impl::out_degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
-        const types::id_type vertex_id
-    ) const {
-        return specialized_impl::degree_map(*this, vertex_id);
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+        return specialized_impl::degree_map(*this);
     }
 
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -98,6 +98,18 @@ public:
         return specialized_impl::degree(*this, vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+        return specialized_impl::in_degree_map(*this);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+        return specialized_impl::out_degree_map(*this);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+        return specialized_impl::degree_map(*this);
+    }
+
     gl_attr_force_inline void remove_vertex(const vertex_type& vertex) {
         specialized_impl::remove_vertex(*this, vertex.id());
     }

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -81,6 +81,43 @@ struct directed_adjacency_matrix {
         return in_degree(self, vertex_id) + out_degree(self, vertex_id);
     }
 
+    [[nodiscard]] static std::vector<types::size_type> in_degree_map(const impl_type& self) {
+        std::vector<types::id_type> in_degree_map(self._matrix.size(), constants::zero);
+
+        for (const auto& row : self._matrix)
+            for (types::id_type id = constants::initial_id; id < self._matrix.size(); ++id)
+                if (row[id] != nullptr)
+                    ++in_degree_map[id];
+
+        return in_degree_map;
+    }
+
+    [[nodiscard]] static std::vector<types::size_type> out_degree_map(const impl_type& self) {
+        std::vector<types::id_type> out_degree_map;
+        out_degree_map.reserve(self._matrix.size());
+
+        for (types::id_type id = constants::initial_id; id < self._matrix.size(); ++id)
+            out_degree_map.push_back(out_degree(self, id));
+
+        return out_degree_map;
+    }
+
+    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
+        std::vector<types::id_type> degree_map(self._matrix.size(), constants::zero);
+
+        for (types::id_type u_id = constants::initial_id; u_id < self._matrix.size(); ++u_id) {
+            const auto& row = self._matrix[u_id];
+            for (types::id_type v_id = constants::initial_id; v_id < self._matrix.size(); ++v_id) {
+                if (row[v_id] != nullptr) {
+                    ++degree_map[u_id];
+                    ++degree_map[v_id];
+                }
+            }
+        }
+
+        return degree_map;
+    }
+
     static void remove_vertex(impl_type& self, const types::id_type vertex_id) {
         self._n_unique_edges -= self.adjacent_edges(vertex_id).distance();
         self._matrix.erase(std::next(std::begin(self._matrix), vertex_id));
@@ -150,6 +187,34 @@ struct undirected_adjacency_matrix {
             if (edge)
                 degree += constants::one + static_cast<types::size_type>(edge->is_loop());
         return degree;
+    }
+
+    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> in_degree_map(
+        const impl_type& self
+    ) {
+        return degree_map(self);
+    }
+
+    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+        const impl_type& self
+    ) {
+        return degree_map(self);
+    }
+
+    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
+        std::vector<types::id_type> degree_map(self._matrix.size(), constants::zero);
+
+        for (types::id_type u_id = constants::initial_id; u_id < self._matrix.size(); ++u_id) {
+            const auto& row = self._matrix[u_id];
+            for (types::id_type v_id = constants::initial_id; v_id <= u_id; ++v_id) {
+                if (row[v_id] != nullptr) {
+                    ++degree_map[u_id];
+                    ++degree_map[v_id];
+                }
+            }
+        }
+
+        return degree_map;
     }
 
     static void remove_vertex(impl_type& self, const types::id_type vertex_id) {

--- a/tests/source/test_adjacency_list.cpp
+++ b/tests/source/test_adjacency_list.cpp
@@ -87,17 +87,23 @@ struct test_directed_adjacency_list {
         );
     }
 
-    void fully_connect_vertex(const lib_t::id_type first_id) {
-        for (const auto second_id : constants::vertex_id_view)
-            if (second_id != first_id)
-                add_edge(first_id, second_id);
+    void fully_connect_vertex(const lib_t::id_type first_id, const bool no_loops = true) {
+        for (const auto second_id : constants::vertex_id_view) {
+            if (second_id == first_id and no_loops)
+                continue;
+
+            add_edge(first_id, second_id);
+        }
     }
 
-    void initialize_full_graph() {
+    void init_complete_graph(const bool no_loops = true) {
         for (const auto first_id : constants::vertex_id_view)
-            fully_connect_vertex(first_id);
+            fully_connect_vertex(first_id, no_loops);
 
-        REQUIRE_EQ(sut.n_unique_edges(), n_unique_edges_in_full_graph);
+        if (no_loops)
+            REQUIRE_EQ(sut.n_unique_edges(), n_unique_edges_in_full_graph);
+        else
+            REQUIRE_EQ(sut.n_unique_edges(), constants::n_elements * constants::n_elements);
     }
 
     sut_type sut{constants::n_elements};
@@ -298,7 +304,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
     "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     std::function<lib_t::size_type(const lib_t::id_type)> deg_proj;
 
@@ -330,7 +336,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
     "degree should return the number of edges incident with the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
     const auto deg_proj = [this](const auto vertex_id) { return sut.degree(vertex_id); };
 
     CHECK(std::ranges::all_of(
@@ -351,9 +357,47 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_directed_adjacency_list,
+    "{in/out}_degree_map should return a map of numbers of edges incident {to/from} the "
+    "corresponding vertices"
+) {
+    init_complete_graph(false);
+    const auto expected_deg = constants::n_elements;
+
+    std::vector<lib_t::id_type> degree_map;
+
+    SUBCASE("in_degree") {
+        degree_map = sut.in_degree_map();
+    }
+
+    SUBCASE("out_degree") {
+        degree_map = sut.out_degree_map();
+    }
+
+    CAPTURE(degree_map);
+
+    REQUIRE_EQ(degree_map.size(), constants::n_elements);
+    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
+    "degree_map should return a map of the numbers of edges incident with the corresponding "
+    "vertices"
+) {
+    init_complete_graph(false);
+    const auto expected_deg = constants::n_elements * constants::two;
+
+    std::vector<lib_t::id_type> degree_map = sut.degree_map();
+
+    REQUIRE_EQ(degree_map.size(), constants::n_elements);
+    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     const auto& removed_vertex = vertices[constants::first_element_idx];
     sut.remove_vertex(removed_vertex);
@@ -398,7 +442,7 @@ struct test_undirected_adjacency_list {
                 add_edge(first_id, second_id);
     }
 
-    void initialize_full_graph() {
+    void init_complete_graph() {
         for (const auto first_id : constants::vertex_id_view)
             for (const auto second_id : std::views::iota(constants::vertex_id_1, first_id))
                 add_edge(first_id, second_id);
@@ -648,7 +692,7 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_list,
     "{in_/out_/}degree should return the number of edges incident {to/from} the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     std::function<lib_t::size_type(const lib_t::id_type)> deg_proj;
 
@@ -684,7 +728,7 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_list,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     const auto& removed_vertex = vertices[constants::first_element_idx];
     sut.remove_vertex(removed_vertex);

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -432,18 +432,26 @@ struct test_undirected_adjacency_matrix {
         );
     }
 
-    void fully_connect_vertex(const lib_t::id_type first_id) {
-        for (const auto second_id : constants::vertex_id_view)
-            if (second_id != first_id)
-                add_edge(first_id, second_id);
+    void fully_connect_vertex(const lib_t::id_type first_id, const bool no_loops = true) {
+        for (const auto second_id : constants::vertex_id_view) {
+            if (second_id == first_id and no_loops)
+                continue;
+
+            add_edge(first_id, second_id);
+        }
     }
 
-    void init_complete_graph() {
-        for (const auto first_id : constants::vertex_id_view)
-            for (const auto second_id : std::views::iota(constants::vertex_id_1, first_id))
+    void init_complete_graph(const bool no_loops = true) {
+        for (const auto first_id : constants::vertex_id_view) {
+            const auto bound = no_loops ? first_id : first_id + constants::one;
+            for (const auto second_id : std::views::iota(constants::vertex_id_1, bound))
                 add_edge(first_id, second_id);
+        }
 
-        REQUIRE_EQ(sut.n_unique_edges(), n_unique_edges_in_full_graph);
+        if (no_loops)
+            REQUIRE_EQ(sut.n_unique_edges(), n_unique_edges_in_full_graph);
+        else
+            REQUIRE_EQ(sut.n_unique_edges(), n_unique_edges_in_full_graph + constants::n_elements);
     }
 
     sut_type sut{constants::n_elements};
@@ -661,6 +669,34 @@ TEST_CASE_FIXTURE(
         deg_proj(constants::vertex_id_1),
         n_incident_edges_for_fully_connected_vertex + constants::two // loops counted twice
     );
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "{in_/out_/}degree_map should return a map of numbers of edges incident {to/from/with} the "
+    "corresponding vertices"
+) {
+    init_complete_graph(false);
+    const auto expected_deg = constants::n_elements + 1;
+
+    std::vector<lib_t::id_type> degree_map;
+
+    SUBCASE("in_degree") {
+        degree_map = sut.in_degree_map();
+    }
+
+    SUBCASE("out_degree") {
+        degree_map = sut.out_degree_map();
+    }
+
+    SUBCASE("degree") {
+        degree_map = sut.degree_map();
+    }
+
+    CAPTURE(degree_map);
+
+    REQUIRE_EQ(degree_map.size(), constants::n_elements);
+    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_adjacency_matrix.cpp
+++ b/tests/source/test_adjacency_matrix.cpp
@@ -139,7 +139,7 @@ struct test_directed_adjacency_matrix {
                 add_edge(first_id, second_id);
     }
 
-    void initialize_full_graph() {
+    void init_complete_graph() {
         for (const auto first_id : constants::vertex_id_view)
             fully_connect_vertex(first_id);
 
@@ -294,7 +294,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     std::function<lib_t::size_type(const lib_t::id_type)> deg_proj;
 
@@ -326,7 +326,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "degree should return the number of edges incident with the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
     const auto deg_proj = [this](const auto vertex_id) { return sut.degree(vertex_id); };
 
     CHECK(std::ranges::all_of(
@@ -349,7 +349,7 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     const auto& removed_vertex = vertices[constants::first_element_idx];
     sut.remove_vertex(removed_vertex);
@@ -394,7 +394,7 @@ struct test_undirected_adjacency_matrix {
                 add_edge(first_id, second_id);
     }
 
-    void initialize_full_graph() {
+    void init_complete_graph() {
         for (const auto first_id : constants::vertex_id_view)
             for (const auto second_id : std::views::iota(constants::vertex_id_1, first_id))
                 add_edge(first_id, second_id);
@@ -587,7 +587,7 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "{in_/out_/}degree should return the number of edges incident {to/from/with} the given vertex"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     std::function<lib_t::size_type(const lib_t::id_type)> deg_proj;
 
@@ -623,7 +623,7 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    initialize_full_graph();
+    init_complete_graph();
 
     const auto& removed_vertex = vertices[constants::first_element_idx];
     sut.remove_vertex(removed_vertex);

--- a/tests/source/test_graph.cpp
+++ b/tests/source/test_graph.cpp
@@ -21,7 +21,7 @@ struct test_graph {
 
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     requires(lib_tt::is_directed_v<typename GraphType::edge_type>)
-    void initialize_full_graph(GraphType& graph) {
+    void init_complete_graph(GraphType& graph) {
         const auto vertices = graph.vertices();
         for (const auto& first : vertices)
             for (const auto& second : vertices)
@@ -37,7 +37,7 @@ struct test_graph {
 
     template <lib_tt::c_instantiation_of<lib::graph> GraphType>
     requires(lib_tt::is_undirected_v<typename GraphType::edge_type>)
-    void initialize_full_graph(GraphType& graph) {
+    void init_complete_graph(GraphType& graph) {
         const auto vertices = graph.vertices();
         for (const auto& first : vertices)
             for (const auto& second : vertices)
@@ -257,7 +257,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("remove_vertex(vertex) should remove the given vertex and align ids of remaining "
             "vertices") {
         sut_type sut{constants::n_elements};
-        fixture.initialize_full_graph(sut);
+        fixture.init_complete_graph(sut);
 
         sut.remove_vertex(constants::vertex_id_1);
 
@@ -291,7 +291,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("remove_vertex(id) should remove the given vertex and align ids of remaining vertices"
     ) {
         sut_type sut{constants::n_elements};
-        fixture.initialize_full_graph(sut);
+        fixture.init_complete_graph(sut);
 
         sut.remove_vertex(constants::vertex_id_1);
 
@@ -322,7 +322,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto n_vertices = constants::n_elements + constants::one_element;
 
         sut_type sut{n_vertices};
-        fixture.initialize_full_graph(sut);
+        fixture.init_complete_graph(sut);
 
         sut.remove_vertices_from(
             vertex_id_list{constants::vertex_id_1, constants::vertex_id_3, constants::vertex_id_1}
@@ -345,7 +345,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto n_vertices = constants::n_elements + constants::one_element;
 
         sut_type sut{n_vertices};
-        fixture.initialize_full_graph(sut);
+        fixture.init_complete_graph(sut);
 
         const auto& v1 = sut.get_vertex(constants::vertex_id_1);
         const auto& v3 = sut.get_vertex(constants::vertex_id_3);


### PR DESCRIPTION
- Added the `in_degree_map`, `out_degree_map` and `degree_map` functions to the graph class
- Replaced per vertex in-degree calculating in the `topological_sort` algorithm with the `in_degree_map` function