### PR TITLE
YT-CPPHGL-7: Implement the undirected vertex-list model

### DIFF
--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -368,6 +368,7 @@ private:
         this->_n_vertices--;
         if constexpr (type_traits::c_non_empty_properties<vertex_properties_type>)
             this->_vertex_properties.erase(this->_vertex_properties.begin() + vertex_id);
+        // TODO: impl::remove_vertex(vertex_id)
     }
 
     // --- hyperedge methods ---

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -37,8 +37,8 @@ template <
     type_traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties HyperedgeProperties = types::empty_properties>
-using adjacency_list_hg_traits =
-    hypergraph_traits<DirectionalTag, VertexProperties, HyperedgeProperties, impl::adjacency_list_t>;
+using vertex_list_hg_traits =
+    hypergraph_traits<DirectionalTag, VertexProperties, HyperedgeProperties, impl::vertex_list_t>;
 
 template <
     type_traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
@@ -69,9 +69,9 @@ concept c_hyperedge_list_hg_traits =
     and std::same_as<typename TraitsType::implementation_tag, impl::hyperedge_list_t>;
 
 template <typename TraitsType>
-concept c_adjacency_list_hg_traits =
+concept c_vertex_list_hg_traits =
     c_instantiation_of<TraitsType, hypergraph_traits>
-    and std::same_as<typename TraitsType::implementation_tag, impl::adjacency_list_t>;
+    and std::same_as<typename TraitsType::implementation_tag, impl::vertex_list_t>;
 
 template <typename TraitsType>
 concept c_incidence_matrix_hg_traits =

--- a/include/hgl/impl/hyperedge_list.hpp
+++ b/include/hgl/impl/hyperedge_list.hpp
@@ -7,6 +7,7 @@
 #include "hgl/types/types.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <vector>
 
 #ifdef HGL_TESTING
@@ -45,11 +46,36 @@ public:
 
     // --- vertex methods ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type) const noexcept {}
+    // clang-format off
+
+    gl_attr_force_inline void add_vertices([[maybe_unused]] const types::size_type) const noexcept {}
+
+    // clang-format on
 
     void remove_vertex(const types::id_type vertex_id) noexcept {
-        for (auto& hyperedge_vertices : this->_storage)
-            this->_unbind_impl(hyperedge_vertices, vertex_id);
+        for (auto& hyperedge : this->_storage) {
+            auto vertex_it = std::ranges::lower_bound(hyperedge, vertex_id);
+            if (vertex_it != hyperedge.end() and *vertex_it == vertex_id)
+                vertex_it = hyperedge.erase(vertex_it); // unbind the vertex
+            while (vertex_it != hyperedge.end())
+                --(*vertex_it++); // decrement ids > vertex_id
+        }
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    ) const noexcept {
+        return std::views::iota(0uz, this->_storage.size())
+             | std::views::filter([this, vertex_id](types::id_type hid) {
+                   return this->_are_bound_impl(this->_storage[hid], vertex_id);
+               });
+    }
+
+    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+        types::size_type deg = 0uz;
+        for (const auto& hyperedge : this->_storage)
+            if (this->_are_bound_impl(hyperedge, vertex_id))
+                ++deg;
+        return deg;
     }
 
     // --- hyperedge methods ---
@@ -62,39 +88,41 @@ public:
         this->_storage.erase(this->_storage.begin() + hyperedge_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    ) const noexcept {
+        return std::views::all(this->_storage[hyperedge_id]);
+    }
+
     [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
         const types::id_type hyperedge_id
     ) const noexcept {
         return this->_storage[hyperedge_id].size();
     }
 
-    [[nodiscard]] gl_attr_force_inline auto hyperedge_vertices(const types::id_type hyperedge_id
-    ) const noexcept {
-        return std::views::all(this->_storage[hyperedge_id]);
-    }
-
     // --- binding methods ---
 
