### PR TITLE
YT-CPPHGL-4: Create the hypergraph traits structure

### DIFF
--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hypergraph_elements.hpp"
+#include "impl/impl_tags.hpp"
+
+namespace hgl {
+
+template <
+    type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties HyperedgeProperties = types::empty_properties,
+    type_traits::c_hypergraph_impl_tag ImplTag = impl::edge_list_t>
+struct hypergraph_traits {
+    using vertex_type = vertex_descriptor<VertexProperties>;
+    using vertex_properties_type = typename vertex_type::properties_type;
+
+    using hyperedge_type = hyperedge_descriptor<HyperedgeDirectionalTag, HyperedgeProperties>;
+    using hyperedge_directional_tag = typename hyperedge_type::directional_tag;
+    using hyperedge_properties_type = typename hyperedge_type::properties_type;
+
+    using implementation_tag = ImplTag;
+};
+
+template <
+    type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties>
+using edge_list_hg_traits =
+    hypergraph_traits<HyperedgeDirectionalTag, VertexProperties, EdgeProperties, impl::edge_list_t>;
+
+template <
+    type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties>
+using adjacency_list_hg_traits = hypergraph_traits<
+    HyperedgeDirectionalTag,
+    VertexProperties,
+    EdgeProperties,
+    impl::adjacency_list_t>;
+
+template <
+    type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties>
+using incidence_matrix_hg_traits = hypergraph_traits<
+    HyperedgeDirectionalTag,
+    VertexProperties,
+    EdgeProperties,
+    impl::incidence_matrix_t>;
+
+template <
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_hypergraph_impl_tag ImplTag = impl::edge_list_t>
+using undirected_hg_traits =
+    hypergraph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;
+
+template <
+    type_traits::c_properties VertexProperties = types::empty_properties,
+    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_hypergraph_impl_tag ImplTag = impl::edge_list_t>
+using bf_directed_hg_traits =
+    hypergraph_traits<bf_directed_t, VertexProperties, EdgeProperties, ImplTag>;
+
+namespace type_traits {
+
+template <typename TraitsType>
+concept c_edge_list_hg_traits =
+    c_instantiation_of<TraitsType, hypergraph_traits>
+    and std::same_as<typename TraitsType::implementation_tag, impl::edge_list_t>;
+
+template <typename TraitsType>
+concept c_adjacency_list_hg_traits =
+    c_instantiation_of<TraitsType, hypergraph_traits>
+    and std::same_as<typename TraitsType::implementation_tag, impl::adjacency_list_t>;
+
+template <typename TraitsType>
+concept c_incidence_matrix_hg_traits =
+    c_instantiation_of<TraitsType, hypergraph_traits>
+    and std::same_as<typename TraitsType::implementation_tag, impl::incidence_matrix_t>;
+
+template <typename TraitsType>
+concept c_undirected_hg_traits =
+    c_instantiation_of<TraitsType, hypergraph_traits>
+    and std::same_as<typename TraitsType::hyperedge_directional_tag, undirected_t>;
+
+template <typename TraitsType>
+concept c_bf_directed_hg_traits =
+    c_instantiation_of<TraitsType, hypergraph_traits>
+    and std::same_as<typename TraitsType::hyperedge_directional_tag, bf_directed_t>;
+
+} // namespace type_traits
+
+} // namespace hgl

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -28,43 +28,46 @@ struct hypergraph_traits {
 template <
     type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties>
-using edge_list_hg_traits =
-    hypergraph_traits<HyperedgeDirectionalTag, VertexProperties, EdgeProperties, impl::edge_list_t>;
+    type_traits::c_properties HyperedgeProperties = types::empty_properties>
+using edge_list_hg_traits = hypergraph_traits<
+    HyperedgeDirectionalTag,
+    VertexProperties,
+    HyperedgeProperties,
+    impl::edge_list_t>;
 
 template <
     type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties>
+    type_traits::c_properties HyperedgeProperties = types::empty_properties>
 using adjacency_list_hg_traits = hypergraph_traits<
     HyperedgeDirectionalTag,
     VertexProperties,
-    EdgeProperties,
+    HyperedgeProperties,
     impl::adjacency_list_t>;
 
 template <
     type_traits::c_hyperedge_directional_tag HyperedgeDirectionalTag = undirected_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties>
+    type_traits::c_properties HyperedgeProperties = types::empty_properties>
 using incidence_matrix_hg_traits = hypergraph_traits<
     HyperedgeDirectionalTag,
     VertexProperties,
-    EdgeProperties,
+    HyperedgeProperties,
     impl::incidence_matrix_t>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_properties HyperedgeProperties = types::empty_properties,
     type_traits::c_hypergraph_impl_tag ImplTag = impl::edge_list_t>
 using undirected_hg_traits =
-    hypergraph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;
+    hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 template <
     type_traits::c_properties VertexProperties = types::empty_properties,
-    type_traits::c_properties EdgeProperties = types::empty_properties,
+    type_traits::c_properties HyperedgeProperties = types::empty_properties,
     type_traits::c_hypergraph_impl_tag ImplTag = impl::edge_list_t>
 using bf_directed_hg_traits =
-    hypergraph_traits<bf_directed_t, VertexProperties, EdgeProperties, ImplTag>;
+    hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 namespace type_traits {
 

--- a/include/hgl/impl/impl_tags.hpp
+++ b/include/hgl/impl/impl_tags.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+namespace hgl {
+
+namespace impl {
+
+struct edge_list_t {};
+
+struct adjacency_list_t {};
+
+struct incidence_matrix_t {};
+
+} // namespace impl
+
+namespace type_traits {
+
+template <typename T>
+concept c_hypergraph_impl_tag =
+    c_one_of<T, impl::edge_list_t, impl::adjacency_list_t, impl::incidence_matrix_t>;
+
+} // namespace type_traits
+
+} // namespace hgl

--- a/include/hgl/impl/impl_tags.hpp
+++ b/include/hgl/impl/impl_tags.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "hgl/types/type_traits.hpp"
+
 namespace hgl {
 
 namespace impl {


### PR DESCRIPTION
- Defined the implementation tag types for the following models: edge list (default), adjacency list, incidence matrix
- Created the `hypergraph_traits` structure with basic type definitions
- Defined helper aliases and type constraints for the `hypergraph_traits` structure
