### PR TITLE
YT-CPPGL-56: Replace the usage of pointers for vertex and edge storage to simple composite types [Part 2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ While the `gl::graph` class is the key element of the library, it's not the only
 - [The vertex and edge classes - representation of the graph's elements](/docs/graph_elements.md)
 - [I/O operations](/docs/io.md)
 - [Graph topology generators](/docs/topologies.md)
-- [Algorithms](/docs/algoithms.md)
+- [Algorithms](/docs/algorithms.md)
 - [Core utility types](/docs/core_util_types.md)
 - [Additional functionality](/docs/additional_functionality.md)
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -131,14 +131,21 @@ This section covers the specific types and type traits used for the algorithm im
     - `Args...` - variadic template representing arguments of the callback type.
   - *Equivalent to*: `c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>`
 
-- `c_vertex_callback`
-  - *Description*: Checks if a function is a valid vertex callback.
+- `c_id_callback`
+  - *Description*: Checks if a function is a valid ID callback.
   - *Template parameters*:
     - `F` - the function type to check.
-    - `GraphType` - the graph type associated with the callback.
     - `ReturnType` - the return type of the callback.
     - `Args...` - variadic template representing additional arguments of the callback type.
-  - *Equivalent to*: `std::is_invocable_r_v<ReturnType, F, const typename GraphType::vertex_type&, Args...>`
+  - *Equivalent to*: `std::is_invocable_r_v<ReturnType, F, const types::id_type, Args...>`
+
+- `c_optional_id_callback`
+  - *Description*: Checks if a function is a valid (optional) ID callback.
+  - *Template parameters*:
+    - `F` - the function type to check.
+    - `ReturnType` - the return type of the callback.
+    - `Args...` - variadic template representing additional arguments of the callback type.
+  - *Equivalent to*: `c_optional_callback<F, ReturnType, const types::id_type, Args...>`
 
 - `c_edge_callback`
   - *Description*: Checks if a function is a valid edge callback.
@@ -148,15 +155,6 @@ This section covers the specific types and type traits used for the algorithm im
     - `ReturnType` - the return type of the callback.
     - `Args...` - variadic template representing additional arguments of the callback type.
   - *Equivalent to*: `std::is_invocable_r_v<ReturnType, F, const typename GraphType::edge_type&, Args...>`
-
-- `c_optional_vertex_callback`
-  - *Description*: Checks if a function is a valid (optional) vertex callback.
-  - *Template parameters*:
-    - `F` - the function type to check.
-    - `GraphType` - the graph type associated with the callback.
-    - `ReturnType` - the return type of the callback.
-    - `Args...` - variadic template representing additional arguments of the callback type.
-  - *Equivalent to*: `c_optional_callback<F, ReturnType, const typename GraphType::vertex_type&, Args...>`
 
 - `c_optional_edge_callback`
   - *Description*: Checks if a function is a valid (optional) edge callback.
@@ -183,8 +181,8 @@ This section covers the specific types and type traits used for the algorithm im
   - *Template parameters*:
     - `ResultDiscriminator: result_discriminator` (default = `algorithm::ret`) - Specifies whether the algorrithm should return the predecessors descriptor or not (can be eigher `algorithm::ret` or `algorithm::no_return`).
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -212,8 +210,8 @@ This section covers the specific types and type traits used for the algorithm im
   - *Template parameters*:
     - `ResultDiscriminator: result_discriminator` (default = `algorithm::ret`) - Specifies whether the algorrithm should return the predecessors descriptor or not (can be eigher `algorithm::ret` or `algorithm::no_return`).
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform BFS on.
@@ -236,8 +234,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the coloring on.
@@ -279,8 +277,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
@@ -332,8 +330,8 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Template parameters*:
     - `GraphType: type_traits::c_directed_graph` - The type of the graph on which the sorting is performed (must be directed).
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `PreVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the coloring on.
@@ -347,28 +345,24 @@ This section covers the specific types and type traits used for the algorithm im
 
 ### MST finding
 
-- `edge_heap_prim_mst(graph, pre_visit, post_visit)`
+- `edge_heap_prim_mst(graph)`
   - *Description*:
     - Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
     - Performs the Prim's algorithm using a minimum binary heap of edges.
 
   - *Template parameters*:
     - `GraphType: type_traits::c_undirected_graph` - The type of the graph on which the search is performed (must be undirected).
-    - `PreVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_optional_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
     - `root_id_opt: const std::optional<types::id_type>` - An optional root vertex ID. If set, the search will begin with edges adjacent to the vertex $v$ such that $v_{id} = \text{root-id-opt.value()}$. Otherwise the first vertex of the graph will be used as root.
-    - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
-    - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
     - `algorithm::mst_descriptor<GraphType>` - An [MST](https://en.wikipedia.org/wiki/Minimum_spanning_tree) desciptor object (detailed information can be found in the note below).
 
   - *Defined in*: [gl/algorithm/mst.hpp](/include/gl/algorithm/mst.hpp)
 
-- `vertex_heap_prim_mst(graph, pre_visit, post_visit)`
+- `vertex_heap_prim_mst(graph)`
   - *Description*:
     - Returns an `mst_descriptor` object containing the [Minimum Spanning Tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) edges and its total weight.
     - Performs the Prim's algorithm using a minimum binary heap of vertices.
@@ -406,20 +400,20 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 > [!NOTE]
 > The DFS algorithm templates are defined in the [gl/algorithm/impl/dfs.hpp](/include/gl/algorithm/impl/dfs.hpp) file.
 
-- `dfs(graph, root_vertex, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `dfs(graph, root_id, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Desciption*: An iterative DFS algoithm template.
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
-    - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `VisitVertexPredicate: type_traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
+    - `VisitCallback: type_traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `EnqueueVertexPred: type_traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
+    - `PreVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
-    - `root_vertex: const typename GraphType::vertex_type&` - The vertex from which the search will be started.
+    - `root_id: const types::id_type` - The ID of a vertex from which the search will be started.
     - `visit_vertex_pred: const VisitVertexPredicate&` - A predicate used to determine whether a vertex should be visited based on the vertex itself and its source/parent vertex's ID.
     - `visit: const VisitCallback&` - The vertex visiting function.
     - `enque_vertex_pred: const EnqueueVertexPred&` - A predicate used to determine whether a vertex should be pushed to the search stack based on the vertex itself and its source edge.
@@ -428,21 +422,21 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
 
   - *Return type*: `void`
 
-- `r_dfs(graph, vertex, source_id, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
+- `r_dfs(graph, vertex_id, pred_id, visit_vertex_pred, visit, enque_vertex_pred, pre_visit, post_visit)`
   - *Description*: A recursive DFS algorithm template.
 
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
-    - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
-    - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `VisitVertexPredicate: type_traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
+    - `VisitCallback: type_traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `EnqueueVertexPred: type_traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
+    - `PreVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
-    - `vertex: const typename GraphType::vertex_type&` - The vertex to search in the current recursive call.
-    - `source_id: const types::id_type` - The ID of the parent/source vertex of the currently searched vertex.
+    - `vertex_id: const types::id_type&` - The ID of a vertex to search in the current recursive call.
+    - `pred_id: const types::id_type` - The ID of the predecessor vertex vertex of the currently searched vertex.
     - `visit_vertex_pred: const VisitVertexPredicate&` - A predicate used to determine whether a vertex should be visited based on the vertex itself and its source/parent vertex's ID.
     - `visit: const VisitCallback&` - The vertex visiting function.
     - `enque_vertex_pred: const EnqueueVertexPred&` - A predicate used to determine whether a vertex should be pushed to the search stack based on the vertex itself and its source edge.
@@ -462,11 +456,11 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
   - *Template parameters*:
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
     - `InitQueueRangeType: type_traits::c_sized_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
-    - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
-    - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `VisitVertexPredicate: type_traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
+    - `VisitCallback: type_traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `EnqueueVertexPred: type_traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
+    - `PreVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
@@ -493,11 +487,11 @@ Additionaly you can use the depth-first/breadth-first search algorithm templates
     - `GraphType: type_traits::c_graph` - The type of the graph on which the search is performed.
     - `PQCompare: std::predicate<algorithm::vertex_info, algorithm::vertex_info>` - The type of the vertex priority queue comparator.
     - `InitQueueRangeType: type_traits::c_sized_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
-    - `VisitVertexPredicate: type_traits::c_optional_vertex_callback<GraphType, bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: type_traits::c_vertex_callback<GraphType, bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
-    - `EnqueueVertexPred: type_traits::c_vertex_callback<GraphType, algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
-    - `PreVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
-    - `PostVisitCallback: type_traits::c_vertex_callback<GraphType, void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
+    - `VisitVertexPredicate: type_traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
+    - `VisitCallback: type_traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
+    - `EnqueueVertexPred: type_traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
+    - `PreVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
+    - `PostVisitCallback: type_traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -551,5 +551,5 @@ This section provides links to additional resources and documentation that can h
 - [The vertex and edge classes - representation of the graph's elements](/docs/graph_elements.md)
 - [I/O operations](/docs/io.md)
 - [Graph topology generators](/docs/topologies.md)
-- [Algorithms](/docs/algoithms.md)
+- [Algorithms](/docs/algorithms.md)
 - [Core utility types](/docs/core_util_types.md)

--- a/docs/graph_elements.md
+++ b/docs/graph_elements.md
@@ -87,8 +87,6 @@ By default, the `edge_descriptor` class does not carry any properties and assume
 
 ### Template parameters
 
-- **`VertexType`**: The type of the vertex descriptors connected by this edge.
-  - *Constraints*: must satisfy the **`type_traits::c_instantiation_of<vertex_descriptor>`** concept
 - **`DirectionalTag`**: A tag type indicating whether the edge is directed or undirected.
   - *Default value*: `directed_t`
   - *Constraints*: must satisfy the **`type_traits::c_edge_directional_tag`** concept (either `directed_t` or `undirected_t`)
@@ -99,15 +97,14 @@ By default, the `edge_descriptor` class does not carry any properties and assume
 ### Member types
 
 - **`type`**: Alias for the `edge_descriptor` itself.
-- **`vertex_type`**: Type of the vertex descriptors connected by this edge.
 - **`directional_tag`**: The tag indicating whether the edge is directed or undirected.
 - **`properties_type`**: Type of the edge properties as defined by the `Properties` template parameter.
 
 ### Constructors
 
-- **`edge_descriptor(const vertex_type& first, const vertex_type& second)`**:
+- **`edge_descriptor(const types::id_type first, const types::id_type second)`**:
   - Constructs an edge between two vertices.
-- **`edge_descriptor(const vertex_type& first, const vertex_type& second, const properties_type& properties)`**:
+- **`edge_descriptor(const types::id_type first, const types::id_type second, const properties_type& properties)`**:
   - Constructs an edge between two vertices with specified properties.
   - *Constraints*: the `properties_type` must be non-default.
 - **Move constructor and assignment operator**: *default*
@@ -133,88 +130,48 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
 - **`incident_vertices() const`**:
   - *Description*: Returns a pair of references to the two vertices connected by the edge.
   - *Returned value*: $(u, v)$
-  - *Return type*: `types::homogeneous_pair<const vertex_type&>`
-
-- **`incident_vertex_ids() const`**:
-  - *Description*: Returns the unique IDs of the vertices connected by the edge.
-  - *Returned value*: $(u_{id}, v_{id})$
-  - *Return type*: `types::homogeneous_pair<types::id_type>`
+  - *Return type*: `types::homogeneous_pair<const types::id_type>`
 
 - **`first() const`**:
   - *Description*: Returns a reference to the first vertex of the edge.
   - *Returned value*: $u$
-  - *Return type*: `const vertex_type&`
+  - *Return type*: `types::id_type`
 
 - **`second() const`**:
   - *Description*: Returns a reference to the second vertex of the edge.
   - *Returned value*: $v$
-  - *Return type*: `const vertex_type&`
-
-- **`incident_vertex(vertex) const`**:
-  - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex. Throws an error if the provided vertex is not incident with the edge.
-  - *Returned value*:
-    - $v$ if $\text{vertex} = u$
-    - $u$ if $\text{vertex} = v$
-    - error otherwise
-  - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex for which the opposite vertex is requested.
-  - *Return type*: `const vertex_type&`
+  - *Return type*: `const types::id_type`
 
 - **`incident_vertex(vertex_id) const`**:
-  - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex ID. Throws an error if the provided vertex ID is invalid.
+  - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex. Throws an error if the provided vertex is not incident with the edge.
   - *Returned value*:
-    - $v$ if $\text{vertex-id} = u_{id}$
-    - $u$ if $\text{vertex-id} = v_{id}$
+    - $v$ if $\text{vertex-id} = u$
+    - $u$ if $\text{vertex-id} = v$
     - error otherwise
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the vertex ID for which the opposite vertex ID is requested.
-  - *Return type*: `types::id_type`
-
-- **`is_incident_with(vertex) const`**:
-  - *Description*: Returns `true` if the provided vertex is connected to the edge.
-  - *Returned value*: $\text{vertex} \in {u, v}$
-  - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex to check for incidence with the edge.
-  - *Return type*: `bool`
+    - `vertex_id: const types::id_type` – the vertex for which the opposite vertex is requested.
+  - *Return type*: `const types::id_type`
 
 - **`is_incident_with(vertex_id) const`**:
   - *Description*: Returns `true` if a vertex with the given ID is connected to the edge.
-  - *Returned value*: $\text{vertex-id} \in {u_{id}, v_{id}}$
+  - *Returned value*: $\text{vertex-id} \in {u, v}$
   - *Parameters*:
     - `vertex_id: const types::id_type` – the vertex ID to check for incidence with the edge.
-  - *Return type*: `bool`
-
-- **`is_incident_from(vertex) const`**:
-  - *Description*: Returns `true` if the provided vertex is the source of the edge (for directed edges).
-  - *Returned value*:
-    - For directed edges: $\text{vertex} = u$
-    - For undirected edges: `is_incident_with(vertex)`
-  - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex to check if it is the source.
   - *Return type*: `bool`
 
 - **`is_incident_from(vertex_id) const`**:
   - *Description*: Returns `true` if a vertex with the given ID is the source of the edge.
   - *Returned value*:
-    - For directed edges: $\text{vertex-id} = u_{id}$
-    - For undirected edges: `is_incident_with(vertex)`
+    - For directed edges: $\text{vertex-id} = u$
+    - For undirected edges: `is_incident_with(vertex_id)`
   - *Parameters*:
     - `vertex_id: const types::id_type` – the vertex ID to check if it is the source.
-  - *Return type*: `bool`
-
-- **`is_incident_to(vertex) const`**:
-  - *Description*: Returns `true` if the provided vertex is the target vertex of the edge (for directed edges).
-  - *Returned value*:
-    - For directed edges: $\text{vertex} = v$
-    - For undirected edges: `is_incident_with(vertex)`
-  - *Parameters*:
-    - `vertex: const vertex_type&` – the vertex to check if it is the target.
   - *Return type*: `bool`
 
 - **`is_incident_to(vertex_id) const`**:
   - *Description*: Returns `true` if a vertex with the given ID is the target of the edge.
   - *Returned value*:
-    - For directed edges: $\text{vertex-id} = v_{id}$
+    - For directed edges: $\text{vertex-id} = v$
     - For undirected edges: `is_incident_with(vertex)`
   - *Parameters*:
     - `vertex_id: const types::id_type` – the vertex ID to check if it is the target.
@@ -231,28 +188,23 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
 
   ```cpp
   template <
-      type_traits::c_instantiation_of<vertex_descriptor> VertexType,
       type_traits::c_edge_directional_tag DirectionalTag = directed_t,
       type_traits::c_properties Properties = types::empty_properties>
-  using edge = edge_descriptor<VertexType, DirectionalTag, Properties>;
+  using edge = edge_descriptor<DirectionalTag, Properties>;
   ```
 
 - `directed_edge`: An alias for `edge_descriptor` specifically for directed edges.
 
   ```cpp
-  template <
-      type_traits::c_instantiation_of<vertex_descriptor> VertexType,
-      type_traits::c_properties Properties = types::empty_properties>
-  using directed_edge = edge_descriptor<VertexType, directed_t, Properties>;
+  template <type_traits::c_properties Properties = types::empty_properties>
+  using directed_edge = edge_descriptor<directed_t, Properties>;
   ```
 
 - `undirected_edge`: An alias for `edge_descriptor` specifically for undirected edges.
 
   ```cpp
-  template <
-      type_traits::c_instantiation_of<vertex_descriptor> VertexType,
-      type_traits::c_properties Properties = types::empty_properties>
-  using undirected_edge = edge_descriptor<VertexType, undirected_t, Properties>;
+  template <type_traits::c_properties Properties = types::empty_properties>
+  using undirected_edge = edge_descriptor<undirected_t, Properties>;
   ```
 
 <br />

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -13,10 +13,8 @@ namespace gl::algorithm {
 template <
     result_discriminator ResultDiscriminator = algorithm::ret,
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> breadth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
@@ -35,8 +33,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> breadth_firs
         impl::bfs(
             graph,
             impl::init_range(root_vertex_id_opt.value()),
-            impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+            impl::default_visit_vertex_predicate(visited),
+            impl::default_visit_callback<ResultDiscriminator>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
             pre_visit,
             post_visit
@@ -47,8 +45,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> breadth_firs
             impl::bfs(
                 graph,
                 impl::init_range(root_id),
-                impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+                impl::default_visit_vertex_predicate(visited),
+                impl::default_visit_callback<ResultDiscriminator>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType, true>(visited),
                 pre_visit,
                 post_visit

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -12,10 +12,8 @@ using bicoloring_type = std::vector<types::binary_color>;
 
 template <
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 [[nodiscard]] std::optional<bicoloring_type> bipartite_coloring(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -41,19 +39,18 @@ template <
             impl::init_range(root_id),
             algorithm::empty_callback{}, // visit predicate
             algorithm::empty_callback{}, // visit callback
-            [&coloring](const vertex_type& vertex, const edge_type& in_edge)
+            [&coloring](const types::id_type vertex_id, const edge_type& in_edge)
                 -> predicate_result { // enqueue predicate
                 if (in_edge.is_loop())
                     return false;
 
-                const auto vertex_id = vertex.id();
-                const auto source_id = in_edge.incident_vertex(vertex).id();
+                const auto pred_id = in_edge.incident_vertex(vertex_id).id();
 
-                if (coloring[vertex_id] == coloring[source_id])
+                if (coloring[vertex_id] == coloring[pred_id])
                     return predicate_result::unknown; // graph is not bipartite
 
-                if (not coloring[vertex.id()].is_set()) {
-                    coloring[vertex.id()] = coloring[source_id].next();
+                if (not coloring[vertex_id].is_set()) {
+                    coloring[vertex_id] = coloring[pred_id].next();
                     return true;
                 }
 

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -26,8 +26,7 @@ template <
     coloring_opt.emplace(graph.n_vertices(), bin_color_value::unset);
     auto& coloring = coloring_opt.value();
 
-    for (const auto root_vertex : graph.vertices()) {
-        const auto root_id = root_vertex.id();
+    for (const auto root_id : graph.vertex_ids()) {
         if (coloring[root_id].is_set())
             continue;
 
@@ -44,7 +43,7 @@ template <
                 if (in_edge.is_loop())
                     return false;
 
-                const auto pred_id = in_edge.incident_vertex(vertex_id).id();
+                const auto pred_id = in_edge.incident_vertex(vertex_id);
 
                 if (coloring[vertex_id] == coloring[pred_id])
                     return predicate_result::unknown; // graph is not bipartite

--- a/include/gl/algorithm/depth_first_search.hpp
+++ b/include/gl/algorithm/depth_first_search.hpp
@@ -12,10 +12,8 @@ namespace gl::algorithm {
 template <
     result_discriminator ResultDiscriminator = algorithm::ret,
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
@@ -33,21 +31,21 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> depth_first_
     if (root_vertex_id_opt) {
         impl::dfs(
             graph,
-            graph.get_vertex(root_vertex_id_opt.value()),
-            impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+            root_vertex_id_opt.value(),
+            impl::default_visit_vertex_predicate(visited),
+            impl::default_visit_callback<ResultDiscriminator>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
-        for (const auto& root_vertex : graph.vertices())
+        for (const auto root_vertex_id : graph.vertex_ids())
             impl::dfs(
                 graph,
-                root_vertex,
-                impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+                root_vertex_id,
+                impl::default_visit_vertex_predicate(visited),
+                impl::default_visit_callback<ResultDiscriminator>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit
@@ -61,10 +59,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> depth_first_
 template <
     result_discriminator ResultDiscriminator = algorithm::ret,
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> recursive_depth_first_search(
     const GraphType& graph,
     const std::optional<types::id_type>& root_vertex_id_opt = no_root_vertex,
@@ -83,23 +79,23 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> recursive_de
         const auto root_id = root_vertex_id_opt.value();
         impl::r_dfs(
             graph,
-            graph.get_vertex(root_id),
             root_id,
-            impl::default_visit_vertex_predicate<GraphType>(visited),
-            impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+            root_id, // pred_id
+            impl::default_visit_vertex_predicate(visited),
+            impl::default_visit_callback<ResultDiscriminator>(visited, pd),
             impl::default_enqueue_vertex_predicate<GraphType>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
-        for (const auto& root_vertex : graph.vertices())
+        for (const auto& root_id : graph.vertex_ids())
             impl::r_dfs(
                 graph,
-                root_vertex,
-                root_vertex.id(),
-                impl::default_visit_vertex_predicate<GraphType>(visited),
-                impl::default_visit_callback<GraphType, ResultDiscriminator>(visited, pd),
+                root_id,
+                root_id, // pred_id
+                impl::default_visit_vertex_predicate(visited),
+                impl::default_visit_callback<ResultDiscriminator>(visited, pd),
                 impl::default_enqueue_vertex_predicate<GraphType>(visited),
                 pre_visit,
                 post_visit

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -65,10 +65,8 @@ template <type_traits::c_graph GraphType>
 
 template <
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 [[nodiscard]] paths_descriptor_type<GraphType> dijkstra_shortest_paths(
     const GraphType& graph,
     const types::id_type source_id,
@@ -94,10 +92,9 @@ template <
         impl::init_range(source_id),
         algorithm::empty_callback{}, // visit predicate
         algorithm::empty_callback{}, // visit callback
-        [&paths, &negative_edge](const vertex_type& vertex, const edge_type& in_edge)
+        [&paths, &negative_edge](const types::id_type vertex_id, const edge_type& in_edge)
             -> predicate_result { // enqueue predicate
-            const auto vertex_id = vertex.id();
-            const auto source_id = in_edge.incident_vertex(vertex).id();
+            const auto pred_id = in_edge.incident_vertex(vertex_id).id();
 
             const auto edge_weight = get_weight<GraphType>(in_edge);
             if (edge_weight < constants::zero) {
@@ -105,11 +102,11 @@ template <
                 return predicate_result::unknown;
             }
 
-            const auto new_distance = paths.distances[source_id] + edge_weight;
+            const auto new_distance = paths.distances[pred_id] + edge_weight;
             if (not paths.predecessors[vertex_id].has_value()
                 or new_distance < paths.distances[vertex_id]) {
                 paths.distances[vertex_id] = new_distance;
-                paths.predecessors[vertex_id].emplace(source_id);
+                paths.predecessors[vertex_id].emplace(pred_id);
                 return true;
             }
 

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -94,7 +94,7 @@ template <
         algorithm::empty_callback{}, // visit callback
         [&paths, &negative_edge](const types::id_type vertex_id, const edge_type& in_edge)
             -> predicate_result { // enqueue predicate
-            const auto pred_id = in_edge.incident_vertex(vertex_id).id();
+            const auto pred_id = in_edge.incident_vertex(vertex_id);
 
             const auto edge_weight = get_weight<GraphType>(in_edge);
             if (edge_weight < constants::zero) {
@@ -118,8 +118,8 @@ template <
         const auto& edge = negative_edge.value().get();
         throw std::invalid_argument(std::format(
             "[alg::dijkstra_shortest_paths] Found an edge with a negative weight: [{}, {} | w={}]",
-            edge.first().id(),
-            edge.second().id(),
+            edge.first(),
+            edge.second(),
             get_weight<GraphType>(edge)
         ));
     }

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -56,7 +56,7 @@ bool bfs(
                 return false;
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == predicate_result::unknown)

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -16,7 +16,8 @@ template <
         std::vector<algorithm::vertex_info>,
     type_traits::c_optional_id_callback<bool> VisitVertexPredicate,
     type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
-    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&>
+        EnqueueVertexPred,
     type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 bool bfs(

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -14,14 +14,11 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_sized_range_of<algorithm::vertex_info> InitQueueRangeType =
         std::vector<algorithm::vertex_info>,
-    type_traits::c_optional_vertex_callback<GraphType, bool> VisitVertexPredicate,
-    type_traits::c_optional_vertex_callback<GraphType, bool, types::id_type> VisitCallback,
-    type_traits::c_vertex_callback<GraphType, predicate_result, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<bool> VisitVertexPredicate,
+    type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 bool bfs(
     const GraphType& graph,
     const InitQueueRangeType& initial_queue_content,
@@ -46,31 +43,30 @@ bool bfs(
         const algorithm::vertex_info vinfo = vertex_queue.front();
         vertex_queue.pop();
 
-        const auto& vertex = graph.get_vertex(vinfo.id);
         if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vertex))
+            if (not visit_vertex_pred(vinfo.id))
                 continue;
 
         if constexpr (not type_traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vertex);
+            pre_visit(vinfo.id);
 
         if constexpr (not type_traits::c_empty_callback<VisitCallback>)
-            if (not visit(vertex, vinfo.source_id))
+            if (not visit(vinfo.id, vinfo.pred_id))
                 return false;
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto& incident_vertex = edge.incident_vertex(vertex);
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
 
-            const auto enqueue = enqueue_vertex_pred(incident_vertex, edge);
+            const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == predicate_result::unknown)
                 return false;
 
             if (enqueue)
-                vertex_queue.emplace(incident_vertex.id(), vinfo.id);
+                vertex_queue.emplace(incident_vertex_id, vinfo.id);
         }
 
         if constexpr (not type_traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vertex);
+            post_visit(vinfo.id);
     }
 
     return true;

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -30,23 +30,21 @@ template <
     return InitRangeType{algorithm::vertex_info{root_vertex_id}};
 }
 
-template <type_traits::c_graph GraphType>
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited) {
-    return [&](const typename GraphType::vertex_type& vertex) -> bool {
-        return not visited[vertex.id()];
+    return [&](const types::id_type vertex_id) -> bool {
+        return not visited[vertex_id];
     };
 }
 
-template <type_traits::c_graph GraphType, result_discriminator ResultDiscriminator>
+template <result_discriminator ResultDiscriminator>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
     std::vector<bool>& visited,
     alg_return_type_non_void<ResultDiscriminator, predecessors_descriptor>& pd
 ) {
-    return [&](const typename GraphType::vertex_type& vertex, const types::id_type source_id) {
-        const auto vertex_id = vertex.id();
+    return [&](const types::id_type vertex_id, const types::id_type pred_id) {
         visited[vertex_id] = true;
         if constexpr (ResultDiscriminator == algorithm::ret)
-            pd[vertex_id].emplace(source_id);
+            pd[vertex_id].emplace(pred_id);
         return true;
     };
 }
@@ -56,9 +54,8 @@ template <type_traits::c_graph GraphType, bool AsResult = false>
 ) {
     using return_type = std::conditional_t<AsResult, predicate_result, bool>;
 
-    return [&](const typename GraphType::vertex_type& vertex,
-               const typename GraphType::edge_type& in_edge) -> return_type {
-        return not visited[vertex.id()];
+    return [&](const types::id_type vertex_id, const typename GraphType::edge_type& in_edge) -> return_type {
+        return not visited[vertex_id];
     };
 }
 

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -31,9 +31,7 @@ template <
 }
 
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited) {
-    return [&](const types::id_type vertex_id) -> bool {
-        return not visited[vertex_id];
-    };
+    return [&](const types::id_type vertex_id) -> bool { return not visited[vertex_id]; };
 }
 
 template <result_discriminator ResultDiscriminator>
@@ -54,9 +52,8 @@ template <type_traits::c_graph GraphType, bool AsResult = false>
 ) {
     using return_type = std::conditional_t<AsResult, predicate_result, bool>;
 
-    return [&](const types::id_type vertex_id, const typename GraphType::edge_type& in_edge) -> return_type {
-        return not visited[vertex_id];
-    };
+    return [&](const types::id_type vertex_id, const typename GraphType::edge_type& in_edge
+           ) -> return_type { return not visited[vertex_id]; };
 }
 
 } // namespace gl::algorithm::impl

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -20,7 +20,7 @@ template <
     type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void dfs(
     const GraphType& graph,
-    const types::id_type root_vertex_id,
+    const types::id_type root_id,
     const VisitVertexPredicate& visit_vertex_pred,
     const VisitCallback& visit,
     const EnqueueVertexPred& enqueue_vertex_pred,
@@ -30,12 +30,12 @@ void dfs(
     using vertex_stack_type = std::stack<algorithm::vertex_info>;
 
     if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-        if (not visit_vertex_pred(root_vertex_id))
+        if (not visit_vertex_pred(root_id))
             return;
 
     // prepare the vertex stack
     vertex_stack_type vertex_stack;
-    vertex_stack.emplace(root_vertex_id);
+    vertex_stack.emplace(root_id);
 
     // search the graph
     while (not vertex_stack.empty()) {

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -12,17 +12,14 @@ namespace gl::algorithm::impl {
 
 template <
     type_traits::c_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, bool> VisitVertexPredicate,
-    type_traits::c_vertex_callback<GraphType, bool, types::id_type> VisitCallback,
-    type_traits::c_vertex_callback<GraphType, predicate_result, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<bool> VisitVertexPredicate,
+    type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void dfs(
     const GraphType& graph,
-    const typename GraphType::vertex_type& root_vertex,
+    const types::id_type root_vertex_id,
     const VisitVertexPredicate& visit_vertex_pred,
     const VisitCallback& visit,
     const EnqueueVertexPred& enqueue_vertex_pred,
@@ -32,53 +29,50 @@ void dfs(
     using vertex_stack_type = std::stack<algorithm::vertex_info>;
 
     if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-        if (not visit_vertex_pred(root_vertex))
+        if (not visit_vertex_pred(root_vertex_id))
             return;
 
     // prepare the vertex stack
     vertex_stack_type vertex_stack;
-    vertex_stack.emplace(root_vertex.id());
+    vertex_stack.emplace(root_vertex_id);
 
     // search the graph
     while (not vertex_stack.empty()) {
         const auto vinfo = vertex_stack.top();
         vertex_stack.pop();
 
-        const auto& vertex = graph.get_vertex(vinfo.id);
         if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vertex))
+            if (not visit_vertex_pred(vinfo.id))
                 continue;
 
         if constexpr (not type_traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vertex);
+            pre_visit(vinfo.id);
 
-        visit(vertex, vinfo.source_id);
+        visit(vinfo.id, vinfo.pred_id);
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto& incident_vertex = edge.incident_vertex(vertex);
-            if (enqueue_vertex_pred(incident_vertex, edge))
-                vertex_stack.emplace(incident_vertex.id(), vinfo.id);
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
+            if (enqueue_vertex_pred(incident_vertex_id, edge))
+                vertex_stack.emplace(incident_vertex_id, vinfo.id);
         }
 
         if constexpr (not type_traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vertex);
+            post_visit(vinfo.id);
     }
 }
 
 template <
     type_traits::c_graph GraphType,
-    type_traits::c_vertex_callback<GraphType, bool> VisitVertexPredicate,
-    type_traits::c_vertex_callback<GraphType, bool, types::id_type> VisitCallback,
-    type_traits::c_vertex_callback<GraphType, predicate_result, const typename GraphType::edge_type&>
+    type_traits::c_optional_id_callback<bool> VisitVertexPredicate,
+    type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&>
         EnqueueVertexPred,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void r_dfs(
     const GraphType& graph,
-    const typename GraphType::vertex_type& vertex,
-    const types::id_type source_id,
+    const types::id_type vertex_id,
+    const types::id_type pred_id,
     const VisitVertexPredicate& visit_vertex_pred,
     const VisitCallback& visit,
     const EnqueueVertexPred& enqueue_vertex_pred,
@@ -86,22 +80,21 @@ void r_dfs(
     const PostVisitCallback& post_visit = {}
 ) {
     if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-        if (not visit_vertex_pred(vertex))
+        if (not visit_vertex_pred(vertex_id))
             return;
 
     if constexpr (not type_traits::c_empty_callback<PreVisitCallback>)
-        pre_visit(vertex);
+        pre_visit(vertex_id);
 
-    visit(vertex, source_id);
+    visit(vertex_id, pred_id);
 
     // recursively search vertices adjacent to the current vertex
-    const auto vertex_id = vertex.id();
     for (const auto& edge : graph.adjacent_edges(vertex_id)) {
-        const auto& incident_vertex = edge.incident_vertex(vertex);
-        if (enqueue_vertex_pred(incident_vertex, edge))
+        const auto& incident_vertex_id = edge.incident_vertex(vertex_id).id();
+        if (enqueue_vertex_pred(incident_vertex_id, edge))
             r_dfs(
                 graph,
-                incident_vertex,
+                incident_vertex_id,
                 vertex_id,
                 visit_vertex_pred,
                 visit,
@@ -112,7 +105,7 @@ void r_dfs(
     }
 
     if constexpr (not type_traits::c_empty_callback<PostVisitCallback>)
-        post_visit(vertex);
+        post_visit(vertex_id);
 }
 
 } // namespace gl::algorithm::impl

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -52,7 +52,7 @@ void dfs(
         visit(vinfo.id, vinfo.pred_id);
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
             if (enqueue_vertex_pred(incident_vertex_id, edge))
                 vertex_stack.emplace(incident_vertex_id, vinfo.id);
         }
@@ -91,7 +91,7 @@ void r_dfs(
 
     // recursively search vertices adjacent to the current vertex
     for (const auto& edge : graph.adjacent_edges(vertex_id)) {
-        const auto& incident_vertex_id = edge.incident_vertex(vertex_id).id();
+        const auto& incident_vertex_id = edge.incident_vertex(vertex_id);
         if (enqueue_vertex_pred(incident_vertex_id, edge))
             r_dfs(
                 graph,

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -14,7 +14,8 @@ template <
     type_traits::c_graph GraphType,
     type_traits::c_optional_id_callback<bool> VisitVertexPredicate,
     type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
-    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&>
+        EnqueueVertexPred,
     type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void dfs(

--- a/include/gl/algorithm/impl/pfs.hpp
+++ b/include/gl/algorithm/impl/pfs.hpp
@@ -15,14 +15,11 @@ template <
     std::predicate<algorithm::vertex_info, algorithm::vertex_info> PQCompare,
     type_traits::c_sized_range_of<algorithm::vertex_info> InitQueueRangeType =
         std::vector<algorithm::vertex_info>,
-    type_traits::c_optional_vertex_callback<GraphType, bool> VisitVertexPredicate,
-    type_traits::c_optional_callback<GraphType, bool, types::id_type> VisitCallback,
-    type_traits::c_vertex_callback<GraphType, predicate_result, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<GraphType, bool> VisitVertexPredicate,
+    type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 bool pfs(
     const GraphType& graph,
     const PQCompare& pq_compare,
@@ -49,30 +46,29 @@ bool pfs(
         const auto vinfo = vertex_queue.top();
         vertex_queue.pop();
 
-        const auto& vertex = graph.get_vertex(vinfo.id);
         if constexpr (not type_traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vertex))
+            if (not visit_vertex_pred(vinfo.id))
                 continue;
 
         if constexpr (not type_traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vertex);
+            pre_visit(vinfo.id);
 
         if constexpr (not type_traits::c_empty_callback<VisitCallback>)
-            if (not visit(vertex, vinfo.source_id))
+            if (not visit(vinfo.id, vinfo.pred_id))
                 return false;
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto& incident_vertex = edge.incident_vertex(vertex);
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
 
-            const auto enqueue = enqueue_vertex_pred(incident_vertex, edge);
+            const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == predicate_result::unknown)
                 return false;
 
             if (enqueue)
-                vertex_queue.emplace(incident_vertex.id(), vinfo.id);
+                vertex_queue.emplace(incident_vertex_id, vinfo.id);
         }
         if constexpr (not type_traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vertex);
+            post_visit(vinfo.id);
     }
 
     return true;

--- a/include/gl/algorithm/impl/pfs.hpp
+++ b/include/gl/algorithm/impl/pfs.hpp
@@ -17,7 +17,8 @@ template <
         std::vector<algorithm::vertex_info>,
     type_traits::c_optional_id_callback<GraphType, bool> VisitVertexPredicate,
     type_traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
-    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
+    type_traits::c_id_callback<predicate_result, const typename GraphType::edge_type&>
+        EnqueueVertexPred,
     type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 bool pfs(

--- a/include/gl/algorithm/impl/pfs.hpp
+++ b/include/gl/algorithm/impl/pfs.hpp
@@ -59,7 +59,7 @@ bool pfs(
                 return false;
 
         for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id).id();
+            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == predicate_result::unknown)

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -72,7 +72,7 @@ template <type_traits::c_undirected_graph GraphType>
         const auto& min_edge = min_edge_info.edge.get();
         const auto min_weight = get_weight<GraphType>(min_edge);
 
-        const auto& target_id = min_edge.incident_vertex(min_edge_info.source_id).id();
+        const auto& target_id = min_edge.incident_vertex(min_edge_info.source_id);
         if (visited[target_id])
             continue;
 
@@ -85,7 +85,7 @@ template <type_traits::c_undirected_graph GraphType>
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.adjacent_edges(target_id))
-            if (not visited[edge.incident_vertex(target_id).id()])
+            if (not visited[edge.incident_vertex(target_id)])
                 edge_queue.emplace(edge, target_id);
     }
 
@@ -141,7 +141,7 @@ requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<Graph
         // Update adjacent vertices
         for (const auto& edge : graph.adjacent_edges(vertex_id)) {
             const auto edge_weight = get_weight<GraphType>(edge);
-            const auto incident_vertex_id = edge.incident_vertex(vertex_id).id();
+            const auto incident_vertex_id = edge.incident_vertex(vertex_id);
 
             if (not in_mst[incident_vertex_id] && edge_weight < min_cost[incident_vertex_id]) {
                 min_cost[incident_vertex_id] = edge_weight;

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -28,8 +28,7 @@ struct mst_descriptor {
 
 template <type_traits::c_undirected_graph GraphType>
 [[nodiscard]] mst_descriptor<GraphType> edge_heap_prim_mst(
-    const GraphType& graph,
-    const std::optional<types::id_type> root_id_opt
+    const GraphType& graph, const std::optional<types::id_type> root_id_opt
 ) {
     // type definitions
 
@@ -96,8 +95,7 @@ template <type_traits::c_undirected_graph GraphType>
 template <type_traits::c_undirected_graph GraphType>
 requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
 [[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
-    const GraphType& graph,
-    const std::optional<types::id_type> root_id_opt
+    const GraphType& graph, const std::optional<types::id_type> root_id_opt
 ) {
     // type definitions
     using edge_type = typename GraphType::edge_type;

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -26,17 +26,10 @@ struct mst_descriptor {
     weight_type weight = static_cast<weight_type>(constants::zero);
 };
 
-template <
-    type_traits::c_undirected_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+template <type_traits::c_undirected_graph GraphType>
 [[nodiscard]] mst_descriptor<GraphType> edge_heap_prim_mst(
     const GraphType& graph,
-    const std::optional<types::id_type> root_id_opt,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    const std::optional<types::id_type> root_id_opt
 ) {
     // type definitions
 
@@ -100,18 +93,11 @@ template <
     return mst;
 }
 
-template <
-    type_traits::c_undirected_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+template <type_traits::c_undirected_graph GraphType>
 requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
 [[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
     const GraphType& graph,
-    const std::optional<types::id_type> root_id_opt,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    const std::optional<types::id_type> root_id_opt
 ) {
     // type definitions
     using edge_type = typename GraphType::edge_type;

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -10,10 +10,8 @@ namespace gl::algorithm {
 
 template <
     type_traits::c_directed_graph GraphType,
-    type_traits::c_optional_vertex_callback<GraphType, void> PreVisitCallback =
-        algorithm::empty_callback,
-    type_traits::c_optional_vertex_callback<GraphType, void> PostVisitCallback =
-        algorithm::empty_callback>
+    type_traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
+    type_traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 [[nodiscard]] std::optional<std::vector<types::id_type>> topological_sort(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -22,15 +20,13 @@ template <
     using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
 
-    const auto vertex_ids = graph.vertex_ids();
-
     // prepare the vertex in degree map
     std::vector<types::size_type> in_degree_map = graph.in_degree_map();
 
     // prepare the initial queue content (source vertices)
     std::vector<algorithm::vertex_info> source_vertex_list;
     source_vertex_list.reserve(graph.n_vertices());
-    for (const auto id : vertex_ids)
+    for (const auto id : graph.vertex_ids())
         if (in_degree_map[id] == constants::default_size)
             source_vertex_list.emplace_back(id);
 
@@ -44,16 +40,16 @@ template <
         source_vertex_list,
         algorithm::empty_callback{}, // visit predicate
         [&topological_order](
-            const vertex_type& vertex, const types::id_type source_id
+            const types::id_type vertex_id, const types::id_type source_id
         ) { // visit callback
-            topological_order.push_back(vertex.id());
+            topological_order.push_back(vertex_id);
             return true;
         },
-        [&in_degree_map](const vertex_type& vertex, const edge_type& in_edge)
+        [&in_degree_map](const types::id_type vertex_id, const edge_type& in_edge)
             -> predicate_result { // enqueue predicate
             if (in_edge.is_loop())
                 return false;
-            return --in_degree_map[vertex.id()] == constants::default_size;
+            return --in_degree_map[vertex_id] == constants::default_size;
         },
         pre_visit,
         post_visit

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -18,13 +18,13 @@ using enum result_discriminator;
 struct empty_callback {};
 
 struct vertex_info {
-    vertex_info(types::id_type id) : id(id), source_id(id) {}
+    vertex_info(types::id_type id) : id(id), pred_id(id) {}
 
-    vertex_info(types::id_type id, types::id_type source_id) : id(id), source_id(source_id) {}
+    vertex_info(types::id_type id, types::id_type pred_id) : id(id), pred_id(pred_id) {}
 
-    // if id == source_id then vertex_id is the id of the starting vertex
+    // if id == pred_id then vertex_id is the id of the starting vertex
     types::id_type id;
-    types::id_type source_id;
+    types::id_type pred_id;
 };
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
@@ -101,17 +101,17 @@ concept c_empty_callback = std::same_as<F, algorithm::empty_callback>;
 template <typename F, typename ReturnType, typename... Args>
 concept c_optional_callback = c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>;
 
-template <typename F, typename GraphType, typename ReturnType, typename... Args>
-concept c_vertex_callback =
-    std::is_invocable_r_v<ReturnType, F, const typename GraphType::vertex_type&, Args...>;
+template <typename F, typename ReturnType, typename... Args>
+concept c_id_callback =
+    std::is_invocable_r_v<ReturnType, F, const types::id_type&, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_edge_callback =
     std::is_invocable_r_v<ReturnType, F, const typename GraphType::edge_type&, Args...>;
 
-template <typename F, typename GraphType, typename ReturnType, typename... Args>
-concept c_optional_vertex_callback =
-    c_optional_callback<F, ReturnType, const typename GraphType::vertex_type&, Args...>;
+template <typename F, typename ReturnType, typename... Args>
+concept c_optional_id_callback =
+    c_optional_callback<F, ReturnType, const types::id_type, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_optional_edge_callback =

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -102,14 +102,14 @@ template <typename F, typename ReturnType, typename... Args>
 concept c_optional_callback = c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>;
 
 template <typename F, typename ReturnType, typename... Args>
-concept c_id_callback = std::is_invocable_r_v<ReturnType, F, const types::id_type&, Args...>;
+concept c_id_callback = std::is_invocable_r_v<ReturnType, F, const types::id_type, Args...>;
+
+template <typename F, typename ReturnType, typename... Args>
+concept c_optional_id_callback = c_optional_callback<F, ReturnType, const types::id_type, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_edge_callback =
     std::is_invocable_r_v<ReturnType, F, const typename GraphType::edge_type&, Args...>;
-
-template <typename F, typename ReturnType, typename... Args>
-concept c_optional_id_callback = c_optional_callback<F, ReturnType, const types::id_type, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_optional_edge_callback =

--- a/include/gl/algorithm/types.hpp
+++ b/include/gl/algorithm/types.hpp
@@ -102,16 +102,14 @@ template <typename F, typename ReturnType, typename... Args>
 concept c_optional_callback = c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>;
 
 template <typename F, typename ReturnType, typename... Args>
-concept c_id_callback =
-    std::is_invocable_r_v<ReturnType, F, const types::id_type&, Args...>;
+concept c_id_callback = std::is_invocable_r_v<ReturnType, F, const types::id_type&, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_edge_callback =
     std::is_invocable_r_v<ReturnType, F, const typename GraphType::edge_type&, Args...>;
 
 template <typename F, typename ReturnType, typename... Args>
-concept c_optional_id_callback =
-    c_optional_callback<F, ReturnType, const types::id_type, Args...>;
+concept c_optional_id_callback = c_optional_callback<F, ReturnType, const types::id_type, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_optional_edge_callback =

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -18,10 +18,6 @@ public:
     using type = edge_descriptor<DirectionalTag, Properties>;
     using directional_tag = DirectionalTag;
     using properties_type = Properties;
-    using properties_ref_type = std::conditional_t<
-        type_traits::is_default_properties_type_v<properties_type>,
-        types::empty_properties,
-        properties_type&>;
 
     friend directional_tag;
 

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -11,13 +11,11 @@
 namespace gl {
 
 template <
-    type_traits::c_instantiation_of<vertex_descriptor> VertexType,
     type_traits::c_edge_directional_tag DirectionalTag = directed_t,
     type_traits::c_properties Properties = types::empty_properties>
 class edge_descriptor final {
 public:
-    using type = edge_descriptor<VertexType, DirectionalTag, Properties>;
-    using vertex_type = VertexType;
+    using type = edge_descriptor<DirectionalTag, Properties>;
     using directional_tag = DirectionalTag;
     using properties_type = Properties;
     using properties_ref_type = std::conditional_t<
@@ -34,14 +32,14 @@ public:
     edge_descriptor(const edge_descriptor&) = delete;
     edge_descriptor& operator=(const edge_descriptor&) = delete;
 
-    explicit edge_descriptor(const vertex_type first, const vertex_type& second)
-    : _vertices(std::move(first), std::move(second)) {}
+    explicit edge_descriptor(const types::id_type first, const types::id_type second)
+    : _vertices(first, second) {}
 
     explicit edge_descriptor(
-        const vertex_type first, const vertex_type second, properties_type properties
+        const types::id_type first, const types::id_type second, properties_type properties
     )
     requires(not type_traits::is_default_properties_type_v<properties_type>)
-    : _vertices(std::move(first), std::move(second)), _properties(properties) {}
+    : _vertices(first, second), _properties(properties) {}
 
     edge_descriptor(edge_descriptor&&) = default;
     edge_descriptor& operator=(edge_descriptor&&) = default;
@@ -59,46 +57,33 @@ public:
     // clang-format off
     // gl_attr_force_inline misplacement
 
-    [[nodiscard]] gl_attr_force_inline
-    const types::homogeneous_pair<const vertex_type>& incident_vertices() const {
+    [[nodiscard]] gl_attr_force_inline types::homogeneous_pair<const types::id_type> incident_vertices() const {
         return this->_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline const types::homogeneous_pair<types::id_type> incident_vertex_ids() const {
-        return std::make_pair(this->_vertices.first.id(), this->_vertices.second.id());
-    }
-
-    [[nodiscard]] gl_attr_force_inline const vertex_type& first() const {
+    [[nodiscard]] gl_attr_force_inline const types::id_type first() const {
         return this->_vertices.first;
     }
 
-    [[nodiscard]] gl_attr_force_inline const vertex_type& second() const {
+    [[nodiscard]] gl_attr_force_inline const types::id_type second() const {
         return this->_vertices.second;
     }
 
     // clang-format on
 
     // returns the `other` vertex or throws error if the given vertex is not incident with the edge
-    [[nodiscard]] const vertex_type incident_vertex(const types::id_type vertex_id) const {
-        if (vertex_id == this->_vertices.first.id())
+    [[nodiscard]] const types::id_type incident_vertex(const types::id_type vertex_id) const {
+        if (vertex_id == this->_vertices.first)
             return this->_vertices.second;
 
-        if (vertex_id == this->_vertices.second.id())
+        if (vertex_id == this->_vertices.second)
             return this->_vertices.first;
 
         throw std::invalid_argument(std::format("Got invalid vertex id: {}", vertex_id));
     }
 
-    [[nodiscard]] const vertex_type incident_vertex(const vertex_type& vertex) const {
-        return this->incident_vertex(vertex.id());
-    }
-
     [[nodiscard]] gl_attr_force_inline bool is_incident_with(const types::id_type vertex_id) const {
-        return vertex_id == this->_vertices.first.id() or vertex_id == this->_vertices.second.id();
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool is_incident_with(const vertex_type& vertex) const {
-        return this->is_incident_with(vertex.id());
+        return vertex_id == this->_vertices.first or vertex_id == this->_vertices.second;
     }
 
     // true if the given vertex is the `source` of the edge
@@ -106,19 +91,9 @@ public:
         return directional_tag::is_incident_from(*this, vertex_id);
     }
 
-    // true if the given vertex is the `source` of the edge
-    [[nodiscard]] gl_attr_force_inline bool is_incident_from(const vertex_type& vertex) const {
-        return this->is_incident_from(vertex.id());
-    }
-
     // true if the given vertex is the `target` vertex of the edge
     [[nodiscard]] gl_attr_force_inline bool is_incident_to(const types::id_type vertex_id) const {
         return directional_tag::is_incident_to(*this, vertex_id);
-    }
-
-    // true if the given vertex is the `target` vertex of the edge
-    [[nodiscard]] gl_attr_force_inline bool is_incident_to(const vertex_type& vertex) const {
-        return this->is_incident_to(vertex.id());
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_loop() const {
@@ -135,75 +110,49 @@ public:
     }
 
 private:
-    class vertex_writer {
-    public:
-        vertex_writer(const vertex_type& vertex, bool within_context)
-        : _vertex_ref(vertex), _within_context(within_context) {}
-
-        friend std::ostream& operator<<(std::ostream& os, const vertex_writer& vw) {
-            if (vw._within_context)
-                os << vw._vertex_ref.id();
-            else
-                os << vw._vertex_ref;
-            return os;
-        }
-
-    private:
-        const vertex_type& _vertex_ref;
-        bool _within_context;
-    };
-
-    void _write(std::ostream& os, bool within_context = false) const {
+    void _write(std::ostream& os) const {
         if constexpr (not type_traits::c_writable<properties_type>) {
-            this->_write_no_properties(os, within_context);
+            this->_write_no_properties(os);
             return;
         }
         else {
             if (not io::is_option_set(os, io::graph_option::with_edge_properties)) {
-                this->_write_no_properties(os, within_context);
+                this->_write_no_properties(os);
                 return;
             }
 
             if (io::is_option_set(os, io::graph_option::verbose)) {
-                os << "[first: " << vertex_writer(this->first(), within_context)
-                   << ", second: " << vertex_writer(this->second(), within_context)
+                os << "[first: " << this->_vertices.first << ", second: " << this->_vertices.second
                    << " | properties: " << this->_properties << "]";
             }
             else {
-                os << "[" << vertex_writer(this->first(), within_context) << ", "
-                   << vertex_writer(this->second(), within_context) << " | " << this->_properties
-                   << "]";
+                os << "[" << this->_vertices.first << ", " << this->_vertices.second << " | "
+                   << this->_properties << "]";
             }
         }
     }
 
-    void _write_no_properties(std::ostream& os, bool within_context = false) const {
+    void _write_no_properties(std::ostream& os) const {
         if (io::is_option_set(os, io::graph_option::verbose))
-            os << "[first: " << vertex_writer(this->first(), within_context)
-               << ", second: " << vertex_writer(this->second(), within_context) << "]";
+            os << "[first: " << this->_vertices.first << ", second: " << this->_vertices.first
+               << "]";
         else
-            os << "[" << vertex_writer(this->first(), within_context) << ", "
-               << vertex_writer(this->second(), within_context) << "]";
+            os << "[" << this->_vertices.first << ", " << this->_vertices.second << "]";
     }
 
-    types::homogeneous_pair<const vertex_type> _vertices;
+    types::homogeneous_pair<types::id_type> _vertices;
     [[no_unique_address]] mutable properties_type _properties{};
 };
 
 template <
-    type_traits::c_instantiation_of<vertex_descriptor> VertexType,
     type_traits::c_edge_directional_tag DirectionalTag = directed_t,
     type_traits::c_properties Properties = types::empty_properties>
-using edge = edge_descriptor<VertexType, DirectionalTag, Properties>;
+using edge = edge_descriptor<DirectionalTag, Properties>;
 
-template <
-    type_traits::c_instantiation_of<vertex_descriptor> VertexType,
-    type_traits::c_properties Properties = types::empty_properties>
-using directed_edge = edge_descriptor<VertexType, directed_t, Properties>;
+template <type_traits::c_properties Properties = types::empty_properties>
+using directed_edge = edge_descriptor<directed_t, Properties>;
 
-template <
-    type_traits::c_instantiation_of<vertex_descriptor> VertexType,
-    type_traits::c_properties Properties = types::empty_properties>
-using undirected_edge = edge_descriptor<VertexType, undirected_t, Properties>;
+template <type_traits::c_properties Properties = types::empty_properties>
+using undirected_edge = edge_descriptor<undirected_t, Properties>;
 
 } // namespace gl

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -21,13 +21,7 @@ concept c_edge_directional_tag = c_one_of<T, directed_t, undirected_t>;
 
 } // namespace type_traits
 
-template <type_traits::c_properties Properties>
-class vertex_descriptor;
-
-template <
-    type_traits::c_instantiation_of<vertex_descriptor> VertexType,
-    type_traits::c_edge_directional_tag EdgeTag,
-    type_traits::c_properties Properties>
+template <type_traits::c_edge_directional_tag EdgeTag, type_traits::c_properties Properties>
 class edge_descriptor;
 
 namespace type_traits {
@@ -58,7 +52,7 @@ struct directed_t {
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
-        const typename EdgeType::vertex_type& first, const typename EdgeType::vertex_type& second
+        const types::id_type first, const types::id_type second
     ) {
         return std::make_unique<EdgeType>(first, second);
     }
@@ -66,8 +60,8 @@ struct directed_t {
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_directed_v<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
-        const typename EdgeType::vertex_type& first,
-        const typename EdgeType::vertex_type& second,
+        const types::id_type first,
+        const types::id_type second,
         const typename EdgeType::properties_type& properties
     ) {
         return std::make_unique<EdgeType>(first, second, properties);
@@ -78,7 +72,7 @@ struct directed_t {
     [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
         const EdgeType& edge, const types::id_type vertex_id
     ) {
-        return vertex_id == edge._vertices.first.id();
+        return vertex_id == edge._vertices.first;
     }
 
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
@@ -86,7 +80,7 @@ struct directed_t {
     [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
         const EdgeType& edge, const types::id_type vertex_id
     ) {
-        return vertex_id == edge._vertices.second.id();
+        return vertex_id == edge._vertices.second;
     }
 };
 
@@ -100,7 +94,7 @@ struct undirected_t {
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
-        const typename EdgeType::vertex_type& first, const typename EdgeType::vertex_type& second
+        const types::id_type first, const types::id_type second
     ) {
         return std::make_shared<EdgeType>(first, second);
     }
@@ -108,8 +102,8 @@ struct undirected_t {
     template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(type_traits::is_undirected_v<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static edge_ptr_type<EdgeType> make(
-        const typename EdgeType::vertex_type& first,
-        const typename EdgeType::vertex_type& second,
+        const types::id_type first,
+        const types::id_type second,
         const typename EdgeType::properties_type& properties
     ) {
         return std::make_shared<EdgeType>(first, second, properties);
@@ -143,15 +137,15 @@ namespace detail {
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
 [[nodiscard]] gl_attr_force_inline types::edge_ptr_type<EdgeType> make_edge(
-    const typename EdgeType::vertex_type& first, const typename EdgeType::vertex_type& second
+    const types::id_type first, const types::id_type second
 ) {
     return EdgeType::directional_tag::template make<EdgeType>(first, second);
 }
 
 template <type_traits::c_instantiation_of<edge_descriptor> EdgeType>
 [[nodiscard]] gl_attr_force_inline types::edge_ptr_type<EdgeType> make_edge(
-    const typename EdgeType::vertex_type& first,
-    const typename EdgeType::vertex_type& second,
+    const types::id_type first,
+    const types::id_type second,
     const typename EdgeType::properties_type& properties
 ) {
     return EdgeType::directional_tag::template make<EdgeType>(first, second, properties);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -45,11 +45,11 @@ public:
 
     graph() = default;
 
-    graph(const types::size_type n_vertices)
+    explicit graph(const types::size_type n_vertices)
     requires(type_traits::is_default_properties_type_v<vertex_properties_type>)
     : _n_vertices(n_vertices), _impl(n_vertices) {}
 
-    graph(const types::size_type n_vertices)
+    explicit graph(const types::size_type n_vertices)
     requires(not type_traits::is_default_properties_type_v<vertex_properties_type>)
     : _n_vertices(n_vertices), _impl(n_vertices) {
         this->_vertex_properties.reserve(n_vertices);
@@ -276,7 +276,7 @@ public:
         this->_verify_vertex_id(first_id);
         this->_verify_vertex_id(second_id);
         return this->_impl.add_edge(
-            detail::make_edge<edge_type>(this->get_vertex(first_id), this->get_vertex(second_id))
+            detail::make_edge<edge_type>(first_id, second_id)
         );
     }
 
@@ -289,9 +289,7 @@ public:
     {
         this->_verify_vertex_id(first_id);
         this->_verify_vertex_id(second_id);
-        return this->_impl.add_edge(detail::make_edge<edge_type>(
-            this->get_vertex(first_id), this->get_vertex(second_id), properties
-        ));
+        return this->_impl.add_edge(detail::make_edge<edge_type>(first_id, second_id, properties));
     }
 
     // clang-format on
@@ -299,7 +297,7 @@ public:
     const edge_type& add_edge(const vertex_type& first, const vertex_type& second) {
         this->_verify_vertex(first);
         this->_verify_vertex(second);
-        return this->_impl.add_edge(detail::make_edge<edge_type>(first, second));
+        return this->_impl.add_edge(detail::make_edge<edge_type>(first.id(), second.id()));
     }
 
     const edge_type& add_edge(
@@ -309,18 +307,21 @@ public:
     {
         this->_verify_vertex(first);
         this->_verify_vertex(second);
-        return this->_impl.add_edge(detail::make_edge<edge_type>(first, second, properties));
+        return this->_impl.add_edge(
+            detail::make_edge<edge_type>(first.id(), second.id(), properties)
+        );
     }
 
     template <type_traits::c_sized_range_of<types::id_type> IdRange>
     void add_edges_from(const types::id_type source_id, const IdRange& target_id_range) {
-        const auto& source = this->get_vertex(source_id);
+        this->_verify_vertex_id(source_id);
 
         std::vector<edge_ptr_type> new_edges;
         new_edges.reserve(std::ranges::size(target_id_range));
 
         for (const auto target_id : target_id_range) {
-            new_edges.push_back(detail::make_edge<edge_type>(source, this->get_vertex(target_id)));
+            this->_verify_vertex_id(target_id);
+            new_edges.push_back(detail::make_edge<edge_type>(source_id, target_id));
         }
         this->_impl.add_edges_from(source_id, std::move(new_edges));
     }
@@ -335,7 +336,7 @@ public:
         for (const auto& target_ref : target_range) {
             const auto& target = target_ref.get();
             this->_verify_vertex(target);
-            new_edges.push_back(detail::make_edge<edge_type>(source, target));
+            new_edges.push_back(detail::make_edge<edge_type>(source.id(), target.id()));
         }
         this->_impl.add_edges_from(source.id(), std::move(new_edges));
     }
@@ -453,13 +454,13 @@ public:
     [[nodiscard]] bool are_incident(const vertex_type& vertex, const edge_type& edge) const {
         this->_verify_vertex(vertex);
         this->_verify_edge(edge);
-        return edge.is_incident_with(vertex);
+        return edge.is_incident_with(vertex.id());
     }
 
     [[nodiscard]] bool are_incident(const edge_type& edge, const vertex_type& vertex) const {
         this->_verify_vertex(vertex);
         this->_verify_edge(edge);
-        return edge.is_incident_with(vertex);
+        return edge.is_incident_with(vertex.id());
     }
 
     [[nodiscard]] bool are_incident(const edge_type& edge_1, const edge_type& edge_2) const {
@@ -507,8 +508,8 @@ private:
         if (not this->has_edge(edge))
             throw std::invalid_argument(std::format(
                 "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-                edge.first().id(),
-                edge.second().id(),
+                edge.first(),
+                edge.second(),
                 io::format(&edge)
             ));
     }
@@ -522,8 +523,8 @@ private:
         // update vertex ids in edges
         for (auto id : this->vertex_ids()) {
             for (auto& edge : this->_impl.adjacent_edges(id)) {
-                edge._vertices.first._id -= (edge._vertices.first._id > vertex_id);
-                edge._vertices.second._id -= (edge._vertices.second._id > vertex_id);
+                edge._vertices.first -= (edge._vertices.first > vertex_id);
+                edge._vertices.second -= (edge._vertices.second > vertex_id);
             }
         }
 
@@ -543,14 +544,10 @@ private:
             this->n_unique_edges()
         );
 
-        constexpr bool within_context = true;
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << "\n  adjacent edges:\n";
-            for (const auto& edge : this->_impl.adjacent_edges(vertex.id())) {
-                os << "\t- ";
-                edge._write(os, within_context);
-                os << '\n';
-            }
+            for (const auto& edge : this->_impl.adjacent_edges(vertex.id()))
+                os << "\t- " << edge << '\n';
         }
     }
 
@@ -592,10 +589,10 @@ private:
             if (with_edge_properties) {
                 const auto print_incident_edges = [this, &os](const types::id_type vertex_id) {
                     for (const auto& edge : this->_impl.adjacent_edges(vertex_id)) {
-                        if (edge.first().id() != vertex_id)
+                        if (edge.first() != vertex_id)
                             continue; // vertex is not the source
-                        os << edge.first().id() << ' ' << edge.second().id() << ' '
-                           << edge._properties << '\n';
+                        os << edge.first() << ' ' << edge.second() << ' ' << edge._properties
+                           << '\n';
                     }
                 };
 
@@ -608,9 +605,9 @@ private:
 
         const auto print_incident_edges = [this, &os](const types::id_type vertex_id) {
             for (const auto& edge : this->_impl.adjacent_edges(vertex_id)) {
-                if (edge.first().id() != vertex_id)
+                if (edge.first() != vertex_id)
                     continue; // vertex is not the source
-                os << edge.first().id() << ' ' << edge.second().id() << '\n';
+                os << edge.first() << ' ' << edge.second() << '\n';
             }
         };
 

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -20,7 +20,7 @@ struct graph_traits {
     using vertex_ptr_type = types::vertex_ptr_type<vertex_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
 
-    using edge_type = edge_descriptor<vertex_type, EdgeDirectionalTag, EdgeProperties>;
+    using edge_type = edge_descriptor<EdgeDirectionalTag, EdgeProperties>;
     using edge_ptr_type = types::edge_ptr_type<edge_type>;
     using edge_directional_tag = typename edge_type::directional_tag;
     using edge_properties_type = typename edge_type::properties_type;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -126,7 +126,7 @@ public:
     [[nodiscard]] gl_attr_force_inline bool has_edge(const edge_type& edge) const {
         // find the edge by address
         return std::ranges::contains(
-            this->_list[edge.first().id()], &edge, typename specialized_impl::address_projection{}
+            this->_list[edge.first()], &edge, typename specialized_impl::address_projection{}
         );
     }
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -138,9 +138,7 @@ public:
     }
 
     [[nodiscard]] bool has_edge(const edge_type& edge) const {
-        const auto first_id = edge.first();
-        const auto second_id = edge.second();
-
+        const auto [first_id, second_id] = edge.incident_vertices();
         if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
             return false;
 

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -138,8 +138,8 @@ public:
     }
 
     [[nodiscard]] bool has_edge(const edge_type& edge) const {
-        const auto first_id = edge.first().id();
-        const auto second_id = edge.second().id();
+        const auto first_id = edge.first();
+        const auto second_id = edge.second();
 
         if (not (this->_is_valid_vertex_id(first_id) and this->_is_valid_vertex_id(second_id)))
             return false;

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -34,8 +34,8 @@ requires std::is_invocable_r_v<
     if (it == edge_set.end())
         throw std::invalid_argument(std::format(
             "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-            edge->first().id(),
-            edge->second().id(),
+            edge->first(),
+            edge->second(),
             io::format(edge)
         ));
 
@@ -70,7 +70,7 @@ struct directed_adjacency_list {
         types::size_type in_deg = constants::default_size;
         for (const auto& adjacent_edges : self._list)
             in_deg += std::ranges::count(adjacent_edges, vertex_id, [](const auto& edge) {
-                return edge->second().id();
+                return edge->second();
             });
 
         return in_deg;
@@ -93,7 +93,7 @@ struct directed_adjacency_list {
 
         for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
             std::ranges::for_each(self._list[id], [&in_degree_map](const auto& edge) {
-                ++in_degree_map[edge->second().id()];
+                ++in_degree_map[edge->second()];
             });
         }
 
@@ -116,7 +116,7 @@ struct directed_adjacency_list {
 
             // update in degrees
             std::ranges::for_each(self._list[id], [&degree_map](const auto& edge) {
-                ++degree_map[edge->second().id()];
+                ++degree_map[edge->second()];
             });
         }
 
@@ -144,7 +144,7 @@ struct directed_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list[edge->first().id()];
+        auto& adjacent_edges_first = self._list[edge->first()];
         auto& new_edge = adjacent_edges_first.emplace_back(std::move(edge));
         ++self._n_unique_edges;
         return *new_edge;
@@ -173,11 +173,11 @@ struct directed_adjacency_list {
         list at which the edge is located, but the parameter is necessary to match the
         function signature for undirected adjacency list
         */
-        return edge->second().id() == vertex_id;
+        return edge->second() == vertex_id;
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {
-        auto& adj_edges = self._list.at(edge.first().id());
+        auto& adj_edges = self._list.at(edge.first());
         adj_edges.erase(detail::strict_find<impl_type, address_projection>(adj_edges, &edge));
         --self._n_unique_edges;
     }
@@ -253,7 +253,7 @@ struct undirected_adjacency_list {
         for (const auto& edge : self._list[vertex_id]) {
             if (edge->is_loop())
                 continue; // will be removed with the vertex's list
-            incident_vertex_id_set.insert(edge->incident_vertex(vertex_id).id());
+            incident_vertex_id_set.insert(edge->incident_vertex(vertex_id));
         }
 
         // remove all edges incident with the vertex (scan only the selected vertices)
@@ -272,10 +272,10 @@ struct undirected_adjacency_list {
     }
 
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
-        auto& adjacent_edges_first = self._list[edge->first().id()];
+        auto& adjacent_edges_first = self._list[edge->first()];
 
         if (not edge->is_loop())
-            self._list[edge->second().id()].push_back(edge);
+            self._list[edge->second()].push_back(edge);
         adjacent_edges_first.emplace_back(std::move(edge));
 
         ++self._n_unique_edges;
@@ -290,7 +290,7 @@ struct undirected_adjacency_list {
 
         for (auto& edge : new_edges) {
             if (not edge->is_loop())
-                self._list[edge->second().id()].push_back(edge);
+                self._list[edge->second()].push_back(edge);
             adjacent_edges_source.emplace_back(std::move(edge));
         }
 
@@ -300,23 +300,23 @@ struct undirected_adjacency_list {
     [[nodiscard]] inline static bool is_edge_incident_with(
         const edge_ptr_type& edge, const types::id_type vertex_id, const types::id_type source_id
     ) {
-        if (edge->first().id() == source_id)
-            return edge->second().id() == vertex_id;
-        else if (edge->second().id() == source_id)
-            return edge->first().id() == vertex_id;
+        if (edge->first() == source_id)
+            return edge->second() == vertex_id;
+        else if (edge->second() == source_id)
+            return edge->first() == vertex_id;
         return false;
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {
         if (edge.is_loop()) {
-            auto& adj_edges_first = self._list.at(edge.first().id());
+            auto& adj_edges_first = self._list.at(edge.first());
             adj_edges_first.erase(
                 detail::strict_find<impl_type, address_projection>(adj_edges_first, &edge)
             );
         }
         else {
-            auto& adj_edges_first = self._list.at(edge.first().id());
-            auto& adj_edges_second = self._list.at(edge.second().id());
+            auto& adj_edges_first = self._list.at(edge.first());
+            auto& adj_edges_second = self._list.at(edge.second());
 
             adj_edges_first.erase(
                 detail::strict_find<impl_type, address_projection>(adj_edges_first, &edge)

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -265,13 +265,10 @@ struct undirected_adjacency_matrix {
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
         }
         else {
-            const auto first_id = edge.first();
-            const auto second_id = edge.second();
-
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
             // if the edge was found in the first matrix cell,
             // it will also be present in the second matrix cell
-            self._matrix[second_id][first_id] = nullptr;
+            self._matrix[edge.second()][edge.first()] = nullptr;
         }
         --self._n_unique_edges;
     }

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -23,12 +23,12 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
     typename AdjacencyMatrix::matrix_type& matrix, const typename AdjacencyMatrix::edge_type* edge
 ) {
     // get the edge and validate the address
-    auto& matrix_element = matrix.at(edge->first().id()).at(edge->second().id());
+    auto& matrix_element = matrix.at(edge->first()).at(edge->second());
     if (edge != matrix_element.get())
         throw std::invalid_argument(std::format(
             "Got invalid edge [vertices = ({}, {}) | addr = {}]",
-            edge->first().id(),
-            edge->second().id(),
+            edge->first(),
+            edge->second(),
             io::format(edge)
         ));
 
@@ -39,7 +39,7 @@ template <type_traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 inline void check_edge_override(
     const AdjacencyMatrix& adj_matrix, const typename AdjacencyMatrix::edge_ptr_type& edge
 ) {
-    const auto [first_id, second_id] = edge->incident_vertex_ids();
+    const auto [first_id, second_id] = edge->incident_vertices();
 
     if (adj_matrix.has_edge(first_id, second_id))
         throw std::logic_error(std::format(
@@ -136,7 +136,7 @@ struct directed_adjacency_matrix {
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
         detail::check_edge_override<impl_type>(self, edge);
 
-        auto& matrix_element = self._matrix[edge->first().id()][edge->second().id()];
+        auto& matrix_element = self._matrix[edge->first()][edge->second()];
         matrix_element = std::move(edge);
         ++self._n_unique_edges;
 
@@ -152,7 +152,7 @@ struct directed_adjacency_matrix {
 
         auto& matrix_row_source = self._matrix[source_id];
         for (auto& edge : new_edges)
-            matrix_row_source[edge->second().id()] = std::move(edge);
+            matrix_row_source[edge->second()] = std::move(edge);
 
         self._n_unique_edges += new_edges.size();
     }
@@ -231,8 +231,8 @@ struct undirected_adjacency_matrix {
     static const edge_type& add_edge(impl_type& self, edge_ptr_type edge) {
         detail::check_edge_override<impl_type>(self, edge);
 
-        const auto first_id = edge->first().id();
-        const auto second_id = edge->second().id();
+        const auto first_id = edge->first();
+        const auto second_id = edge->second();
 
         if (not edge->is_loop())
             self._matrix[second_id][first_id] = edge;
@@ -253,8 +253,8 @@ struct undirected_adjacency_matrix {
         auto& matrix_row_source = self._matrix[source_id];
         for (auto& edge : new_edges) {
             if (not edge->is_loop())
-                self._matrix[edge->second().id()][source_id] = edge;
-            matrix_row_source[edge->second().id()] = std::move(edge);
+                self._matrix[edge->second()][source_id] = edge;
+            matrix_row_source[edge->second()] = std::move(edge);
         }
 
         self._n_unique_edges += new_edges.size();
@@ -265,8 +265,8 @@ struct undirected_adjacency_matrix {
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
         }
         else {
-            const auto first_id = edge.first().id();
-            const auto second_id = edge.second().id();
+            const auto first_id = edge.first();
+            const auto second_id = edge.second();
 
             detail::strict_get<impl_type>(self._matrix, &edge) = nullptr;
             // if the edge was found in the first matrix cell,

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -113,22 +113,4 @@ using vertex_ptr_type = std::unique_ptr<VertexType>;
 
 } // namespace types
 
-namespace detail {
-
-template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
-[[nodiscard]] gl_attr_force_inline types::vertex_ptr_type<VertexType> make_vertex(
-    const types::id_type id
-) {
-    return std::make_unique<VertexType>(id);
-}
-
-template <type_traits::c_instantiation_of<vertex_descriptor> VertexType>
-[[nodiscard]] gl_attr_force_inline types::vertex_ptr_type<VertexType> make_vertex(
-    const types::id_type id, const typename VertexType::properties_type& properties
-) {
-    return std::make_unique<VertexType>(id, properties);
-}
-
-} // namespace detail
-
 } // namespace gl

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -14,7 +14,7 @@ void verify_graph_structure(const GraphType& actual, const GraphType& expected) 
     // verify that the edges of the in graph are equivalent to the edges of the out graph
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
         return std::ranges::all_of(actual.adjacent_edges(v_actual), [&](const auto& edge) {
-            return expected.has_edge(edge.first().id(), edge.second().id());
+            return expected.has_edge(edge.first(), edge.second());
         });
     }));
 }
@@ -38,10 +38,7 @@ void verify_edge_properties(const GraphType& actual, const GraphType& expected) 
         return std::ranges::all_of(actual.adjacent_edges(v_actual), [&](const auto& edge) {
             // get edge returns optional<ref_wrap>
             return edge.properties()
-                == expected.get_edge(edge.first().id(), edge.second().id())
-                       .value()
-                       .get()
-                       .properties();
+                == expected.get_edge(edge.first(), edge.second()).value().get().properties();
         });
     }));
 }

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -72,22 +72,16 @@ constexpr gl::types::size_type n_incident_edges_for_fully_connected_vertex =
 } // namespace
 
 struct test_directed_adjacency_list {
-    using vertex_type = gl::vertex_descriptor<>;
-    using edge_type = gl::directed_edge<vertex_type>;
+    using edge_type = gl::directed_edge<>;
     using edge_ptr_type = gl::directed_t::edge_ptr_type<edge_type>;
     using sut_type = gl::impl::adjacency_list<gl::list_graph_traits<gl::directed_t>>;
 
-    test_directed_adjacency_list() {
-        for (const auto id : constants::vertex_id_view)
-            vertices.emplace_back(id);
-    }
+    test_directed_adjacency_list() {}
 
     const edge_type& add_edge(
         const gl::types::id_type first_id, const gl::types::id_type second_id
     ) {
-        return sut.add_edge(
-            gl::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
-        );
+        return sut.add_edge(gl::detail::make_edge<edge_type>(first_id, second_id));
     }
 
     void fully_connect_vertex(const gl::types::id_type first_id, const bool no_loops = true) {
@@ -110,7 +104,6 @@ struct test_directed_adjacency_list {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<vertex_type> vertices;
 
     const gl::types::size_type n_unique_edges_in_full_graph =
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
@@ -122,8 +115,8 @@ TEST_CASE_FIXTURE(
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-    REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
     const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
@@ -153,15 +146,11 @@ TEST_CASE_FIXTURE(
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
-    };
+    const edge_type invalid_edge{constants::vertex_id_1, constants::vertex_id_2};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
-    };
+    const edge_type not_present_edge{constants::vertex_id_2, constants::vertex_id_3};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -219,9 +208,7 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(test_directed_adjacency_list, "remove_edge should throw when an edge is invalid") {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(
-            edge_type{vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]}
-        ),
+        sut.remove_edge(edge_type{constants::vertex_id_1, constants::vertex_id_2}),
         std::invalid_argument
     );
 }
@@ -376,22 +363,16 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_adjacency_list {
-    using vertex_type = gl::vertex_descriptor<>;
-    using edge_type = gl::undirected_edge<vertex_type>;
+    using edge_type = gl::undirected_edge<>;
     using edge_ptr_type = gl::undirected_t::edge_ptr_type<edge_type>;
     using sut_type = gl::impl::adjacency_list<gl::list_graph_traits<gl::undirected_t>>;
 
-    test_undirected_adjacency_list() {
-        for (const auto id : constants::vertex_id_view)
-            vertices.emplace_back(id);
-    }
+    test_undirected_adjacency_list() {}
 
     const edge_type& add_edge(
         const gl::types::id_type first_id, const gl::types::id_type second_id
     ) {
-        return sut.add_edge(
-            gl::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
-        );
+        return sut.add_edge(gl::detail::make_edge<edge_type>(first_id, second_id));
     }
 
     void fully_connect_vertex(const gl::types::id_type first_id, const bool no_loops = true) {
@@ -417,7 +398,6 @@ struct test_undirected_adjacency_list {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<vertex_type> vertices;
 
     const gl::types::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;
@@ -427,8 +407,8 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_list, "add_edge should add the edge to the lists of both vertices"
 ) {
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-    REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
@@ -452,7 +432,7 @@ TEST_CASE_FIXTURE(
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
     REQUIRE(new_edge.is_loop());
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
 
     const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
@@ -481,15 +461,11 @@ TEST_CASE_FIXTURE(
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
-    };
+    const edge_type invalid_edge{constants::vertex_id_1, constants::vertex_id_2};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
-    };
+    const edge_type not_present_edge{constants::vertex_id_2, constants::vertex_id_3};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -558,9 +534,7 @@ TEST_CASE_FIXTURE(
 ) {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(
-            edge_type{vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]}
-        ),
+        sut.remove_edge(edge_type{constants::vertex_id_1, constants::vertex_id_2}),
         std::invalid_argument
     );
 }
@@ -577,7 +551,7 @@ TEST_CASE_FIXTURE(
 
     const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
-    const auto second_id = edge_to_remove.second().id();
+    const auto second_id = edge_to_remove.second();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -58,36 +58,34 @@ TEST_CASE_TEMPLATE_DEFINE(
     }
 
     SUBCASE("add_edge should throw an error if the vertices are already incident") {
-        using vertex_type = typename SutType::vertex_type;
         using edge_type = typename SutType::edge_type;
 
         SutType sut{constants::n_elements};
-
-        const vertex_type v1{constants::vertex_id_1};
-        const vertex_type v2{constants::vertex_id_2};
-
-        sut.add_edge(gl::detail::make_edge<edge_type>(v1, v2));
+        sut.add_edge(
+            gl::detail::make_edge<edge_type>(constants::vertex_id_1, constants::vertex_id_2)
+        );
         REQUIRE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
 
-        CHECK_THROWS_AS(sut.add_edge(gl::detail::make_edge<edge_type>(v1, v2)), std::logic_error);
+        CHECK_THROWS_AS(
+            sut.add_edge(
+                gl::detail::make_edge<edge_type>(constants::vertex_id_1, constants::vertex_id_2)
+            ),
+            std::logic_error
+        );
     }
 
     SUBCASE("add_edges_from should throw an error if the vertices are already incident") {
-        using vertex_type = typename SutType::vertex_type;
         using edge_type = typename SutType::edge_type;
         using edge_ptr_type = typename SutType::edge_ptr_type;
 
         SutType sut{constants::n_elements};
-
-        const vertex_type v1{constants::vertex_id_1};
-        const vertex_type v2{constants::vertex_id_2};
-        const vertex_type v3{constants::vertex_id_3};
-
-        const auto vertex_refs = {std::cref(v1), std::cref(v2), std::cref(v3)};
+        const auto vertices = {
+            constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
+        };
 
         std::vector<edge_ptr_type> new_edges;
-        for (const auto& target : vertex_refs)
-            new_edges.push_back(gl::detail::make_edge<edge_type>(v1, target.get()));
+        for (const auto& target : vertices)
+            new_edges.push_back(gl::detail::make_edge<edge_type>(constants::vertex_id_1, target));
 
         sut.add_edges_from(constants::vertex_id_1, std::move(new_edges));
 
@@ -95,11 +93,13 @@ TEST_CASE_TEMPLATE_DEFINE(
             return sut.has_edge(constants::vertex_id_1, target_id);
         }));
 
-        std::ranges::for_each(vertex_refs, [&sut, &v1](const auto& target) {
+        std::ranges::for_each(vertices, [&sut](const auto target) {
             std::vector<edge_ptr_type> new_edges;
-            new_edges.push_back(gl::detail::make_edge<edge_type>(v1, target.get()));
+            new_edges.push_back(gl::detail::make_edge<edge_type>(constants::vertex_id_1, target));
 
-            CHECK_THROWS_AS(sut.add_edges_from(v1.id(), std::move(new_edges)), std::logic_error);
+            CHECK_THROWS_AS(
+                sut.add_edges_from(constants::vertex_id_1, std::move(new_edges)), std::logic_error
+            );
         });
     }
 }
@@ -118,22 +118,16 @@ constexpr gl::types::size_type n_incident_edges_for_fully_connected_vertex =
 } // namespace
 
 struct test_directed_adjacency_matrix {
-    using vertex_type = gl::vertex_descriptor<>;
-    using edge_type = gl::directed_edge<vertex_type>;
+    using edge_type = gl::directed_edge<>;
     using edge_ptr_type = gl::directed_t::edge_ptr_type<edge_type>;
     using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>;
 
-    test_directed_adjacency_matrix() {
-        for (const auto id : constants::vertex_id_view)
-            vertices.emplace_back(id);
-    }
+    test_directed_adjacency_matrix() {}
 
     const edge_type& add_edge(
         const gl::types::id_type first_id, const gl::types::id_type second_id
     ) {
-        return sut.add_edge(
-            gl::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
-        );
+        return sut.add_edge(gl::detail::make_edge<edge_type>(first_id, second_id));
     }
 
     void fully_connect_vertex(const gl::types::id_type first_id, const bool no_loops = true) {
@@ -156,7 +150,6 @@ struct test_directed_adjacency_matrix {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<vertex_type> vertices;
 
     static constexpr gl::types::size_type n_unique_edges_in_full_graph =
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
@@ -168,8 +161,8 @@ TEST_CASE_FIXTURE(
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-    REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
     const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
     CHECK_EQ(adjacent_edges_1.distance(), constants::one_element);
@@ -199,15 +192,11 @@ TEST_CASE_FIXTURE(
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
-    };
+    const edge_type invalid_edge{constants::vertex_id_1, constants::vertex_id_2};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
-    };
+    const edge_type not_present_edge{constants::vertex_id_2, constants::vertex_id_3};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -236,9 +225,7 @@ TEST_CASE_FIXTURE(
 ) {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(
-            edge_type{vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]}
-        ),
+        sut.remove_edge(edge_type{constants::vertex_id_1, constants::vertex_id_2}),
         std::invalid_argument
     );
 }
@@ -394,22 +381,16 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_adjacency_matrix {
-    using vertex_type = gl::vertex_descriptor<>;
-    using edge_type = gl::undirected_edge<vertex_type>;
+    using edge_type = gl::undirected_edge<>;
     using edge_ptr_type = gl::undirected_t::edge_ptr_type<edge_type>;
     using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>;
 
-    test_undirected_adjacency_matrix() {
-        for (const auto id : constants::vertex_id_view)
-            vertices.emplace_back(id);
-    }
+    test_undirected_adjacency_matrix() {}
 
     const edge_type& add_edge(
         const gl::types::id_type first_id, const gl::types::id_type second_id
     ) {
-        return sut.add_edge(
-            gl::detail::make_edge<edge_type>(vertices[first_id], vertices[second_id])
-        );
+        return sut.add_edge(gl::detail::make_edge<edge_type>(first_id, second_id));
     }
 
     void fully_connect_vertex(const gl::types::id_type first_id, const bool no_loops = true) {
@@ -435,7 +416,6 @@ struct test_undirected_adjacency_matrix {
     }
 
     sut_type sut{constants::n_elements};
-    std::vector<vertex_type> vertices;
 
     static constexpr gl::types::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;
@@ -445,8 +425,8 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix, "add_edge should add the edge to the lists of both vertices"
 ) {
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-    REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
@@ -470,7 +450,7 @@ TEST_CASE_FIXTURE(
     const auto& new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_1);
     REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
     REQUIRE(new_edge.is_loop());
-    REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
+    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
 
     const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
     REQUIRE_EQ(adjacent_edges.distance(), constants::one_element);
@@ -499,15 +479,11 @@ TEST_CASE_FIXTURE(
     const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]
-    };
+    const edge_type invalid_edge{constants::vertex_id_1, constants::vertex_id_2};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        vertices[constants::vertex_id_2], vertices[constants::vertex_id_3]
-    };
+    const edge_type not_present_edge{constants::vertex_id_2, constants::vertex_id_3};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -538,9 +514,7 @@ TEST_CASE_FIXTURE(
 ) {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(
-            edge_type{vertices[constants::vertex_id_1], vertices[constants::vertex_id_2]}
-        ),
+        sut.remove_edge(edge_type{constants::vertex_id_1, constants::vertex_id_2}),
         std::invalid_argument
     );
 }
@@ -557,7 +531,7 @@ TEST_CASE_FIXTURE(
 
     const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
 
-    const auto second_id = edge_to_remove.second().id();
+    const auto second_id = edge_to_remove.second();
     REQUIRE_EQ(sut.adjacent_edges(second_id).distance(), constants::one_element);
 
     sut.remove_edge(edge_to_remove);

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -59,15 +59,16 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::breadth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
-            vertex.properties().visited = true;
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
+            vertex_properties[vertex_id].visited = true;
         }
     );
 
@@ -131,11 +132,11 @@ TEST_CASE_TEMPLATE_DEFINE(
     gl::algorithm::breadth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
         }
     );
 

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -67,15 +67,16 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
 
     std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::depth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
-            vertex.properties().visited = true;
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
+            vertex_properties[vertex_id].visited = true;
         }
     );
 
@@ -139,11 +140,11 @@ TEST_CASE_TEMPLATE_DEFINE(
     gl::algorithm::depth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
         }
     );
 
@@ -244,15 +245,16 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto expected_postvisit_order = std::views::reverse(expected_previsit_order);
 
     std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::recursive_depth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
-            vertex.properties().visited = true;
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
+            vertex_properties[vertex_id].visited = true;
         }
     );
 
@@ -321,11 +323,11 @@ TEST_CASE_TEMPLATE_DEFINE(
     gl::algorithm::recursive_depth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const auto& vertex) { // previsit
-            previsit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // previsit
+            previsit_order.push_back(vertex_id);
         },
-        [&](const auto& vertex) { // postvisit
-            postvisit_order.push_back(vertex.id());
+        [&](const gl::types::id_type vertex_id) { // postvisit
+            postvisit_order.push_back(vertex_id);
         }
     );
 

--- a/tests/source/gl/test_alg_mst.cpp
+++ b/tests/source/gl/test_alg_mst.cpp
@@ -42,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             for (const auto vertex_id : sut.vertex_ids()) {
                 for (const auto& edge : sut.adjacent_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
-                    expected_edges.emplace_back(edge.first().id(), edge.second().id());
+                    expected_edges.emplace_back(edge.first(), edge.second());
                 }
             }
 
@@ -79,7 +79,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
             const auto& edge = edge_ref.get();
-            const auto [first_id, second_id] = edge.incident_vertex_ids();
+            const auto [first_id, second_id] = edge.incident_vertices();
             return std::find_if(
                        expected_edges.begin(),
                        expected_edges.end(),
@@ -124,7 +124,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
         for (const auto& edge : sut.adjacent_edges(vertex_id))
-            expected_edges.emplace_back(edge.first().id(), edge.second().id());
+            expected_edges.emplace_back(edge.first(), edge.second());
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
@@ -135,7 +135,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
         const auto& edge = edge_ref.get();
-        const auto [first_id, second_id] = edge.incident_vertex_ids();
+        const auto [first_id, second_id] = edge.incident_vertices();
         return std::find_if(
                    expected_edges.begin(),
                    expected_edges.end(),
@@ -182,7 +182,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             for (const auto vertex_id : sut.vertex_ids()) {
                 for (const auto& edge : sut.adjacent_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
-                    expected_edges.emplace_back(edge.first().id(), edge.second().id());
+                    expected_edges.emplace_back(edge.first(), edge.second());
                 }
             }
 
@@ -219,7 +219,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
             const auto& edge = edge_ref.get();
-            const auto [first_id, second_id] = edge.incident_vertex_ids();
+            const auto [first_id, second_id] = edge.incident_vertices();
             return std::find_if(
                        expected_edges.begin(),
                        expected_edges.end(),
@@ -264,7 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
         for (const auto& edge : sut.adjacent_edges(vertex_id))
-            expected_edges.emplace_back(edge.first().id(), edge.second().id());
+            expected_edges.emplace_back(edge.first(), edge.second());
 
     const weight_type expected_weight = sut.n_vertices() - constants::one;
 
@@ -275,7 +275,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge_ref) {
         const auto& edge = edge_ref.get();
-        const auto [first_id, second_id] = edge.incident_vertex_ids();
+        const auto [first_id, second_id] = edge.incident_vertices();
         return std::find_if(
                    expected_edges.begin(),
                    expected_edges.end(),

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -13,20 +13,18 @@ TEST_SUITE_BEGIN("test_edge_descriptor");
 struct test_edge_descriptor {
     using vertex_type = gl::vertex_descriptor<>;
 
-    vertex_type vd_1{constants::vertex_id_1};
-    vertex_type vd_2{constants::vertex_id_2};
-    vertex_type vd_3{constants::vertex_id_3};
-
-    vertex_type invalid_vd{constants::invalid_id};
+    gl::types::id_type v1 = constants::vertex_id_1;
+    gl::types::id_type v2 = constants::vertex_id_2;
+    gl::types::id_type v3 = constants::vertex_id_3;
 };
 
 TEST_CASE_FIXTURE(
     test_edge_descriptor, "is_directed() should return true only for edges with directed edge tag"
 ) {
-    gl::directed_edge<gl::vertex<>> directed_edge{vd_1, vd_2};
+    gl::directed_edge<> directed_edge{v1, v2};
     CHECK(directed_edge.is_directed());
 
-    gl::undirected_edge<gl::vertex<>> undirected_edge{vd_1, vd_2};
+    gl::undirected_edge<> undirected_edge{v1, v2};
     CHECK_FALSE(undirected_edge.is_directed());
 }
 
@@ -34,10 +32,10 @@ TEST_CASE_FIXTURE(
     test_edge_descriptor,
     "is_undirected() should return true only for edges with bidirectional edge tag"
 ) {
-    gl::undirected_edge<gl::vertex<>> undirected_edge{vd_1, vd_2};
+    gl::undirected_edge<> undirected_edge{v1, v2};
     CHECK(undirected_edge.is_undirected());
 
-    gl::directed_edge<gl::vertex<>> directed_edge{vd_1, vd_2};
+    gl::directed_edge<> directed_edge{v1, v2};
     CHECK_FALSE(directed_edge.is_undirected());
 }
 
@@ -47,66 +45,60 @@ TEST_CASE_TEMPLATE_DEFINE(
     test_edge_descriptor fixture;
 
     const types::used_property used{true};
-    const EdgeType sut{fixture.vd_1, fixture.vd_2, used};
+    const EdgeType sut{fixture.v1, fixture.v2, used};
 
     CHECK_EQ(sut.properties(), used);
 }
 
 // TODO: fix .clang-format to split such lines
-TEST_CASE_TEMPLATE_INSTANTIATE(properties_edge_directional_tag_template, gl::directed_edge<gl::vertex<>, types::used_property>, gl::undirected_edge<gl::vertex<>, types::used_property>);
+TEST_CASE_TEMPLATE_INSTANTIATE(properties_edge_directional_tag_template, gl::directed_edge<types::used_property>, gl::undirected_edge<types::used_property>);
 
 TEST_CASE_TEMPLATE_DEFINE(
     "directional_tag-independent tests", EdgeType, edge_directional_tag_template
 ) {
     test_edge_descriptor fixture{};
 
-    EdgeType sut{fixture.vd_1, fixture.vd_2};
+    EdgeType sut{fixture.v1, fixture.v2};
 
-    SUBCASE("incident_vertices should return the pair of vertices the edge was initialized with") {
+    SUBCASE("incident_vertices should return the pair of vertex IDS the edge was initialized with"
+    ) {
         const auto& vertices = sut.incident_vertices();
-        CHECK_EQ(vertices.first, fixture.vd_1);
-        CHECK_EQ(vertices.second, fixture.vd_2);
-    }
-
-    SUBCASE("incident_vertex_ids should return the pair of ids of the vertices the edge was "
-            "initialized with") {
-        const auto& vertex_ids = sut.incident_vertex_ids();
-        CHECK_EQ(vertex_ids.first, fixture.vd_1.id());
-        CHECK_EQ(vertex_ids.second, fixture.vd_2.id());
+        CHECK_EQ(vertices.first, fixture.v1);
+        CHECK_EQ(vertices.second, fixture.v2);
     }
 
     SUBCASE("first should return the first vertex descriptor the edge was initialized with") {
-        CHECK_EQ(sut.first(), fixture.vd_1);
+        CHECK_EQ(sut.first(), fixture.v1);
     }
 
     SUBCASE("second should return the second vertex descriptor the edge was initialized with") {
-        CHECK_EQ(sut.second(), fixture.vd_2);
+        CHECK_EQ(sut.second(), fixture.v2);
     }
 
     SUBCASE("incident_vertex should throw if input vertex is not incident with the edge") {
         CHECK_THROWS_AS(
-            func::discard_result(sut.incident_vertex(fixture.vd_3)), std::invalid_argument
+            func::discard_result(sut.incident_vertex(fixture.v3)), std::invalid_argument
         );
     }
 
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {
-        CHECK_EQ(sut.incident_vertex(fixture.vd_1), fixture.vd_2);
-        CHECK_EQ(sut.incident_vertex(fixture.vd_2), fixture.vd_1);
+        CHECK_EQ(sut.incident_vertex(fixture.v1), fixture.v2);
+        CHECK_EQ(sut.incident_vertex(fixture.v2), fixture.v1);
     }
 
     SUBCASE("is_incident_with should return true when the given vertex is one of the connected "
             "vertices") {
-        CHECK(sut.is_incident_with(fixture.vd_1));
-        CHECK(sut.is_incident_with(fixture.vd_2));
+        CHECK(sut.is_incident_with(fixture.v1));
+        CHECK(sut.is_incident_with(fixture.v2));
 
-        CHECK_FALSE(sut.is_incident_with(fixture.invalid_vd));
-        CHECK_FALSE(sut.is_incident_with(fixture.invalid_vd));
+        CHECK_FALSE(sut.is_incident_with(constants::invalid_id));
+        CHECK_FALSE(sut.is_incident_with(constants::invalid_id));
     }
 
     SUBCASE("is_loop should return true onlyu for edges where both vertices are the same") {
         CHECK_FALSE(sut.is_loop());
 
-        const EdgeType loop{fixture.vd_1, fixture.vd_1};
+        const EdgeType loop{fixture.v1, fixture.v1};
         CHECK(loop.is_loop());
     }
 }
@@ -114,8 +106,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 // TODO: fix .clang-format to split such lines
 TEST_CASE_TEMPLATE_INSTANTIATE(
     edge_directional_tag_template,
-    gl::directed_edge<gl::vertex<>>, // default directed edge
-    gl::undirected_edge<gl::vertex<>> // default undirected edge
+    gl::directed_edge<>, // default directed edge
+    gl::undirected_edge<> // default undirected edge
 );
 
 TEST_SUITE_END(); // test_edge_descriptor

--- a/tests/source/gl/test_edge_tags.cpp
+++ b/tests/source/gl/test_edge_tags.cpp
@@ -10,19 +10,15 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_edge_tags");
 
 struct test_edge_tags {
-    using vertex_type = gl::vertex_descriptor<>;
-
-    vertex_type vd_1{constants::vertex_id_1};
-    vertex_type vd_2{constants::vertex_id_2};
-
-    vertex_type invalid_vd{constants::invalid_id};
+    gl::types::id_type v1 = constants::vertex_id_1;
+    gl::types::id_type v2 = constants::vertex_id_2;
 };
 
 struct test_directed_edge_tag : test_edge_tags {
     using sut_type = gl::directed_t;
-    using edge_type = gl::directed_edge<vertex_type>;
+    using edge_type = gl::directed_edge<>;
 
-    const std::unique_ptr<edge_type> edge = gl::detail::make_edge<edge_type>(vd_1, vd_2);
+    const std::unique_ptr<edge_type> edge = gl::detail::make_edge<edge_type>(v1, v2);
 };
 
 TEST_CASE_FIXTURE(
@@ -33,18 +29,18 @@ TEST_CASE_FIXTURE(
     REQUIRE(edge->is_directed());
     REQUIRE_FALSE(edge->is_undirected());
 
-    CHECK_EQ(edge->first(), vd_1);
-    CHECK_EQ(edge->second(), vd_2);
+    CHECK_EQ(edge->first(), v1);
+    CHECK_EQ(edge->second(), v2);
 }
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
     "make_edge should return a unique ptr to a directed edge with the given properties"
 ) {
-    using property_edge_type = gl::directed_edge<vertex_type, types::used_property>;
+    using property_edge_type = gl::directed_edge<types::used_property>;
 
     const types::used_property used{true};
-    const auto property_edge = gl::detail::make_edge<property_edge_type>(vd_1, vd_2, used);
+    const auto property_edge = gl::detail::make_edge<property_edge_type>(v1, v2, used);
 
     static_assert(std::is_same_v<
                   std::remove_cvref_t<decltype(property_edge)>,
@@ -53,32 +49,32 @@ TEST_CASE_FIXTURE(
     REQUIRE(property_edge->is_directed());
     REQUIRE_FALSE(property_edge->is_undirected());
 
-    CHECK_EQ(property_edge->first(), vd_1);
-    CHECK_EQ(property_edge->second(), vd_2);
+    CHECK_EQ(property_edge->first(), v1);
+    CHECK_EQ(property_edge->second(), v2);
     CHECK_EQ(property_edge->properties(), used);
 }
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag, "is_incident_from should return true only for the first vertex"
 ) {
-    CHECK(sut_type::is_incident_from(*edge, vd_1.id()));
-    CHECK_FALSE(sut_type::is_incident_from(*edge, vd_2.id()));
-    CHECK_FALSE(sut_type::is_incident_from(*edge, invalid_vd.id()));
+    CHECK(sut_type::is_incident_from(*edge, v1));
+    CHECK_FALSE(sut_type::is_incident_from(*edge, v2));
+    CHECK_FALSE(sut_type::is_incident_from(*edge, constants::invalid_id));
 }
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag, "is_incident_to should return true only for the second vertex"
 ) {
-    CHECK(sut_type::is_incident_to(*edge, vd_2.id()));
-    CHECK_FALSE(sut_type::is_incident_to(*edge, vd_1.id()));
-    CHECK_FALSE(sut_type::is_incident_to(*edge, invalid_vd.id()));
+    CHECK(sut_type::is_incident_to(*edge, v2));
+    CHECK_FALSE(sut_type::is_incident_to(*edge, v1));
+    CHECK_FALSE(sut_type::is_incident_to(*edge, constants::invalid_id));
 }
 
 struct test_undirected_edge_tag : test_edge_tags {
     using sut_type = gl::undirected_t;
-    using edge_type = gl::undirected_edge<vertex_type>;
+    using edge_type = gl::undirected_edge<>;
 
-    const std::shared_ptr<edge_type> edge = gl::detail::make_edge<edge_type>(vd_1, vd_2);
+    const std::shared_ptr<edge_type> edge = gl::detail::make_edge<edge_type>(v1, v2);
 };
 
 TEST_CASE_FIXTURE(
@@ -89,18 +85,18 @@ TEST_CASE_FIXTURE(
     REQUIRE(edge->is_undirected());
     REQUIRE_FALSE(edge->is_directed());
 
-    CHECK_EQ(edge->first(), vd_1);
-    CHECK_EQ(edge->second(), vd_2);
+    CHECK_EQ(edge->first(), v1);
+    CHECK_EQ(edge->second(), v2);
 }
 
 TEST_CASE_FIXTURE(
     test_directed_edge_tag,
     "make_edge should return a shared ptr to a directed edge with the given properties"
 ) {
-    using property_edge_type = gl::undirected_edge<vertex_type, types::used_property>;
+    using property_edge_type = gl::undirected_edge<types::used_property>;
 
     const types::used_property used{true};
-    const auto property_edge = gl::detail::make_edge<property_edge_type>(vd_1, vd_2, used);
+    const auto property_edge = gl::detail::make_edge<property_edge_type>(v1, v2, used);
 
     static_assert(std::is_same_v<
                   std::remove_cvref_t<decltype(property_edge)>,
@@ -109,27 +105,27 @@ TEST_CASE_FIXTURE(
     REQUIRE(property_edge->is_undirected());
     REQUIRE_FALSE(property_edge->is_directed());
 
-    CHECK_EQ(property_edge->first(), vd_1);
-    CHECK_EQ(property_edge->second(), vd_2);
+    CHECK_EQ(property_edge->first(), v1);
+    CHECK_EQ(property_edge->second(), v2);
     CHECK_EQ(property_edge->properties(), used);
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_edge_tag, "is_incident_from should return true for both vertices"
 ) {
-    CHECK(sut_type::is_incident_from(*edge, vd_1.id()));
-    CHECK(sut_type::is_incident_from(*edge, vd_2.id()));
+    CHECK(sut_type::is_incident_from(*edge, v1));
+    CHECK(sut_type::is_incident_from(*edge, v2));
 
-    CHECK_FALSE(sut_type::is_incident_from(*edge, invalid_vd.id()));
-    CHECK_FALSE(sut_type::is_incident_from(*edge, invalid_vd.id()));
+    CHECK_FALSE(sut_type::is_incident_from(*edge, constants::invalid_id));
+    CHECK_FALSE(sut_type::is_incident_from(*edge, constants::invalid_id));
 }
 
 TEST_CASE_FIXTURE(test_undirected_edge_tag, "is_incident_to should return true for both vertices") {
-    CHECK(sut_type::is_incident_to(*edge, vd_1.id()));
-    CHECK(sut_type::is_incident_to(*edge, vd_2.id()));
+    CHECK(sut_type::is_incident_to(*edge, v1));
+    CHECK(sut_type::is_incident_to(*edge, v2));
 
-    CHECK_FALSE(sut_type::is_incident_to(*edge, invalid_vd.id()));
-    CHECK_FALSE(sut_type::is_incident_to(*edge, invalid_vd.id()));
+    CHECK_FALSE(sut_type::is_incident_to(*edge, constants::invalid_id));
+    CHECK_FALSE(sut_type::is_incident_to(*edge, constants::invalid_id));
 }
 
 TEST_SUITE_END(); // untest_edge_tags

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -372,8 +372,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge(ids) should properly add the new edge") {
             const auto& new_edge = sut.add_edge(constants::vertex_id_1, constants::vertex_id_2);
-            REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-            REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+            REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+            REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
@@ -400,8 +400,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge(vertices) should properly add the new edge") {
             const auto& new_edge = sut.add_edge(vertex_1, vertex_2);
-            REQUIRE(new_edge.is_incident_from(vertex_1));
-            REQUIRE(new_edge.is_incident_to(vertex_2));
+            REQUIRE(new_edge.is_incident_from(vertex_1.id()));
+            REQUIRE(new_edge.is_incident_to(vertex_2.id()));
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
 
@@ -573,8 +573,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("add_edge(ids) should properly add the new edge") {
             const auto& new_edge =
                 sut.add_edge(constants::vertex_id_1, constants::vertex_id_2, constants::used);
-            REQUIRE(new_edge.is_incident_from(vertices[constants::vertex_id_1]));
-            REQUIRE(new_edge.is_incident_to(vertices[constants::vertex_id_2]));
+            REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+            REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);
@@ -608,8 +608,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge(vertices) should properly add the new edge") {
             const auto& new_edge = sut.add_edge(vertex_1, vertex_2, constants::used);
-            REQUIRE(new_edge.is_incident_from(vertex_1));
-            REQUIRE(new_edge.is_incident_to(vertex_2));
+            REQUIRE(new_edge.is_incident_from(vertex_1.id()));
+            REQUIRE(new_edge.is_incident_to(vertex_2.id()));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
             REQUIRE_EQ(sut.n_unique_edges(), constants::one_element);

--- a/tests/source/gl/test_graph_incidence.cpp
+++ b/tests/source/gl/test_graph_incidence.cpp
@@ -9,19 +9,15 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_graph_incidence");
 
-struct test_graph_incidence {
+TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_template) {
     using vertex_type = gl::vertex_descriptor<>;
 
-    vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
-};
-
-TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_template) {
-    test_graph_incidence fixture;
-
     SutType sut{constants::n_elements};
+
     const auto& vd_1 = sut.get_vertex(constants::vertex_id_1);
     const auto& vd_2 = sut.get_vertex(constants::vertex_id_2);
     const auto& vd_3 = sut.get_vertex(constants::vertex_id_3);
+    vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
 
     SUBCASE("are_incident(vertex_id, vertex_id) should throw for out of range vertex ids") {
         CHECK_THROWS_AS(
@@ -59,18 +55,14 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
     SUBCASE("are_incident(vertex, vertex) should throw if at least one of the vertices is invalid"
     ) {
         CHECK_THROWS_AS(
-            func::discard_result(
-                sut.are_incident(fixture.out_of_range_vertex, fixture.out_of_range_vertex)
-            ),
+            func::discard_result(sut.are_incident(out_of_range_vertex, out_of_range_vertex)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.out_of_range_vertex, vd_2)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(out_of_range_vertex, vd_2)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, fixture.out_of_range_vertex)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(vd_1, out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -95,26 +87,22 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto& edge = sut.add_edge(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.out_of_range_vertex, edge)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(fixture.out_of_range_vertex, edge)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.out_of_range_vertex)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, fixture.out_of_range_vertex)),
-            std::out_of_range
+            func::discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
         );
     }
 
     SUBCASE("are_incident(vertex and edge pair) should throw if the edge is invalid") {
-        const typename SutType::edge_type invalid_edge{vd_1, vd_2};
+        const typename SutType::edge_type invalid_edge{vd_1.id(), vd_2.id()};
 
         CHECK_THROWS_AS(
             func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
@@ -144,7 +132,7 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
 
     SUBCASE("are_incident(edge, edge) should throw if either edge is invalid") {
         const auto& edge = sut.add_edge(vd_1, vd_2);
-        const typename SutType::edge_type invalid_edge{vd_1, vd_2};
+        const typename SutType::edge_type invalid_edge{vd_1.id(), vd_2.id()};
 
         CHECK_THROWS_AS(
             func::discard_result(sut.are_incident(edge, invalid_edge)), std::invalid_argument

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -140,7 +140,7 @@ struct test_undirected_graph_io {
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
             for (const auto& edge : sut_out.adjacent_edges(vertex))
-                if (edge.first().id() == vertex.id())
+                if (edge.first() == vertex.id())
                     edge.properties() = std::format("edge_{}", e_idx++);
         }
     }

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -148,34 +148,33 @@ template <gl::type_traits::c_graph GraphType>
 template <gl::type_traits::c_graph GraphType>
 [[nodiscard]] auto is_biconnected_to_binary_chlidren(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
-    return [&graph](const vertex_type& source) {
-        const auto target_ids = gl::topology::detail::get_binary_target_ids(source.id());
+    return [&graph](const gl::types::id_type source_id) {
+        const auto target_ids = gl::topology::detail::get_binary_target_ids(source_id);
         const gl::types::id_type parent_id =
-            source.id() == constants::zero
+            source_id == constants::zero
                 ? constants::zero
-                : (source.id() - constants::one) / constants::two;
+                : (source_id - constants::one) / constants::two;
 
         if (target_ids.first >= graph.n_vertices()) {
             // no need to check second as second = first + 1
-            const auto adjacent_edges = graph.adjacent_edges(source);
+            const auto adjacent_edges = graph.adjacent_edges(source_id);
 
             return adjacent_edges.distance() == constants::one
-               and adjacent_edges[constants::first_element_idx].incident_vertex(source).id()
-                       == parent_id;
+               and adjacent_edges[constants::first_element_idx].incident_vertex(source_id
+                   ) == parent_id;
         }
 
-        const auto& parent = graph.get_vertex(parent_id);
-        const auto& target_1 = graph.get_vertex(target_ids.first);
-        const auto& target_2 = graph.get_vertex(target_ids.second);
+        const auto& target_1 = target_ids.first;
+        const auto& target_2 = target_ids.second;
 
-        return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
-            if (vertex == target_1 or vertex == target_2)
-                return graph.has_edge(source, vertex);
+        return std::ranges::all_of(graph.vertex_ids(), [&](const auto vertex_id) {
+            if (vertex_id == target_1 or vertex_id == target_2)
+                return graph.has_edge(source_id, vertex_id);
 
-            if (vertex == parent and source.id() != constants::zero)
-                return graph.has_edge(source, vertex);
+            if (vertex_id == parent_id and source_id != constants::zero)
+                return graph.has_edge(source_id, vertex_id);
 
-            return not graph.has_edge(source, vertex);
+            return not graph.has_edge(source_id, vertex_id);
         });
     };
 }
@@ -347,7 +346,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(
-            bin_tree.vertices(), predicate::is_biconnected_to_binary_chlidren(bin_tree)
+            bin_tree.vertex_ids(), predicate::is_biconnected_to_binary_chlidren(bin_tree)
         ));
     }
 }
@@ -433,7 +432,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(
-            bin_tree.vertices(), predicate::is_biconnected_to_binary_chlidren(bin_tree)
+            bin_tree.vertex_ids(), predicate::is_biconnected_to_binary_chlidren(bin_tree)
         ));
     }
 }

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -84,7 +84,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     i = constants::zero;
     CHECK(std::ranges::all_of(
         sut.vertices(),
-        [&](const auto vertex_id) {
+        [&](const gl::types::id_type vertex_id) {
             const bool result = sut.in_degree(vertex_id) == expected_in_deg_list[i]
                and sut.out_degree(vertex_id) == expected_out_deg_list[i]
                and sut.degree(vertex_id) == expected_deg_list[i];
@@ -157,7 +157,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     i = constants::zero;
     CHECK(std::ranges::all_of(
         sut.vertices(),
-        [&](const auto vertex_id) {
+        [&](const gl::types::id_type vertex_id) {
             const auto expected_deg = expected_deg_list[i];
             const bool result = sut.in_degree(vertex_id) == expected_deg
                and sut.out_degree(vertex_id) == expected_deg


### PR DESCRIPTION
- Modified the `edge_descriptor` class to store only the IDs of its incident vertices
- Aligned graph implementation to use vertex IDs instead of descriptor objects for internal operations
- Aligned algorithms to use vertex-ID-based callbacks