-    void bind(const types::id_type hyperedge_id, const types::id_type vertex_id) noexcept {
-        auto& hyperedge_vertices = this->_storage[hyperedge_id];
+    void bind(const types::id_type vertex_id, const types::id_type hyperedge_id) noexcept {
+        auto& hyperedge = this->_storage[hyperedge_id];
 
         // insert the id at the correct position to keep the vertex-id collection sorted
-        const auto it = std::ranges::lower_bound(hyperedge_vertices, vertex_id);
-        if (it == hyperedge_vertices.end() or *it != vertex_id)
-            hyperedge_vertices.insert(it, vertex_id);
+        const auto it = std::ranges::lower_bound(hyperedge, vertex_id);
+        if (it == hyperedge.end() or *it != vertex_id)
+            hyperedge.insert(it, vertex_id);
     }
 
     gl_attr_force_inline void unbind(
-        const types::id_type hyperedge_id, const types::id_type vertex_id
+        const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
-        this->_unbind_impl(this->_storage[hyperedge_id], vertex_id);
+        auto& hyperedge = this->_storage[hyperedge_id];
+        const auto vertex_it = std::ranges::lower_bound(hyperedge, vertex_id);
+        if (vertex_it != hyperedge.end() and *vertex_it == vertex_id)
+            hyperedge.erase(vertex_it);
     }
 
-    [[nodiscard]] bool are_bound(const types::id_type hyperedge_id, const types::id_type vertex_id)
-        const noexcept {
-        auto& hyperedge_vertices = this->_storage[hyperedge_id];
-        const auto vertex_it = std::ranges::lower_bound(hyperedge_vertices, vertex_id);
-        return vertex_it != hyperedge_vertices.end() and *vertex_it == vertex_id;
+    [[nodiscard]] gl_attr_force_inline bool are_bound(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_are_bound_impl(this->_storage[hyperedge_id], vertex_id);
     }
 
 #ifdef HGL_TESTING
@@ -102,12 +130,11 @@ public:
 #endif
 
 private:
-    void _unbind_impl(
-        hyperedge_storage_type& hyperedge_vertices, const types::id_type vertex_id
-    ) noexcept {
-        const auto vertex_it = std::ranges::lower_bound(hyperedge_vertices, vertex_id);
-        if (vertex_it != hyperedge_vertices.end() and *vertex_it == vertex_id)
-            hyperedge_vertices.erase(vertex_it);
+    [[nodiscard]] bool _are_bound_impl(
+        const hyperedge_storage_type& hyperedge, const types::id_type vertex_id
+    ) const noexcept {
+        const auto vertex_it = std::ranges::lower_bound(hyperedge, vertex_id);
+        return vertex_it != hyperedge.end() and *vertex_it == vertex_id;
     }
 
     hypergraph_storage_type _storage;

--- a/include/hgl/impl/impl_tags.hpp
+++ b/include/hgl/impl/impl_tags.hpp
@@ -12,7 +12,7 @@ namespace impl {
 
 struct hyperedge_list_t {};
 
-struct adjacency_list_t {};
+struct vertex_list_t {};
 
 struct incidence_matrix_t {};
 
@@ -22,7 +22,7 @@ namespace type_traits {
 
 template <typename T>
 concept c_hypergraph_impl_tag =
-    c_one_of<T, impl::hyperedge_list_t, impl::adjacency_list_t, impl::incidence_matrix_t>;
+    c_one_of<T, impl::hyperedge_list_t, impl::vertex_list_t, impl::incidence_matrix_t>;
 
 } // namespace type_traits
 

--- a/include/hgl/impl/vertex_list.hpp
+++ b/include/hgl/impl/vertex_list.hpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/types/types.hpp"
+
+#include <algorithm>
+#include <ranges>
+#include <vector>
+
+#ifdef HGL_TESTING
+namespace hgl_testing {
+struct test_vertex_list;
+} // namespace hgl_testing
+#endif
+
+namespace hgl::impl {
+
+class undirected_vertex_list final {
+public:
+    using vertex_storage_type = std::vector<types::id_type>;
+    using hypergraph_storage_type = std::vector<vertex_storage_type>;
+
+    undirected_vertex_list(const undirected_vertex_list&) = delete;
+    undirected_vertex_list& operator=(const undirected_vertex_list&) = delete;
+
+    undirected_vertex_list() = default;
+
+    undirected_vertex_list(
+        const types::size_type n_vertices, [[maybe_unused]] const types::size_type n_hyperedges
+    )
+    : _storage{n_vertices} {}
+
+    undirected_vertex_list(undirected_vertex_list&&) = default;
+    undirected_vertex_list& operator=(undirected_vertex_list&&) = default;
+
+    ~undirected_vertex_list() = default;
+
+    // --- vertex methods ---
+
+    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+        this->_storage.resize(this->_storage.size() + n);
+    }
+
+    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+        this->_storage.erase(this->_storage.begin() + vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    ) const noexcept {
+        return std::views::all(this->_storage[vertex_id]);
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
+    ) const noexcept {
+        return this->_storage[vertex_id].size();
+    }
+
+    // --- hyperedge methods ---
+
+    // clang-format off
+
+    gl_attr_force_inline void add_hyperedges([[maybe_unused]] const types::size_type) const noexcept {}
+
+    // clang-format on
+
+    void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+        for (auto& vertex : this->_storage) {
+            auto hyperedge_it = std::ranges::lower_bound(vertex, hyperedge_id);
+            if (hyperedge_it != vertex.end() and *hyperedge_it == hyperedge_id)
+                hyperedge_it = vertex.erase(hyperedge_it); // unbind the hyperedge
+            while (hyperedge_it != vertex.end())
+                --(*hyperedge_it++); // decrement ids > hyperedge_id
+        }
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    ) const noexcept {
+        return std::views::iota(0uz, this->_storage.size())
+             | std::views::filter([this, hyperedge_id](types::id_type vid) {
+                   return this->_are_bound_impl(this->_storage[vid], hyperedge_id);
+               });
+    }
+
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
+    ) const noexcept {
+        types::size_type size = 0uz;
+        for (const auto& vertex : this->_storage)
+            if (this->_are_bound_impl(vertex, hyperedge_id))
+                ++size;
+        return size;
+    }
+
+    // --- binding methods ---
+
+    void bind(const types::id_type vertex_id, const types::id_type hyperedge_id) noexcept {
+        auto& vertex = this->_storage[vertex_id];
+
+        // insert the id at the correct position to keep the hyperedge-id collection sorted
+        const auto it = std::ranges::lower_bound(vertex, hyperedge_id);
+        if (it == vertex.end() or *it != hyperedge_id)
+            vertex.insert(it, hyperedge_id);
+    }
+
+    gl_attr_force_inline void unbind(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept {
+        auto& vertex = this->_storage[vertex_id];
+
+        const auto hyperedge_it = std::ranges::lower_bound(vertex, hyperedge_id);
+        if (hyperedge_it != vertex.end() and *hyperedge_it == hyperedge_id)
+            vertex.erase(hyperedge_it);
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool are_bound(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_are_bound_impl(this->_storage[vertex_id], hyperedge_id);
+    }
+
+#ifdef HGL_TESTING
+    friend struct hgl_testing::test_vertex_list;
+#endif
+
+private:
+    [[nodiscard]] bool _are_bound_impl(
+        const vertex_storage_type& vertex, const types::id_type hyperedge_id
+    ) const noexcept {
+        const auto hyperedge_it = std::ranges::lower_bound(vertex, hyperedge_id);
+        return hyperedge_it != vertex.end() and *hyperedge_it == hyperedge_id;
+    }
+
+    hypergraph_storage_type _storage;
+};
+
+} // namespace hgl::impl

--- a/tests/source/hgl/test_hyperedge_list.cpp
+++ b/tests/source/hgl/test_hyperedge_list.cpp
@@ -4,6 +4,7 @@
 #include <hgl/impl/hyperedge_list.hpp>
 
 #include <algorithm>
+#include <ranges>
 
 namespace hgl_testing {
 
@@ -49,13 +50,22 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_undirected_hyperedge_list,
-    "remove_hyperedge should properly erase the proper hyperedge storage from the hypergraph"
+    "remove_hyperedge should properly erase the proper hyperedge storage entry from the hypergraph"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     REQUIRE_EQ(storage(sut).size(), constants::n_hyperedges);
 
     sut.remove_hyperedge(constants::id1);
     CHECK_EQ(storage(sut).size(), constants::n_hyperedges - 1uz);
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_hyperedge_list, "incident_vertices should remove an empty view by default"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+        return std::ranges::empty(sut.incident_vertices(hyperedge_id));
+    }));
 }
 
 TEST_CASE_FIXTURE(test_undirected_hyperedge_list, "hyperedge_size should return 0 by default") {
@@ -66,90 +76,163 @@ TEST_CASE_FIXTURE(test_undirected_hyperedge_list, "hyperedge_size should return 
 }
 
 TEST_CASE_FIXTURE(
-    test_undirected_hyperedge_list, "hyperedge_vertices should remove an empty view by default"
-) {
-    sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-        return std::ranges::empty(sut.hyperedge_vertices(hyperedge_id));
-    }));
-}
-
-TEST_CASE_FIXTURE(
     test_undirected_hyperedge_list,
-    "bind(hyperedge, vertex) should add the vertex to the given hyperedge's storage only if the "
-    "they are not bound"
+    "bind should add the vertex to the given hyperedge's storage only if the they are not bound"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    REQUIRE(std::ranges::empty(sut.hyperedge_vertices(constants::id1)));
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
 
     sut.bind(constants::id1, constants::id1);
-    const auto vertices1 = sut.hyperedge_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices1 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices1), 1uz);
     CHECK(std::ranges::contains(vertices1, constants::id1));
     CHECK(std::ranges::equal(vertices1, storage(sut)[constants::id1]));
 
     sut.bind(constants::id1, constants::id1);
-    const auto vertices2 = sut.hyperedge_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices2 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(std::ranges::size(vertices2), 1uz);
     CHECK(std::ranges::equal(vertices2, vertices1));
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_hyperedge_list,
-    "unbind(hyperedge, vertex) should remove the vertex from the given hyperedge's storage only if "
-    "the they are bound"
+    "unbind should remove the vertex from the given hyperedge's storage only if the they are bound"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    REQUIRE(std::ranges::empty(sut.hyperedge_vertices(constants::id1)));
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
 
     sut.bind(constants::id1, constants::id1);
-    const auto vertices1 = sut.hyperedge_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices1 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
     REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
     REQUIRE(std::ranges::contains(vertices1, constants::id1));
 
     sut.unbind(constants::id1, constants::id2);
-    const auto vertices2 = sut.hyperedge_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices2 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
     REQUIRE_EQ(std::ranges::size(vertices2), 1uz);
     REQUIRE(std::ranges::equal(vertices2, vertices1));
 
     sut.unbind(constants::id1, constants::id1);
-    CHECK(std::ranges::empty(sut.hyperedge_vertices(constants::id1)));
+    CHECK(std::ranges::empty(sut.incident_vertices(constants::id1)));
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_hyperedge_list,
-    "are_bound(hyperedge, vertex) should return true only when the given vertex is present in the "
-    "hyperedge's storage"
+    "are_bound should return true only when the given vertex is present in the hyperedge's storage"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    REQUIRE(std::ranges::empty(sut.hyperedge_vertices(constants::id1)));
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
 
     sut.bind(constants::id1, constants::id1);
-    const auto vertices1 = sut.hyperedge_vertices(constants::id1) | std::ranges::to<std::vector>();
     REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
-    REQUIRE(std::ranges::contains(vertices1, constants::id1));
+    REQUIRE(std::ranges::contains(sut.incident_vertices(constants::id1), constants::id1));
 
     CHECK(sut.are_bound(constants::id1, constants::id1));
     CHECK_FALSE(sut.are_bound(constants::id1, constants::id2));
     CHECK_FALSE(sut.are_bound(constants::id2, constants::id1));
 }
 
+TEST_CASE_FIXTURE(test_undirected_hyperedge_list, "add_vertices should do nothing") {
+    sut_type sut{};
+    sut.add_vertices(constants::n_vertices);
+    CHECK(storage(sut).empty());
+}
+
 TEST_CASE_FIXTURE(
     test_undirected_hyperedge_list,
-    "remove_vertex should unbind the given vertex from all hyperedges"
+    "remove_vertex should properly unbind (if necessary) the given vertex and align ids > vertex_id"
+) {
+    constexpr hgl::types::size_type n_vertices = 4uz, n_hyperedges = 1uz;
+    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind(constants::id2, hyperedge_id);
+    sut.bind(constants::id4, hyperedge_id);
+
+    hgl::types::id_type rem_vid;
+    std::vector<hgl::types::id_type> expected_vertices;
+
+    SUBCASE("not present vertex < first incident vertex") {
+        rem_vid = constants::id1;
+        expected_vertices = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present vertex = first incident vertex") {
+        rem_vid = constants::id2;
+        expected_vertices = {constants::id4 - 1uz};
+    }
+
+    SUBCASE("not present vertex > first incident vertex") {
+        rem_vid = constants::id3;
+        expected_vertices = {constants::id2, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present vertex = last incident vertex") {
+        rem_vid = constants::id4;
+        expected_vertices = {constants::id2};
+    }
+
+    SUBCASE("not present vertex > last incident vertex") {
+        rem_vid = constants::id4 + 1uz;
+        expected_vertices = {constants::id2, constants::id4};
+    }
+
+    CAPTURE(rem_vid);
+    CAPTURE(expected_vertices);
+
+    sut.remove_vertex(rem_vid);
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), expected_vertices));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_hyperedge_list,
+    "remove_vertex should unbind the given vertex from all hyperedges and align ids > vertex_id"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    for (const auto hyperedge_id : constants::hyperedge_ids_view)
-        sut.bind(hyperedge_id, constants::id1);
+    for (const auto vid : constants::vertex_ids_view)
+        for (const auto heid : constants::hyperedge_ids_view)
+            sut.bind(vid, heid);
+
+    constexpr auto vertex_id = constants::id1;
     REQUIRE(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-        return sut.are_bound(hyperedge_id, constants::id1);
+        return sut.are_bound(vertex_id, hyperedge_id);
     }));
 
-    sut.remove_vertex(constants::id1);
+    sut.remove_vertex(vertex_id);
     CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-        return std::ranges::empty(sut.hyperedge_vertices(hyperedge_id));
+        return std::ranges::equal(
+            sut.incident_vertices(hyperedge_id),
+            std::views::iota(constants::id1, constants::n_vertices - 1uz)
+        );
     }));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_hyperedge_list,
+    "incident_hyperedges should return a view of the vertex's incident hyperedge ids"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+    for (const auto hyperedge_id : constants::hyperedge_ids_view)
+        sut.bind(vertex_id, hyperedge_id);
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_hyperedge_list,
+    "degree should return the number of the vertex's incident hyperedges"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE_EQ(sut.degree(vertex_id), 0uz);
+
+    for (const auto hyperedge_id : constants::hyperedge_ids_view)
+        sut.bind(vertex_id, hyperedge_id);
+    CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
 }
 
 TEST_SUITE_END(); // test_hyperedge_list

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -371,8 +371,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hypergraph_traits_template,
     hgl::hyperedge_list_hg_traits<hgl::undirected_t>, // undirected edge list
     hgl::hyperedge_list_hg_traits<hgl::bf_directed_t>, // bf-directed edge list
-    hgl::adjacency_list_hg_traits<hgl::undirected_t>, // undirected adjacency list
-    hgl::adjacency_list_hg_traits<hgl::bf_directed_t>, // bf-directed adjacency list
+    hgl::vertex_list_hg_traits<hgl::undirected_t>, // undirected adjacency list
+    hgl::vertex_list_hg_traits<hgl::bf_directed_t>, // bf-directed adjacency list
     hgl::incidence_matrix_hg_traits<hgl::undirected_t>, // undirected incidence matrix
     hgl::incidence_matrix_hg_traits<hgl::bf_directed_t> // bf-directed incidence matrix
 );
@@ -422,11 +422,11 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::bf_directed_t,
         hgl::types::name_property,
         hgl::types::name_property>, // bf-directed hyperedge list
-    hgl::adjacency_list_hg_traits<
+    hgl::vertex_list_hg_traits<
         hgl::undirected_t,
         hgl::types::name_property,
         hgl::types::name_property>, // undirected adjacency list
-    hgl::adjacency_list_hg_traits<
+    hgl::vertex_list_hg_traits<
         hgl::bf_directed_t,
         hgl::types::name_property,
         hgl::types::name_property>, // bf-directed adjacency list

--- a/tests/source/hgl/test_vertex_list.cpp
+++ b/tests/source/hgl/test_vertex_list.cpp
@@ -1,0 +1,250 @@
+#include "testing/hgl/constants.hpp"
+
+#include <doctest.h>
+#include <hgl/impl/vertex_list.hpp>
+
+#include <algorithm>
+#include <ranges>
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_vertex_list");
+
+struct test_vertex_list {
+    template <typename VertexList>
+    typename VertexList::hypergraph_storage_type& storage(VertexList& sut) const noexcept {
+        return sut._storage;
+    }
+};
+
+struct test_undirected_vertex_list : public test_vertex_list {
+    using sut_type = hgl::impl::undirected_vertex_list;
+};
+
+TEST_CASE_FIXTURE(test_undirected_vertex_list, "should initialize empty storage by default") {
+    sut_type sut{};
+    CHECK(storage(sut).empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "initialization with size parameters should properly initialize storage"
+) {
+    sut_type sut(constants::n_vertices, constants::n_hyperedges);
+    CHECK_EQ(storage(sut).size(), constants::n_vertices);
+    CHECK(std::ranges::all_of(storage(sut), [](const auto& vertex_storage) {
+        return vertex_storage.empty();
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list, "add_vertices should properly extend the hypergraph storage"
+) {
+    sut_type sut{};
+    sut.add_vertices(constants::n_vertices);
+    CHECK_EQ(storage(sut).size(), constants::n_vertices);
+    CHECK(std::ranges::all_of(storage(sut), [](const auto& vertex_storage) {
+        return vertex_storage.empty();
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "remove_vertex should properly erase the proper vertex storage entry from the hypergraph"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    REQUIRE_EQ(storage(sut).size(), constants::n_vertices);
+
+    sut.remove_vertex(constants::id1);
+    CHECK_EQ(storage(sut).size(), constants::n_vertices - 1uz);
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list, "incident_hyperedges should return an empty view by default"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK(std::ranges::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
+        return std::ranges::empty(sut.incident_hyperedges(vertex_id));
+    }));
+}
+
+TEST_CASE_FIXTURE(test_undirected_vertex_list, "degree should return 0 by default") {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK(std::ranges::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
+        return sut.degree(vertex_id) == 0uz;
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "bind should add the hyperedge to the given vertex's storage only if they are not bound"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    constexpr auto vertex_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+    sut.bind(vertex_id, hyperedge_id);
+    const auto hyperedges1 = sut.incident_hyperedges(vertex_id) | std::ranges::to<std::vector>();
+    CHECK_EQ(sut.degree(vertex_id), 1uz);
+    CHECK_EQ(std::ranges::size(hyperedges1), 1uz);
+    CHECK(std::ranges::contains(hyperedges1, hyperedge_id));
+    CHECK(std::ranges::equal(hyperedges1, storage(sut)[vertex_id]));
+
+    sut.bind(vertex_id, hyperedge_id);
+    const auto hyperedges2 = sut.incident_hyperedges(vertex_id) | std::ranges::to<std::vector>();
+    CHECK_EQ(std::ranges::size(hyperedges2), 1uz);
+    CHECK(std::ranges::equal(hyperedges2, hyperedges1));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "unbind should remove the hyperedge from the given vertex's storage only if they are bound"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    constexpr auto vertex_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+    sut.bind(vertex_id, hyperedge_id);
+    const auto hyperedges1 = sut.incident_hyperedges(vertex_id) | std::ranges::to<std::vector>();
+    REQUIRE_EQ(sut.degree(vertex_id), 1uz);
+    REQUIRE(std::ranges::contains(hyperedges1, hyperedge_id));
+
+    sut.unbind(constants::id2, hyperedge_id);
+    const auto hyperedges2 = sut.incident_hyperedges(vertex_id) | std::ranges::to<std::vector>();
+    REQUIRE_EQ(std::ranges::size(hyperedges2), 1uz);
+    REQUIRE(std::ranges::equal(hyperedges2, hyperedges1));
+
+    sut.unbind(vertex_id, hyperedge_id);
+    CHECK(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "are_bound should return true only when the given hyperedge is present in the vertex's "
+    "storage"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    constexpr auto vertex_id = constants::id1;
+    constexpr auto hyperedge_id1 = constants::id1;
+    constexpr auto hyperedge_id2 = constants::id2;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+    sut.bind(vertex_id, hyperedge_id1);
+    REQUIRE_EQ(sut.degree(vertex_id), 1uz);
+    REQUIRE(std::ranges::contains(sut.incident_hyperedges(vertex_id), hyperedge_id1));
+
+    CHECK(sut.are_bound(vertex_id, hyperedge_id1));
+    CHECK_FALSE(sut.are_bound(vertex_id, hyperedge_id2));
+    CHECK_FALSE(sut.are_bound(constants::id2, hyperedge_id1));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "remove_hyperedge should properly unbind (if necessary) the given hyperedge and align ids "
+    "> hyperedge_id"
+) {
+    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 4uz;
+    constexpr hgl::types::id_type vertex_id = constants::id1;
+
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind(vertex_id, constants::id2);
+    sut.bind(vertex_id, constants::id4);
+
+    hgl::types::id_type rem_heid;
+    std::vector<hgl::types::id_type> expected_hyperedges;
+
+    SUBCASE("not present hyperedge < first incident hyperedge") {
+        rem_heid = constants::id1;
+        expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present hyperedge = first incident hyperedge") {
+        rem_heid = constants::id2;
+        expected_hyperedges = {constants::id4 - 1uz};
+    }
+
+    SUBCASE("not present hyperedge > first incident hyperedge") {
+        rem_heid = constants::id3;
+        expected_hyperedges = {constants::id2, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present hyperedge = last incident hyperedge") {
+        rem_heid = constants::id4;
+        expected_hyperedges = {constants::id2};
+    }
+
+    SUBCASE("not present hyperedge > last incident hyperedge") {
+        rem_heid = constants::id4 + 1uz;
+        expected_hyperedges = {constants::id2, constants::id4};
+    }
+
+    CAPTURE(rem_heid);
+    CAPTURE(expected_hyperedges);
+
+    sut.remove_hyperedge(rem_heid);
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "remove_hyperedge should unbind from all vertices and align ids > hyperedge_id"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    for (const auto vid : constants::vertex_ids_view)
+        for (const auto heid : constants::hyperedge_ids_view)
+            sut.bind(vid, heid);
+
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
+        return sut.are_bound(vertex_id, hyperedge_id);
+    }));
+
+    sut.remove_hyperedge(hyperedge_id);
+
+    CHECK(std::ranges::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
+        return std::ranges::equal(
+            sut.incident_hyperedges(vertex_id),
+            std::views::iota(constants::id1, constants::n_hyperedges - 1uz)
+        );
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "incident_vertices should return a view of the hyperedge's incident vertex ids"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_vertices(hyperedge_id)));
+
+    for (const auto vertex_id : constants::vertex_ids_view)
+        sut.bind(vertex_id, hyperedge_id);
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_vertex_list,
+    "hyperedge_size should return the number of the hyperedge's incident vertices"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE_EQ(sut.hyperedge_size(hyperedge_id), 0uz);
+
+    for (const auto vertex_id : constants::vertex_ids_view)
+        sut.bind(vertex_id, hyperedge_id);
+    CHECK_EQ(sut.hyperedge_size(hyperedge_id), constants::n_vertices);
+}
+
+TEST_CASE_FIXTURE(test_undirected_vertex_list, "add_hyperedges should do nothing") {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    sut.add_hyperedges(constants::n_hyperedges);
+    CHECK_EQ(storage(sut).size(), constants::n_vertices);
+}
+
+TEST_SUITE_END(); // test_vertex_list
+
+} // namespace hgl_testing


### PR DESCRIPTION
- Created the `impl::undirected_vertex_list` model class, which stores a list of vertices and their incident hyperedges and define the following operations:
  - Adding and removing vertices
  - Adding and removing hyperedges
  - Binding and unbinding vertices to hyperedges
  - Retrieving the degree of a vertex
  - Retrieving the set of hyperedges incident with (containing) a given vertex
  - Retrieving the number of vertices incident with a given hyperedge
  - Retrieving the set of vertices incident with a given hyperedge
- Renamed the `impl::adjacency_list_t` tag to `impl::vertex_list_t`
- Added missing methods to the `impl::undirected_hyperedge_list` class
- Aligned the vertex removal logic in the hyperedge-list model to properly unbind the given vertex from all edges and decrement the ids, which are greater than the given vertex id

