### PR TITLE
YT-CPPHL-11: Implement the bf-directed incidence-matrix model

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,23 @@
+CompileFlags:
+  Add:
+    - -std=c++23
+    - -xc++-header
+    - -Iinclude
+    - -Itests/include
+    - -Itests/external
+    - -Wall
+    - -Wextra
+    - -ftemplate-depth=512
+
+Diagnostics:
+  UnusedIncludes: None
+  ClangTidy:
+    Add:
+      - bugprone-*
+      - modernize-*
+      - performance-*
+    Remove:
+      - modernize-use-trailing-return-type
+
+Index:
+  Background: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # Install the headers
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Install the library target
 install(TARGETS cpp-gl EXPORT cpp-gl-targets)

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -52,7 +52,8 @@ public:
         if constexpr (type_traits::c_non_empty_properties<hyperedge_properties_type>) {
             this->_hyperedge_properties.reserve(n_hyperedges);
             for (const auto _ : this->hyperedge_ids())
-                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
+                this->_hyperedge_properties.push_back(
+                    std::make_unique<hyperedge_properties_type>()
                 );
         }
     }
@@ -257,7 +258,8 @@ public:
             const auto old_size = this->_hyperedge_properties.size();
             this->_hyperedge_properties.reserve(this->_n_hyperedges);
             for (types::size_type i = old_size; i < this->_n_hyperedges; ++i)
-                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
+                this->_hyperedge_properties.push_back(
+                    std::make_unique<hyperedge_properties_type>()
                 );
         }
     }

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -52,8 +52,7 @@ public:
         if constexpr (type_traits::c_non_empty_properties<hyperedge_properties_type>) {
             this->_hyperedge_properties.reserve(n_hyperedges);
             for (const auto _ : this->hyperedge_ids())
-                this->_hyperedge_properties.push_back(
-                    std::make_unique<hyperedge_properties_type>()
+                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
                 );
         }
     }
@@ -258,8 +257,7 @@ public:
             const auto old_size = this->_hyperedge_properties.size();
             this->_hyperedge_properties.reserve(this->_n_hyperedges);
             for (types::size_type i = old_size; i < this->_n_hyperedges; ++i)
-                this->_hyperedge_properties.push_back(
-                    std::make_unique<hyperedge_properties_type>()
+                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
                 );
         }
     }

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -59,11 +59,11 @@ public:
 
     // --- general methods ---
 
-    [[nodiscard]] gl_attr_force_inline types::size_type n_vertices() const noexcept {
+    [[nodiscard]] gl_attr_force_inline types::size_type order() const noexcept {
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type n_hyperedges() const noexcept {
+    [[nodiscard]] gl_attr_force_inline types::size_type size() const noexcept {
         return this->_n_hyperedges;
     }
 

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -9,6 +9,7 @@
 #include "hgl/types/types.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <ranges>
 #include <vector>
 
@@ -57,7 +58,8 @@ public:
             this->_remove_minor(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
+        const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
             return this->_incident_with_major(vertex_id);
@@ -65,7 +67,8 @@ public:
             return this->_incident_with_minor(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(
+        const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
             return this->_major_size(vertex_id);
@@ -87,7 +90,8 @@ public:
             this->_remove_minor(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
+        const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
             return this->_incident_with_major(hyperedge_id);
@@ -142,7 +146,9 @@ private:
     using major_storage_type = std::vector<major_element_type>;
 
     gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_major_storage.erase(this->_major_storage.begin() + major_id);
+        this->_major_storage.erase(
+            this->_major_storage.begin() + static_cast<std::ptrdiff_t>(major_id)
+        );
     }
 
     void _remove_minor(const types::id_type minor_id) noexcept {
@@ -155,12 +161,14 @@ private:
         }
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_with_major(const types::id_type major_id
+    [[nodiscard]] gl_attr_force_inline auto _incident_with_major(
+        const types::id_type major_id
     ) const noexcept {
         return std::views::all(this->_major_storage[major_id]);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_with_minor(const types::id_type minor_id
+    [[nodiscard]] gl_attr_force_inline auto _incident_with_minor(
+        const types::id_type minor_id
     ) const noexcept {
         return std::views::iota(0uz, this->_major_storage.size())
              | std::views::filter([this, minor_id](types::id_type major_id) {
@@ -168,7 +176,8 @@ private:
                });
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type _major_size(const types::id_type major_id
+    [[nodiscard]] gl_attr_force_inline types::size_type _major_size(
+        const types::id_type major_id
     ) const noexcept {
         return this->_major_storage[major_id].size();
     }
@@ -181,6 +190,7 @@ private:
         return size;
     }
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void _bind_impl(const types::id_type major_id, const types::id_type minor_id) noexcept {
         auto& minor_storage = this->_major_storage[major_id];
 
@@ -191,7 +201,9 @@ private:
     }
 
     gl_attr_force_inline void _unbind_impl(
-        const types::id_type major_id, const types::id_type minor_id
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+        const types::id_type major_id,
+        const types::id_type minor_id
     ) noexcept {
         auto& minor_storage = this->_major_storage[major_id];
         const auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -60,9 +60,9 @@ public:
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_incident_to_major(vertex_id);
+            return this->_incident_with_major(vertex_id);
         else
-            return this->_incident_to_minor(vertex_id);
+            return this->_incident_with_minor(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
@@ -90,9 +90,9 @@ public:
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_incident_to_major(hyperedge_id);
+            return this->_incident_with_major(hyperedge_id);
         else
-            return this->_incident_to_minor(hyperedge_id);
+            return this->_incident_with_minor(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
@@ -155,12 +155,12 @@ private:
         }
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_to_major(const types::id_type major_id
+    [[nodiscard]] gl_attr_force_inline auto _incident_with_major(const types::id_type major_id
     ) const noexcept {
         return std::views::all(this->_major_storage[major_id]);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_to_minor(const types::id_type minor_id
+    [[nodiscard]] gl_attr_force_inline auto _incident_with_minor(const types::id_type minor_id
     ) const noexcept {
         return std::views::iota(0uz, this->_major_storage.size())
              | std::views::filter([this, minor_id](types::id_type major_id) {

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -52,28 +52,17 @@ public:
     }
 
     gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            this->_remove_major(vertex_id);
-        else
-            this->_remove_minor(vertex_id);
+        this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_incident_with_major(vertex_id);
-        else
-            return this->_incident_with_minor(vertex_id);
+        return this->_incident_with<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_major_size(vertex_id);
-        else
-            return this->_minor_size(vertex_id);
+        return this->_size<impl::element_type::vertex>(vertex_id);
     }
 
     // --- hyperedge methods ---
@@ -84,28 +73,18 @@ public:
     }
 
     gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            this->_remove_major(hyperedge_id);
-        else
-            this->_remove_minor(hyperedge_id);
+        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_incident_with_major(hyperedge_id);
-        else
-            return this->_incident_with_minor(hyperedge_id);
+        return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
         const types::id_type hyperedge_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_major_size(hyperedge_id);
-        else
-            return this->_minor_size(hyperedge_id);
+        return this->_size<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     // --- binding methods ---
@@ -145,49 +124,49 @@ private:
     using major_element_type = minor_storage_type;
     using major_storage_type = std::vector<major_element_type>;
 
-    gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_major_storage.erase(
-            this->_major_storage.begin() + static_cast<std::ptrdiff_t>(major_id)
-        );
-    }
-
-    void _remove_minor(const types::id_type minor_id) noexcept {
-        for (auto& minor_storage : this->_major_storage) {
-            auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);
-            if (minor_it != minor_storage.end() and *minor_it == minor_id)
-                minor_it = minor_storage.erase(minor_it); // unbind the element
-            while (minor_it != minor_storage.end())
-                --(*minor_it++); // decrement ids > minor_id
+    template <impl::element_type Element>
+    void _remove(const types::id_type id) noexcept {
+        if constexpr (Element == layout_tag::major_element) { // remove major
+            this->_major_storage.erase(
+                this->_major_storage.begin() + static_cast<std::ptrdiff_t>(id)
+            );
+        }
+        else { // remove minor
+            for (auto& minor_storage : this->_major_storage) {
+                auto minor_it = std::ranges::lower_bound(minor_storage, id);
+                if (minor_it != minor_storage.end() and *minor_it == id)
+                    minor_it = minor_storage.erase(minor_it); // unbind the element
+                while (minor_it != minor_storage.end())
+                    --(*minor_it++); // decrement ids > id (minor)
+            }
         }
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_with_major(
-        const types::id_type major_id
-    ) const noexcept {
-        return std::views::all(this->_major_storage[major_id]);
+    template <impl::element_type Element>
+    [[nodiscard]] gl_attr_force_inline auto _incident_with(const types::id_type id) const noexcept {
+        if constexpr (Element == layout_tag::major_element) { // incident with major
+            return std::views::all(this->_major_storage[id]);
+        }
+        else { // incident with minor
+            return std::views::iota(0uz, this->_major_storage.size())
+                 | std::views::filter([this, minor_id = id](types::id_type major_id) {
+                       return this->_are_bound_impl(this->_major_storage[major_id], minor_id);
+                   });
+        }
     }
 
-    [[nodiscard]] gl_attr_force_inline auto _incident_with_minor(
-        const types::id_type minor_id
-    ) const noexcept {
-        return std::views::iota(0uz, this->_major_storage.size())
-             | std::views::filter([this, minor_id](types::id_type major_id) {
-                   return this->_are_bound_impl(this->_major_storage[major_id], minor_id);
-               });
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::size_type _major_size(
-        const types::id_type major_id
-    ) const noexcept {
-        return this->_major_storage[major_id].size();
-    }
-
-    [[nodiscard]] types::size_type _minor_size(const types::id_type minor_id) const noexcept {
-        types::size_type size = 0uz;
-        for (const auto& major_el : this->_major_storage)
-            if (this->_are_bound_impl(major_el, minor_id))
-                ++size;
-        return size;
+    template <impl::element_type Element>
+    [[nodiscard]] types::size_type _size(const types::id_type id) const noexcept {
+        if constexpr (Element == layout_tag::major_element) { // size major
+            return this->_major_storage[id].size();
+        }
+        else { // size minor
+            types::size_type size = 0uz;
+            for (const auto& major_el : this->_major_storage)
+                if (this->_are_bound_impl(major_el, id))
+                    ++size;
+            return size;
+        }
     }
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -9,9 +9,10 @@
 #include "hgl/types/types.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <ranges>
 #include <vector>
-#include <cstdint>
 
 #ifdef HGL_TESTING
 namespace hgl_testing {
@@ -63,7 +64,8 @@ public:
             this->_remove_minor(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
+        const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
             return this->_incident_with_major(vertex_id);
@@ -94,7 +96,8 @@ public:
             this->_remove_minor(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
+        const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
             return this->_incident_with_major(hyperedge_id);
@@ -102,8 +105,7 @@ public:
             return this->_incident_with_minor(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
             return this->_count_major(hyperedge_id);
         else
@@ -154,7 +156,7 @@ private:
     }
 
     gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_matrix.erase(this->_matrix.begin() + major_id);
+        this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(major_id));
     }
 
     gl_attr_force_inline void _remove_minor(const types::id_type minor_id) noexcept {
@@ -162,7 +164,7 @@ private:
             return;
         this->_matrix_row_size--;
         for (auto& row : this->_matrix) {
-            row.erase(row.begin() + minor_id);
+            row.erase(row.begin() + static_cast<std::ptrdiff_t>(minor_id));
         }
     }
 
@@ -211,7 +213,8 @@ public:
     incidence_matrix(const types::size_type n_vertices, const types::size_type n_hyperedges)
     : _matrix_row_size{layout_tag::minor(n_vertices, n_hyperedges)},
       _matrix(
-          layout_tag::major(n_vertices, n_hyperedges), matrix_row_type(_matrix_row_size, incidence_type::none)
+          layout_tag::major(n_vertices, n_hyperedges),
+          matrix_row_type(_matrix_row_size, incidence_type::none)
       ) {}
 
     incidence_matrix(incidence_matrix&&) = default;
@@ -235,7 +238,8 @@ public:
             this->_remove_minor(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
+        const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
             return this->_incident_with_major(vertex_id);
@@ -268,7 +272,8 @@ public:
             this->_remove_minor(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
+        const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
             return this->_incident_with_major(hyperedge_id);
@@ -276,8 +281,7 @@ public:
             return this->_incident_with_minor(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
             return this->_count_major(hyperedge_id);
         else
@@ -317,15 +321,14 @@ public:
 
 private:
     enum class incidence_type : std::int8_t {
-        none = 0,      // v not in E
+        none = 0, // v not in E
         backward = -1, // v in T(E)
-        forward = 1,   // v in H(E)
+        forward = 1, // v in H(E)
     };
 
-    template <typename P>
-    concept c_incidence_pred = std::predicate<P, incidence_type>;
-
-    static constexpr auto _are_incident_pred = [](const incidence_type t) { return t != incidence_type::none; };
+    static constexpr auto _are_incident_pred = [](const incidence_type t) {
+        return t != incidence_type::none;
+    };
 
     using matrix_row_type = std::vector<incidence_type>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
@@ -370,7 +373,7 @@ private:
 
     [[nodiscard]] types::size_type _count_major(
         const types::id_type major_id,
-        const c_incidence_pred auto pred = incidence_matrix::_are_incident_pred
+        const std::predicate<incidence_type> auto pred = incidence_matrix::_are_incident_pred
     ) const noexcept {
         types::size_type count = 0;
         for (const incidence_type t : this->_matrix[major_id])
@@ -380,7 +383,7 @@ private:
 
     [[nodiscard]] types::size_type _count_minor(
         const types::id_type minor_id,
-        const c_incidence_pred auto pred = incidence_matrix::_are_incident_pred
+        const std::predicate<incidence_type> auto pred = incidence_matrix::_are_incident_pred
     ) const noexcept {
         types::size_type count = 0;
         for (const auto& row : this->_matrix)

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -30,6 +30,7 @@ class incidence_matrix;
 template <type_traits::c_hypergraph_layout_tag LayoutTag>
 class incidence_matrix<hgl::undirected_t, LayoutTag> final {
 public:
+    using directional_tag = hgl::undirected_t;
     using layout_tag = LayoutTag;
 
     incidence_matrix(const incidence_matrix&) = delete;
@@ -184,6 +185,7 @@ private:
 template <type_traits::c_hypergraph_layout_tag LayoutTag>
 class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
 public:
+    using directional_tag = hgl::bf_directed_t;
     using layout_tag = LayoutTag;
 
     incidence_matrix(const incidence_matrix&) = delete;
@@ -342,9 +344,11 @@ private:
     static constexpr auto _is_incident = [](const incidence_type t) {
         return t != incidence_type::none;
     };
+
     static constexpr auto _is_tail = [](const incidence_type t) {
         return t == incidence_type::backward;
     };
+
     static constexpr auto _is_head = [](const incidence_type t) {
         return t == incidence_type::forward;
     };

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -157,8 +157,8 @@ private:
         }
         else { // incident with minor
             return std::views::iota(0uz, this->_matrix.size())
-                 | std::views::filter([this, id](const types::id_type major_id) {
-                       return this->_matrix[major_id][id];
+                 | std::views::filter([this, minor_id = id](const types::id_type major_id) {
+                       return this->_matrix[major_id][minor_id];
                    });
         }
     }

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -51,65 +51,40 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            this->_add_major(n);
-        else
-            this->_add_minor(n);
+        this->_add<impl::element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            this->_remove_major(vertex_id);
-        else
-            this->_remove_minor(vertex_id);
+        this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_incident_with_major(vertex_id);
-        else
-            return this->_incident_with_minor(vertex_id);
+        return this->_incident_with<impl::element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_count_major(vertex_id);
-        else
-            return this->_count_minor(vertex_id);
+        return this->_count<impl::element_type::vertex>(vertex_id);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            this->_add_major(n);
-        else
-            this->_add_minor(n);
+        this->_add<impl::element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            this->_remove_major(hyperedge_id);
-        else
-            this->_remove_minor(hyperedge_id);
+        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_incident_with_major(hyperedge_id);
-        else
-            return this->_incident_with_minor(hyperedge_id);
+        return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_count_major(hyperedge_id);
-        else
-            return this->_count_minor(hyperedge_id);
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_count<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     // --- binding methods ---
@@ -143,63 +118,72 @@ private:
     using matrix_row_type = std::vector<bool>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    gl_attr_force_inline void _add_major(const types::size_type n) noexcept {
-        this->_matrix.resize(
-            this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, false)
-        );
-    }
-
-    void _add_minor(const types::size_type n) noexcept {
-        this->_matrix_row_size += n;
-        for (auto& row : this->_matrix)
-            row.resize(this->_matrix_row_size, false);
-    }
-
-    gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(major_id));
-    }
-
-    gl_attr_force_inline void _remove_minor(const types::id_type minor_id) noexcept {
-        if (this->_matrix_row_size == 0)
-            return;
-        this->_matrix_row_size--;
-        for (auto& row : this->_matrix) {
-            row.erase(row.begin() + static_cast<std::ptrdiff_t>(minor_id));
+    template <impl::element_type Element>
+    void _add(const types::size_type n) noexcept {
+        if constexpr (Element == layout_tag::major_element) { // add major
+            this->_matrix.resize(
+                this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, false)
+            );
+        }
+        else { // add minor
+            this->_matrix_row_size += n;
+            for (auto& row : this->_matrix)
+                row.resize(this->_matrix_row_size, false);
         }
     }
 
-    [[nodiscard]] auto _incident_with_major(const types::id_type major_id) const noexcept {
-        return std::views::iota(0uz, this->_matrix_row_size)
-             | std::views::filter([&row = this->_matrix[major_id]](const types::id_type minor_id) {
-                   return row[minor_id];
-               });
+    template <impl::element_type Element>
+    void _remove(const types::id_type id) noexcept {
+        if constexpr (Element == layout_tag::major_element) { // remove major
+            this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
+        }
+        else { // remove minor
+            if (this->_matrix_row_size == 0)
+                return;
+            this->_matrix_row_size--;
+            for (auto& row : this->_matrix) {
+                row.erase(row.begin() + static_cast<std::ptrdiff_t>(id));
+            }
+        }
     }
 
-    [[nodiscard]] auto _incident_with_minor(const types::id_type minor_id) const noexcept {
-        return std::views::iota(0uz, this->_matrix.size())
-             | std::views::filter([this, minor_id](const types::id_type major_id) {
-                   return this->_matrix[major_id][minor_id];
-               });
+    template <impl::element_type Element>
+    gl_attr_force_inline auto _incident_with(const types::id_type id) const noexcept {
+        if constexpr (Element == layout_tag::major_element) { // incident with major
+            return std::views::iota(0uz, this->_matrix_row_size)
+                 | std::views::filter([&row = this->_matrix[id]](const types::id_type minor_id) {
+                       return row[minor_id];
+                   });
+        }
+        else { // incident with minor
+            return std::views::iota(0uz, this->_matrix.size())
+                 | std::views::filter([this, id](const types::id_type major_id) {
+                       return this->_matrix[major_id][id];
+                   });
+        }
     }
 
-    [[nodiscard]] types::size_type _count_major(const types::id_type major_id) const noexcept {
-        types::size_type count = 0;
-        for (const bool bit : this->_matrix[major_id])
-            count += static_cast<types::size_type>(bit);
-        return count;
-    }
-
-    [[nodiscard]] types::size_type _count_minor(const types::id_type minor_id) const noexcept {
-        types::size_type count = 0;
-        for (const auto& row : this->_matrix)
-            count += static_cast<types::size_type>(row[minor_id]);
-        return count;
+    template <impl::element_type Element>
+    gl_attr_force_inline types::size_type _count(const types::id_type id) const noexcept {
+        if constexpr (Element == layout_tag::major_element) { // count major
+            types::size_type count = 0uz;
+            for (const bool bit : this->_matrix[id])
+                count += static_cast<types::size_type>(bit);
+            return count;
+        }
+        else { // count minor
+            types::size_type count = 0uz;
+            for (const auto& row : this->_matrix)
+                count += static_cast<types::size_type>(row[id]);
+            return count;
+        }
     }
 
     types::size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
 
+/*
 template <type_traits::c_hypergraph_layout_tag LayoutTag>
 class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
 public:
@@ -222,7 +206,7 @@ public:
 
     ~incidence_matrix() = default;
 
-    // --- vertex methods ---
+    // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
@@ -238,25 +222,43 @@ public:
             this->_remove_minor(vertex_id);
     }
 
+    // --- vertex methods : general incidence ---
+
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
         const types::id_type vertex_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_incident_with_major(vertex_id);
-        else
-            return this->_incident_with_minor(vertex_id);
+        return this->_query_layout(vertex_id, _is_incident);
     }
 
     [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_count_major(vertex_id);
-        else
-            return this->_count_minor(vertex_id);
+        return this->_count_layout(vertex_id, _is_incident);
     }
 
-    // TODO: tail/head-specific variants for incident_hyperedges and degree
+    // --- vertex methods : outgoing incidence (vertex is tail) ---
 
-    // --- hyperedge methods ---
+    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(
+        const types::id_type vertex_id
+    ) const noexcept {
+        return this->_query_layout(vertex_id, _is_tail);
+    }
+
+    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept {
+        return this->_count_layout(vertex_id, _is_tail);
+    }
+
+    // --- vertex methods : incoming incidence (vertex is head) ---
+
+    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(
+        const types::id_type vertex_id
+    ) const noexcept {
+        return this->_query_layout(vertex_id, _is_head);
+    }
+
+    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept {
+        return this->_count_layout(vertex_id, _is_head);
+    }
+
+    // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
@@ -272,31 +274,56 @@ public:
             this->_remove_minor(hyperedge_id);
     }
 
+    // --- hyperedge methods : general incidence ---
+
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(
         const types::id_type hyperedge_id
     ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_incident_with_major(hyperedge_id);
-        else
-            return this->_incident_with_minor(hyperedge_id);
+        return this->_query_layout(hyperedge_id, _is_incident);
     }
 
     [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_count_major(hyperedge_id);
-        else
-            return this->_count_minor(hyperedge_id);
+        return this->_count_layout(hyperedge_id, _is_incident);
     }
 
-    // TODO: tail/head-specific variants for incident_vertices and hyperedge_size (tail_size, head_size)
+    // --- hyperedge methods : tail incidence ---
+
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(
+        const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_query_layout(hyperedge_id, _is_tail);
+    }
+
+    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept {
+        return this->_count_layout(hyperedge_id, _is_tail);
+    }
+
+    // --- hyperedge methods : head incidence ---
+
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(
+        const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_query_layout(hyperedge_id, _is_head);
+    }
+
+    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept {
+        return this->_count_layout(hyperedge_id, _is_head);
+    }
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
+    gl_attr_force_inline void bind_tail(
         const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = true;
+        this->_matrix[major_id][minor_id] = incidence_type::backward;
+    }
+
+    gl_attr_force_inline void bind_head(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        this->_matrix[major_id][minor_id] = incidence_type::forward;
     }
 
     gl_attr_force_inline void unbind(
@@ -313,22 +340,38 @@ public:
         return this->_matrix[major_id][minor_id] != incidence_type::none;
     }
 
-    // TODO: tail/head-specific variants for bind/are_bound
+    [[nodiscard]] gl_attr_force_inline bool is_tail(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        return this->_matrix[major_id][minor_id] == incidence_type::backward;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool is_head(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        return this->_matrix[major_id][minor_id] == incidence_type::forward;
+    }
 
 #ifdef HGL_TESTING
     friend struct hgl_testing::test_incidence_matrix;
 #endif
 
 private:
+    // --- incidence utility ---
+
     enum class incidence_type : std::int8_t {
-        none = 0, // v not in E
-        backward = -1, // v in T(E)
-        forward = 1, // v in H(E)
+        none = 0,      // v not in E
+        backward = -1, // v in T(E) (Tail/Source)
+        forward = 1,   // v in H(E) (Head/Destination)
     };
 
-    static constexpr auto _are_incident_pred = [](const incidence_type t) {
-        return t != incidence_type::none;
-    };
+    static constexpr auto _is_incident = [](const incidence_type t) { return t != incidence_type::none; };
+    static constexpr auto _is_tail = [](const incidence_type t) { return t == incidence_type::backward; };
+    static constexpr auto _is_head = [](const incidence_type t) { return t == incidence_type::forward; };
+
+    // --- storage management ---
 
     using matrix_row_type = std::vector<incidence_type>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
@@ -346,53 +389,95 @@ private:
     }
 
     gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_matrix.erase(this->_matrix.begin() + major_id);
+        this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(major_id));
     }
 
     gl_attr_force_inline void _remove_minor(const types::id_type minor_id) noexcept {
-        if (this->_matrix_row_size == 0)
+        if (this->_matrix_row_size == 0uz)
             return;
         this->_matrix_row_size--;
-        for (auto& row : this->_matrix)
-            row.erase(row.begin() + minor_id);
+        for (auto& row : this->_matrix) {
+            row.erase(row.begin() + static_cast<std::ptrdiff_t>(minor_id));
+        }
     }
 
-    [[nodiscard]] auto _incident_with_major(const types::id_type major_id) const noexcept {
+    [[nodiscard]] auto _query_major(
+        const types::id_type major_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
         return std::views::iota(0uz, this->_matrix_row_size)
-             | std::views::filter([&row = this->_matrix[major_id]](const types::id_type minor_id) {
-                   return incidence_matrix::_are_incident_pred(row[minor_id]);
+             | std::views::filter([&row = this->_matrix[major_id], pred](const types::id_type minor_id) {
+                   return pred(row[minor_id]);
                });
     }
 
-    [[nodiscard]] auto _incident_with_minor(const types::id_type minor_id) const noexcept {
+    [[nodiscard]] auto _query_minor(
+        const types::id_type minor_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
         return std::views::iota(0uz, this->_matrix.size())
-             | std::views::filter([this, minor_id](const types::id_type major_id) {
-                   return incidence_matrix::_are_incident_pred(this->_matrix[major_id][minor_id]);
+             | std::views::filter([this, minor_id, pred](const types::id_type major_id) {
+                   return pred(this->_matrix[major_id][minor_id]);
                });
     }
 
     [[nodiscard]] types::size_type _count_major(
-        const types::id_type major_id,
-        const std::predicate<incidence_type> auto pred = incidence_matrix::_are_incident_pred
+        const types::id_type major_id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
-        types::size_type count = 0;
+        types::size_type count = 0uz;
         for (const incidence_type t : this->_matrix[major_id])
             count += static_cast<types::size_type>(pred(t));
         return count;
     }
 
     [[nodiscard]] types::size_type _count_minor(
-        const types::id_type minor_id,
-        const std::predicate<incidence_type> auto pred = incidence_matrix::_are_incident_pred
+        const types::id_type minor_id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
-        types::size_type count = 0;
+        types::size_type count = 0uz;
         for (const auto& row : this->_matrix)
             count += static_cast<types::size_type>(pred(row[minor_id]));
         return count;
     }
 
+    // --- vertex/hyperedge-specific helpers ---
+
+    [[nodiscard]] gl_attr_force_inline auto _query_hyperedges(
+        const types::id_type vertex_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            return this->_query_major(vertex_id, std::forward(pred));
+        else
+            return this->_query_minor(vertex_id, std::forward(pred));
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto _query_vertices(
+        const types::id_type hyperedge_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            return this->_query_major(hyperedge_id, std::forward(pred));
+        else
+            return this->_query_minor(hyperedge_id, std::forward(pred));
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type _count_hyperedges(
+        const types::id_type vertex_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            return this->_count_major(vertex_id, std::forward(pred));
+        else
+            return this->_count_minor(vertex_id, std::forward(pred));
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type _count_vertices(
+        const types::id_type hyperedge_id, std::predicate<incidence_type> auto&& pred
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            return this->_count_major(hyperedge_id, std::forward(pred));
+        else
+            return this->_count_minor(hyperedge_id, std::forward(pred));
+    }
+
     types::size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
+*/
 
 } // namespace hgl::impl

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <ranges>
 #include <vector>
+#include <cstdint>
 
 #ifdef HGL_TESTING
 namespace hgl_testing {
@@ -65,16 +66,16 @@ public:
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_incident_to_major(vertex_id);
+            return this->_incident_with_major(vertex_id);
         else
-            return this->_incident_to_minor(vertex_id);
+            return this->_incident_with_minor(vertex_id);
     }
 
     [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_count_major_bits(vertex_id);
+            return this->_count_major(vertex_id);
         else
-            return this->_count_minor_bits(vertex_id);
+            return this->_count_minor(vertex_id);
     }
 
     // --- hyperedge methods ---
@@ -96,17 +97,17 @@ public:
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_incident_to_major(hyperedge_id);
+            return this->_incident_with_major(hyperedge_id);
         else
-            return this->_incident_to_minor(hyperedge_id);
+            return this->_incident_with_minor(hyperedge_id);
     }
 
     [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
     ) const noexcept {
         if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_count_major_bits(hyperedge_id);
+            return this->_count_major(hyperedge_id);
         else
-            return this->_count_minor_bits(hyperedge_id);
+            return this->_count_minor(hyperedge_id);
     }
 
     // --- binding methods ---
@@ -165,31 +166,225 @@ private:
         }
     }
 
-    [[nodiscard]] auto _incident_to_major(const types::id_type major_id) const noexcept {
+    [[nodiscard]] auto _incident_with_major(const types::id_type major_id) const noexcept {
         return std::views::iota(0uz, this->_matrix_row_size)
              | std::views::filter([&row = this->_matrix[major_id]](const types::id_type minor_id) {
                    return row[minor_id];
                });
     }
 
-    [[nodiscard]] auto _incident_to_minor(const types::id_type minor_id) const noexcept {
+    [[nodiscard]] auto _incident_with_minor(const types::id_type minor_id) const noexcept {
         return std::views::iota(0uz, this->_matrix.size())
              | std::views::filter([this, minor_id](const types::id_type major_id) {
                    return this->_matrix[major_id][minor_id];
                });
     }
 
-    [[nodiscard]] types::size_type _count_major_bits(const types::id_type major_id) const noexcept {
+    [[nodiscard]] types::size_type _count_major(const types::id_type major_id) const noexcept {
         types::size_type count = 0;
         for (const bool bit : this->_matrix[major_id])
             count += static_cast<types::size_type>(bit);
         return count;
     }
 
-    [[nodiscard]] types::size_type _count_minor_bits(const types::id_type minor_id) const noexcept {
+    [[nodiscard]] types::size_type _count_minor(const types::id_type minor_id) const noexcept {
         types::size_type count = 0;
         for (const auto& row : this->_matrix)
             count += static_cast<types::size_type>(row[minor_id]);
+        return count;
+    }
+
+    types::size_type _matrix_row_size = 0uz;
+    hypergraph_storage_type _matrix;
+};
+
+template <type_traits::c_hypergraph_layout_tag LayoutTag>
+class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
+public:
+    using layout_tag = LayoutTag;
+
+    incidence_matrix(const incidence_matrix&) = delete;
+    incidence_matrix& operator=(const incidence_matrix&) = delete;
+
+    incidence_matrix() = default;
+
+    incidence_matrix(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    : _matrix_row_size{layout_tag::minor(n_vertices, n_hyperedges)},
+      _matrix(
+          layout_tag::major(n_vertices, n_hyperedges), matrix_row_type(_matrix_row_size, incidence_type::none)
+      ) {}
+
+    incidence_matrix(incidence_matrix&&) = default;
+    incidence_matrix& operator=(incidence_matrix&&) = default;
+
+    ~incidence_matrix() = default;
+
+    // --- vertex methods ---
+
+    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            this->_add_major(n);
+        else
+            this->_add_minor(n);
+    }
+
+    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            this->_remove_major(vertex_id);
+        else
+            this->_remove_minor(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            return this->_incident_with_major(vertex_id);
+        else
+            return this->_incident_with_minor(vertex_id);
+    }
+
+    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
+            return this->_count_major(vertex_id);
+        else
+            return this->_count_minor(vertex_id);
+    }
+
+    // TODO: tail/head-specific variants for incident_hyperedges and degree
+
+    // --- hyperedge methods ---
+
+    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            this->_add_major(n);
+        else
+            this->_add_minor(n);
+    }
+
+    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            this->_remove_major(hyperedge_id);
+        else
+            this->_remove_minor(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            return this->_incident_with_major(hyperedge_id);
+        else
+            return this->_incident_with_minor(hyperedge_id);
+    }
+
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
+    ) const noexcept {
+        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
+            return this->_count_major(hyperedge_id);
+        else
+            return this->_count_minor(hyperedge_id);
+    }
+
+    // TODO: tail/head-specific variants for incident_vertices and hyperedge_size (tail_size, head_size)
+
+    // --- binding methods ---
+
+    gl_attr_force_inline void bind(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        this->_matrix[major_id][minor_id] = true;
+    }
+
+    gl_attr_force_inline void unbind(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        this->_matrix[major_id][minor_id] = incidence_type::none;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool are_bound(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        return this->_matrix[major_id][minor_id] != incidence_type::none;
+    }
+
+    // TODO: tail/head-specific variants for bind/are_bound
+
+#ifdef HGL_TESTING
+    friend struct hgl_testing::test_incidence_matrix;
+#endif
+
+private:
+    enum class incidence_type : std::int8_t {
+        none = 0,      // v not in E
+        backward = -1, // v in T(E)
+        forward = 1,   // v in H(E)
+    };
+
+    template <typename P>
+    concept c_incidence_pred = std::predicate<P, incidence_type>;
+
+    static constexpr auto _are_incident_pred = [](const incidence_type t) { return t != incidence_type::none; };
+
+    using matrix_row_type = std::vector<incidence_type>;
+    using hypergraph_storage_type = std::vector<matrix_row_type>;
+
+    gl_attr_force_inline void _add_major(const types::size_type n) noexcept {
+        this->_matrix.resize(
+            this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, incidence_type::none)
+        );
+    }
+
+    void _add_minor(const types::size_type n) noexcept {
+        this->_matrix_row_size += n;
+        for (auto& row : this->_matrix)
+            row.resize(this->_matrix_row_size, incidence_type::none);
+    }
+
+    gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
+        this->_matrix.erase(this->_matrix.begin() + major_id);
+    }
+
+    gl_attr_force_inline void _remove_minor(const types::id_type minor_id) noexcept {
+        if (this->_matrix_row_size == 0)
+            return;
+        this->_matrix_row_size--;
+        for (auto& row : this->_matrix)
+            row.erase(row.begin() + minor_id);
+    }
+
+    [[nodiscard]] auto _incident_with_major(const types::id_type major_id) const noexcept {
+        return std::views::iota(0uz, this->_matrix_row_size)
+             | std::views::filter([&row = this->_matrix[major_id]](const types::id_type minor_id) {
+                   return incidence_matrix::_are_incident_pred(row[minor_id]);
+               });
+    }
+
+    [[nodiscard]] auto _incident_with_minor(const types::id_type minor_id) const noexcept {
+        return std::views::iota(0uz, this->_matrix.size())
+             | std::views::filter([this, minor_id](const types::id_type major_id) {
+                   return incidence_matrix::_are_incident_pred(this->_matrix[major_id][minor_id]);
+               });
+    }
+
+    [[nodiscard]] types::size_type _count_major(
+        const types::id_type major_id,
+        const c_incidence_pred auto pred = incidence_matrix::_are_incident_pred
+    ) const noexcept {
+        types::size_type count = 0;
+        for (const incidence_type t : this->_matrix[major_id])
+            count += static_cast<types::size_type>(pred(t));
+        return count;
+    }
+
+    [[nodiscard]] types::size_type _count_minor(
+        const types::id_type minor_id,
+        const c_incidence_pred auto pred = incidence_matrix::_are_incident_pred
+    ) const noexcept {
+        types::size_type count = 0;
+        for (const auto& row : this->_matrix)
+            count += static_cast<types::size_type>(pred(row[minor_id]));
         return count;
     }
 

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -165,25 +165,22 @@ private:
 
     template <impl::element_type Element>
     gl_attr_force_inline types::size_type _count(const types::id_type id) const noexcept {
+        types::size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
-            types::size_type count = 0uz;
             for (const bool bit : this->_matrix[id])
                 count += static_cast<types::size_type>(bit);
-            return count;
         }
         else { // count minor
-            types::size_type count = 0uz;
             for (const auto& row : this->_matrix)
                 count += static_cast<types::size_type>(row[id]);
-            return count;
         }
+        return count;
     }
 
     types::size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
 
-/*
 template <type_traits::c_hypergraph_layout_tag LayoutTag>
 class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
 public:
@@ -209,105 +206,80 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            this->_add_major(n);
-        else
-            this->_add_minor(n);
+        this->_add<impl::element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            this->_remove_major(vertex_id);
-        else
-            this->_remove_minor(vertex_id);
+        this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    // --- vertex methods : general incidence ---
+    // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
     ) const noexcept {
-        return this->_query_layout(vertex_id, _is_incident);
+        return this->_query<impl::element_type::vertex>(vertex_id, _is_incident);
     }
 
     [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
-        return this->_count_layout(vertex_id, _is_incident);
+        return this->_count<impl::element_type::vertex>(vertex_id, _is_incident);
     }
 
-    // --- vertex methods : outgoing incidence (vertex is tail) ---
-
-    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(const types::id_type vertex_id
     ) const noexcept {
-        return this->_query_layout(vertex_id, _is_tail);
+        return this->_query<impl::element_type::vertex>(vertex_id, _is_tail);
     }
 
     [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept {
-        return this->_count_layout(vertex_id, _is_tail);
+        return this->_count<impl::element_type::vertex>(vertex_id, _is_tail);
     }
 
-    // --- vertex methods : incoming incidence (vertex is head) ---
-
-    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(
-        const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(const types::id_type vertex_id
     ) const noexcept {
-        return this->_query_layout(vertex_id, _is_head);
+        return this->_query<impl::element_type::vertex>(vertex_id, _is_head);
     }
 
     [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept {
-        return this->_count_layout(vertex_id, _is_head);
+        return this->_count<impl::element_type::vertex>(vertex_id, _is_head);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            this->_add_major(n);
-        else
-            this->_add_minor(n);
+        this->_add<impl::element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            this->_remove_major(hyperedge_id);
-        else
-            this->_remove_minor(hyperedge_id);
+        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    // --- hyperedge methods : general incidence ---
+    // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
     ) const noexcept {
-        return this->_query_layout(hyperedge_id, _is_incident);
+        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const noexcept {
-        return this->_count_layout(hyperedge_id, _is_incident);
-    }
-
-    // --- hyperedge methods : tail incidence ---
-
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(
-        const types::id_type hyperedge_id
+    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
     ) const noexcept {
-        return this->_query_layout(hyperedge_id, _is_tail);
+        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
     [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept {
-        return this->_count_layout(hyperedge_id, _is_tail);
+        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
-    // --- hyperedge methods : head incidence ---
-
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
     ) const noexcept {
-        return this->_query_layout(hyperedge_id, _is_head);
+        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
     [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept {
-        return this->_count_layout(hyperedge_id, _is_head);
+        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
     // --- binding methods ---
@@ -362,122 +334,90 @@ private:
     // --- incidence utility ---
 
     enum class incidence_type : std::int8_t {
-        none = 0,      // v not in E
-        backward = -1, // v in T(E) (Tail/Source)
-        forward = 1,   // v in H(E) (Head/Destination)
+        none = 0, // v not in E
+        backward = -1, // v in Tail(E)
+        forward = 1, // v in Head(E)
     };
 
-    static constexpr auto _is_incident = [](const incidence_type t) { return t != incidence_type::none; };
-    static constexpr auto _is_tail = [](const incidence_type t) { return t == incidence_type::backward; };
-    static constexpr auto _is_head = [](const incidence_type t) { return t == incidence_type::forward; };
+    static constexpr auto _is_incident = [](const incidence_type t) {
+        return t != incidence_type::none;
+    };
+    static constexpr auto _is_tail = [](const incidence_type t) {
+        return t == incidence_type::backward;
+    };
+    static constexpr auto _is_head = [](const incidence_type t) {
+        return t == incidence_type::forward;
+    };
 
     // --- storage management ---
 
     using matrix_row_type = std::vector<incidence_type>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    gl_attr_force_inline void _add_major(const types::size_type n) noexcept {
-        this->_matrix.resize(
-            this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, incidence_type::none)
-        );
-    }
-
-    void _add_minor(const types::size_type n) noexcept {
-        this->_matrix_row_size += n;
-        for (auto& row : this->_matrix)
-            row.resize(this->_matrix_row_size, incidence_type::none);
-    }
-
-    gl_attr_force_inline void _remove_major(const types::id_type major_id) noexcept {
-        this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(major_id));
-    }
-
-    gl_attr_force_inline void _remove_minor(const types::id_type minor_id) noexcept {
-        if (this->_matrix_row_size == 0uz)
-            return;
-        this->_matrix_row_size--;
-        for (auto& row : this->_matrix) {
-            row.erase(row.begin() + static_cast<std::ptrdiff_t>(minor_id));
+    template <impl::element_type Element>
+    void _add(const types::size_type n) noexcept {
+        if constexpr (Element == layout_tag::major_element) { // add major
+            this->_matrix.resize(
+                this->_matrix.size() + n,
+                matrix_row_type(this->_matrix_row_size, incidence_type::none)
+            );
+        }
+        else { // add minor
+            this->_matrix_row_size += n;
+            for (auto& row : this->_matrix)
+                row.resize(this->_matrix_row_size, incidence_type::none);
         }
     }
 
-    [[nodiscard]] auto _query_major(
-        const types::id_type major_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        return std::views::iota(0uz, this->_matrix_row_size)
-             | std::views::filter([&row = this->_matrix[major_id], pred](const types::id_type minor_id) {
-                   return pred(row[minor_id]);
-               });
+    template <impl::element_type Element>
+    void _remove(const types::id_type id) noexcept {
+        if constexpr (Element == layout_tag::major_element) { // remove major
+            this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
+        }
+        else { // remove minor
+            if (this->_matrix_row_size == 0uz)
+                return;
+            this->_matrix_row_size--;
+            for (auto& row : this->_matrix)
+                row.erase(row.begin() + static_cast<std::ptrdiff_t>(id));
+        }
     }
 
-    [[nodiscard]] auto _query_minor(
-        const types::id_type minor_id, std::predicate<incidence_type> auto&& pred
+    template <impl::element_type Element>
+    [[nodiscard]] gl_attr_force_inline auto _query(
+        const types::id_type id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
-        return std::views::iota(0uz, this->_matrix.size())
-             | std::views::filter([this, minor_id, pred](const types::id_type major_id) {
-                   return pred(this->_matrix[major_id][minor_id]);
-               });
+        if constexpr (Element == layout_tag::major_element) { // query major
+            return std::views::iota(0uz, this->_matrix_row_size)
+                 | std::views::filter([&row = this->_matrix[id], pred](const types::id_type minor_id
+                                      ) { return pred(row[minor_id]); });
+        }
+        else { // query minor
+            return std::views::iota(0uz, this->_matrix.size())
+                 | std::views::filter([this, minor_id = id, pred](const types::id_type major_id) {
+                       return pred(this->_matrix[major_id][minor_id]);
+                   });
+        }
     }
 
-    [[nodiscard]] types::size_type _count_major(
-        const types::id_type major_id, std::predicate<incidence_type> auto&& pred
+    template <impl::element_type Element>
+    [[nodiscard]] gl_attr_force_inline types::size_type _count(
+        const types::id_type id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
         types::size_type count = 0uz;
-        for (const incidence_type t : this->_matrix[major_id])
-            count += static_cast<types::size_type>(pred(t));
+        if constexpr (Element == layout_tag::major_element) { // count major
+            for (const incidence_type t : this->_matrix[id])
+                count += static_cast<types::size_type>(pred(t));
+        }
+        else { // count minor
+            for (const auto& row : this->_matrix)
+                count += static_cast<types::size_type>(pred(row[id]));
+        }
         return count;
-    }
-
-    [[nodiscard]] types::size_type _count_minor(
-        const types::id_type minor_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        types::size_type count = 0uz;
-        for (const auto& row : this->_matrix)
-            count += static_cast<types::size_type>(pred(row[minor_id]));
-        return count;
-    }
-
-    // --- vertex/hyperedge-specific helpers ---
-
-    [[nodiscard]] gl_attr_force_inline auto _query_hyperedges(
-        const types::id_type vertex_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_query_major(vertex_id, std::forward(pred));
-        else
-            return this->_query_minor(vertex_id, std::forward(pred));
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto _query_vertices(
-        const types::id_type hyperedge_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_query_major(hyperedge_id, std::forward(pred));
-        else
-            return this->_query_minor(hyperedge_id, std::forward(pred));
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::size_type _count_hyperedges(
-        const types::id_type vertex_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::vertex_major_t>)
-            return this->_count_major(vertex_id, std::forward(pred));
-        else
-            return this->_count_minor(vertex_id, std::forward(pred));
-    }
-
-    [[nodiscard]] gl_attr_force_inline types::size_type _count_vertices(
-        const types::id_type hyperedge_id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        if constexpr (std::same_as<layout_tag, impl::hyperedge_major_t>)
-            return this->_count_major(hyperedge_id, std::forward(pred));
-        else
-            return this->_count_minor(hyperedge_id, std::forward(pred));
     }
 
     types::size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
-*/
 
 } // namespace hgl::impl

--- a/include/hgl/impl/layout_tags.hpp
+++ b/include/hgl/impl/layout_tags.hpp
@@ -13,7 +13,6 @@ namespace hgl {
 
 namespace impl {
 
-// element_discriminator ?
 enum class element_type : bool { vertex, hyperedge };
 
 struct vertex_major_t {

--- a/include/hgl/impl/layout_tags.hpp
+++ b/include/hgl/impl/layout_tags.hpp
@@ -13,7 +13,13 @@ namespace hgl {
 
 namespace impl {
 
+// element_discriminator ?
+enum class element_type : bool { vertex, hyperedge };
+
 struct vertex_major_t {
+    static constexpr element_type major_element = element_type::vertex;
+    static constexpr element_type minor_element = element_type::hyperedge;
+
     template <std::regular T>
     [[nodiscard]] static constexpr T major(const T& vertex_el, const T& hyperedge_el) noexcept {
         return vertex_el;
@@ -33,6 +39,9 @@ struct vertex_major_t {
 };
 
 struct hyperedge_major_t {
+    static constexpr element_type major_element = element_type::hyperedge;
+    static constexpr element_type minor_element = element_type::vertex;
+
     template <std::regular T>
     [[nodiscard]] static constexpr T major(const T& vertex_el, const T& hyperedge_el) noexcept {
         return hyperedge_el;

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -44,16 +44,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("a hypergraph should be initialized with no vertices and no hyperedges by default") {
         sut_type sut{};
-        CHECK_EQ(sut.n_vertices(), 0uz);
-        CHECK_EQ(sut.n_hyperedges(), 0uz);
+        CHECK_EQ(sut.order(), 0uz);
+        CHECK_EQ(sut.size(), 0uz);
     }
 
     SUBCASE("a hypergraph constructed with n_vertices parameter should contain n_vertices vertices "
             "and no hyperedges") {
         sut_type sut{constants::n_vertices};
 
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
-        REQUIRE_EQ(sut.n_hyperedges(), 0uz);
+        REQUIRE_EQ(sut.order(), constants::n_vertices);
+        REQUIRE_EQ(sut.size(), 0uz);
 
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
@@ -67,8 +67,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             "n_vertices vertices and n_hyperedges hyperedges") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
-        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.order(), constants::n_vertices);
+        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
 
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
@@ -92,11 +92,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (gl::types::id_type v_id = 0uz; v_id < constants::n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
-            CHECK_EQ(sut.n_vertices(), v_id + 1uz);
+            CHECK_EQ(sut.order(), v_id + 1uz);
             CHECK_EQ(sut.degree(v_id), 0uz);
         }
 
-        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
+        CHECK_EQ(sut.order(), constants::n_vertices);
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
@@ -105,7 +105,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::p_true);
-        REQUIRE_EQ(sut.n_vertices(), 1uz);
+        REQUIRE_EQ(sut.order(), 1uz);
 
         CHECK_EQ(vertex.id(), constants::id1);
         CHECK_EQ(vertex.properties(), constants::p_true);
@@ -116,8 +116,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{};
         sut.add_vertices(constants::n_vertices);
 
-        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
-        CHECK_EQ(sut.n_hyperedges(), 0uz);
+        CHECK_EQ(sut.order(), constants::n_vertices);
+        CHECK_EQ(sut.size(), 0uz);
     }
 
     SUBCASE("add_vertices_with should add new vertices to the hypergraph with the given properties"
@@ -133,8 +133,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut.add_vertices_with(properties_list);
 
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
-        CHECK_EQ(sut.n_hyperedges(), 0uz);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
+        CHECK_EQ(sut.size(), 0uz);
 
         CHECK(rng::equal(sut.vertices(), properties_list, rng::equal_to{}, [](const auto vertex) {
             return vertex.properties();
@@ -166,10 +166,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_vertex(vertex) should do nothing if the given vertex is invalid") {
         sut_type sut{constants::n_vertices};
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
+        REQUIRE_EQ(sut.order(), constants::n_vertices);
 
         CHECK_NOTHROW(sut.remove_vertex(vertex_type{constants::out_of_rng_vid}));
-        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
+        CHECK_EQ(sut.order(), constants::n_vertices);
     }
 
     SUBCASE("remove_vertex(vertex) should remove the given vertex and align ids of remaining "
@@ -177,7 +177,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{constants::n_vertices};
         sut.remove_vertex(constants::id1);
 
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
+        REQUIRE_EQ(sut.order(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
@@ -185,10 +185,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_vertex(id) should do nothing if the given id is invalid") {
         sut_type sut{constants::n_vertices};
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
+        REQUIRE_EQ(sut.order(), constants::n_vertices);
 
         CHECK_NOTHROW(sut.remove_vertex(constants::out_of_rng_vid));
-        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
+        CHECK_EQ(sut.order(), constants::n_vertices);
     }
 
     SUBCASE("remove_vertex(id) should remove the given vertex and align ids of remaining vertices"
@@ -196,7 +196,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{constants::n_vertices};
         sut.remove_vertex(constants::id1);
 
-        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
+        REQUIRE_EQ(sut.order(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
@@ -212,7 +212,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
     }
 
     SUBCASE("remove_vertices_from(vertices) should properly remove elements at given indices "
@@ -225,7 +225,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
     }
 
     // --- hyperedge method tests ---
@@ -236,10 +236,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (gl::types::id_type e_id = 0uz; e_id < constants::n_hyperedges; e_id++) {
             const auto hyperedge = sut.add_hyperedge();
             CHECK_EQ(hyperedge.id(), e_id);
-            CHECK_EQ(sut.n_hyperedges(), e_id + 1uz);
+            CHECK_EQ(sut.size(), e_id + 1uz);
         }
 
-        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        CHECK_EQ(sut.size(), constants::n_hyperedges);
     }
 
     SUBCASE("add_hyperedge_with should initialize a new hyperedge with the input properties "
@@ -249,7 +249,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto hyperedge = sut.add_hyperedge_with(constants::p_true);
-        REQUIRE_EQ(sut.n_hyperedges(), 1uz);
+        REQUIRE_EQ(sut.size(), 1uz);
 
         CHECK_EQ(hyperedge.id(), constants::id1);
         CHECK_EQ(hyperedge.properties(), constants::p_true);
@@ -259,8 +259,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{};
         sut.add_hyperedges(constants::n_hyperedges);
 
-        CHECK_EQ(sut.n_vertices(), 0uz);
-        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        CHECK_EQ(sut.order(), 0uz);
+        CHECK_EQ(sut.size(), constants::n_hyperedges);
     }
 
     SUBCASE("add_hyperedges_with should add new hyperedges to the hypergraph with the given "
@@ -276,8 +276,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut.add_hyperedges_with(properties_list);
 
-        REQUIRE_EQ(sut.n_vertices(), 0uz);
-        CHECK_EQ(sut.n_hyperedges(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.order(), 0uz);
+        CHECK_EQ(sut.size(), expected_n_hyperedges);
 
         CHECK(rng::equal(
             sut.hyperedges(),
@@ -312,10 +312,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_hyperedge(hyperedge) should do nothing if the given hyperedge is invalid") {
         sut_type sut{0uz, constants::n_hyperedges};
-        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
 
         CHECK_NOTHROW(sut.remove_hyperedge(hyperedge_type{constants::out_of_rng_eid}));
-        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        CHECK_EQ(sut.size(), constants::n_hyperedges);
     }
 
     SUBCASE("remove_hyperedge(hyperedge) should remove the given hyperedge and align ids of "
@@ -323,7 +323,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{0uz, constants::n_hyperedges};
         sut.remove_hyperedge(constants::id1);
 
-        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
+        REQUIRE_EQ(sut.size(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
@@ -331,10 +331,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_hyperedge(id) should do nothing if the given id is invalid") {
         sut_type sut{0uz, constants::n_hyperedges};
-        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
 
         CHECK_NOTHROW(sut.remove_hyperedge(constants::out_of_rng_eid));
-        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
+        CHECK_EQ(sut.size(), constants::n_hyperedges);
     }
 
     SUBCASE("remove_hyperedge(id) should remove the given hyperedge and align ids of remaining "
@@ -342,7 +342,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{0uz, constants::n_hyperedges};
         sut.remove_hyperedge(constants::id1);
 
-        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
+        REQUIRE_EQ(sut.size(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
@@ -358,7 +358,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
-        REQUIRE_EQ(sut.n_hyperedges(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.size(), expected_n_hyperedges);
     }
 
     SUBCASE("remove_hyperedges_from(hyperedges) should properly remove elements at given indices "
@@ -371,7 +371,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_hyperedges_from(std::vector<hyperedge_type>{he1, he3, he1});
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
-        REQUIRE_EQ(sut.n_hyperedges(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.size(), expected_n_hyperedges);
     }
 
     // --- incidence method tests ---

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -18,10 +18,15 @@ struct test_incidence_matrix {
     }
 
     template <typename IncidenceMatrix>
-    using incidence_descriptor_type = std::conditional_t<
-        std::same_as<typename IncidenceMatrix::directional_tag, hgl::bf_directed_t>,
-        typename IncidenceMatrix::incidence_type,
-        bool>;
+    struct incidence_descriptor {
+        using type = std::conditional_t<
+            std::same_as<typename IncidenceMatrix::directional_tag, hgl::bf_directed_t>,
+            typename IncidenceMatrix::incidence_type,
+            bool>;
+    };
+
+    template <typename IncidenceMatrix>
+    using incidence_descriptor_type = typename incidence_descriptor<IncidenceMatrix>::type;
 };
 
 struct test_undirected_vertex_major_incidence_matrix : public test_incidence_matrix {

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <ranges>
 #include <vector>
-#include <iostream>
 
 namespace hgl_testing {
 
@@ -579,36 +578,6 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.are_bound(constants::id2, constants::id1));
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     template <typename SutType>
     auto is_incident_pred() {
@@ -616,37 +585,28 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
         return [](const incidence_type t) { return t != incidence_type::none; };
     }
 
-    void print_matrix(auto& sut) {
-        for (const auto& [i, row] : std::views::enumerate(matrix(sut))) {
-            std::cout << i << ":";
-            for (const auto t : row)
-                std::cout << " " << static_cast<int>(t);
-            std::cout << std::endl;
-        }
-    }
-
-    auto altbind_to_vertex(auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges) {
+    auto altbind_to_vertex(
+        auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges
+    ) {
         std::vector<hgl::types::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
                 sut.bind_tail(vertex_id, i);
                 tail_bound.push_back(i);
-                // std::cout << "bind_tail(" << vertex_id << ", " << i << ")\n";
-                // print_matrix(sut);
             }
             else {
                 sut.bind_head(vertex_id, i);
                 head_bound.push_back(i);
-                // std::cout << "bind_head(" << vertex_id << ", " << i << ")\n";
-                // print_matrix(sut);
             }
         }
 
         return std::make_pair(std::move(tail_bound), std::move(head_bound));
     }
 
-    auto altbind_to_hyperedge(auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices) {
+    auto altbind_to_hyperedge(
+        auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices
+    ) {
         std::vector<hgl::types::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
@@ -770,7 +730,8 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
 
-    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] =
+        altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
     CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
@@ -788,7 +749,8 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE_EQ(sut.degree(vertex_id), 0uz);
 
-    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] =
+        altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
     CHECK_EQ(sut.out_degree(vertex_id), tail_bound_hyperedges.size());
@@ -889,7 +851,8 @@ TEST_CASE_FIXTURE(
     constexpr auto hyperedge_id = constants::id1;
     REQUIRE(std::ranges::empty(sut.incident_vertices(hyperedge_id)));
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+    const auto [tail_bound_vertices, head_bound_vertices] =
+        altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
     CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
@@ -907,7 +870,8 @@ TEST_CASE_FIXTURE(
     constexpr auto hyperedge_id = constants::id1;
     REQUIRE_EQ(sut.hyperedge_size(hyperedge_id), 0uz);
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+    const auto [tail_bound_vertices, head_bound_vertices] =
+        altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK_EQ(sut.hyperedge_size(hyperedge_id), constants::n_vertices);
     CHECK_EQ(sut.tail_size(hyperedge_id), tail_bound_vertices.size());
@@ -915,7 +879,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_vertex_major_incidence_matrix, "bind_tail should set the corresponding matrix entry to backward incidence"
+    test_bf_directed_vertex_major_incidence_matrix,
+    "bind_tail should set the corresponding matrix entry to backward incidence"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
@@ -931,7 +896,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_vertex_major_incidence_matrix, "bind_head should set the corresponding matrix entry to forward incidence"
+    test_bf_directed_vertex_major_incidence_matrix,
+    "bind_head should set the corresponding matrix entry to forward incidence"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
@@ -972,7 +938,8 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
-    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is set to a valid, matching incidence type"
+    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is "
+    "set to a valid, matching incidence type"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -992,7 +959,8 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.is_head(constants::id3, constants::id1));
 }
 
-struct test_bf_directed_hyperedge_major_incidence_matrix : public test_bf_directed_incidence_matrix {
+struct test_bf_directed_hyperedge_major_incidence_matrix
+: public test_bf_directed_incidence_matrix {
     using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::hyperedge_major_t>;
     using incidence_type = incidence_descriptor_type<sut_type>;
 };
@@ -1112,7 +1080,8 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
 
-    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] =
+        altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
     CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
@@ -1130,7 +1099,8 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE_EQ(sut.degree(vertex_id), 0uz);
 
-    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] =
+        altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
     CHECK_EQ(sut.out_degree(vertex_id), tail_bound_hyperedges.size());
@@ -1138,7 +1108,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_hyperedge_major_incidence_matrix, "add_hyperedges should properly extend matrix"
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "add_hyperedges should properly extend matrix"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     const auto initial_size = matrix(sut).size();
@@ -1217,7 +1188,8 @@ TEST_CASE_FIXTURE(
     constexpr auto hyperedge_id = constants::id1;
     REQUIRE(std::ranges::empty(sut.incident_vertices(hyperedge_id)));
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+    const auto [tail_bound_vertices, head_bound_vertices] =
+        altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
     CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
@@ -1235,7 +1207,8 @@ TEST_CASE_FIXTURE(
     constexpr auto hyperedge_id = constants::id1;
     REQUIRE_EQ(sut.hyperedge_size(hyperedge_id), 0uz);
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+    const auto [tail_bound_vertices, head_bound_vertices] =
+        altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK_EQ(sut.hyperedge_size(hyperedge_id), constants::n_vertices);
     CHECK_EQ(sut.tail_size(hyperedge_id), tail_bound_vertices.size());
@@ -1243,7 +1216,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_vertex_major_incidence_matrix, "bind_tail should set the corresponding matrix entry to backward incidence"
+    test_bf_directed_vertex_major_incidence_matrix,
+    "bind_tail should set the corresponding matrix entry to backward incidence"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
@@ -1259,7 +1233,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_vertex_major_incidence_matrix, "bind_head should set the corresponding matrix entry to forward incidence"
+    test_bf_directed_vertex_major_incidence_matrix,
+    "bind_head should set the corresponding matrix entry to forward incidence"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
@@ -1300,7 +1275,8 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
-    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is set to a valid, matching incidence type"
+    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is "
+    "set to a valid, matching incidence type"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -610,22 +610,13 @@ TEST_CASE_FIXTURE(
 
 
 struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
-    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
-    using incidence_type = incidence_descriptor_type<sut_type>;
-
+    template <typename SutType>
     auto is_incident_pred() {
+        using incidence_type = incidence_descriptor_type<SutType>;
         return [](const incidence_type t) { return t != incidence_type::none; };
     }
 
-    auto is_tail_pred() {
-        return [](const incidence_type t) { return t == incidence_type::backward; };
-    }
-
-    auto is_head_pred() {
-        return [](const incidence_type t) { return t == incidence_type::forward; };
-    }
-
-    void print_matrix(sut_type& sut) {
+    void print_matrix(auto& sut) {
         for (const auto& [i, row] : std::views::enumerate(matrix(sut))) {
             std::cout << i << ":";
             for (const auto t : row)
@@ -634,7 +625,7 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
         }
     }
 
-    auto altbind_to_vertex(sut_type& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges) {
+    auto altbind_to_vertex(auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges) {
         std::vector<hgl::types::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
@@ -655,17 +646,28 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
         return std::make_pair(std::move(tail_bound), std::move(head_bound));
     }
 
-    void altbind_to_hyperedge(sut_type& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices) {
+    auto altbind_to_hyperedge(auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices) {
+        std::vector<hgl::types::id_type> tail_bound, head_bound;
+
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
-            if (i % 2 == 0)
+            if (i % 2 == 0) {
                 sut.bind_tail(i, hyperedge_id);
-            else
+                tail_bound.push_back(i);
+            }
+            else {
                 sut.bind_head(i, hyperedge_id);
+                head_bound.push_back(i);
+            }
         }
+
+        return std::make_pair(std::move(tail_bound), std::move(head_bound));
     }
 };
 
-struct test_bf_directed_vertex_major_incidence_matrix : public test_bf_directed_incidence_matrix {};
+struct test_bf_directed_vertex_major_incidence_matrix : public test_bf_directed_incidence_matrix {
+    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
+    using incidence_type = incidence_descriptor_type<sut_type>;
+};
 
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix, "should initialize empty matrix by default"
@@ -684,7 +686,7 @@ TEST_CASE_FIXTURE(
         return row.size() == constants::n_hyperedges;
     }));
     CHECK(std::ranges::all_of(matrix(sut), [this](const auto& row) {
-        return std::ranges::none_of(row, is_incident_pred());
+        return std::ranges::none_of(row, is_incident_pred<sut_type>());
     }));
 }
 
@@ -768,11 +770,11 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
-    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
 }
 
 TEST_CASE_FIXTURE(
@@ -786,11 +788,11 @@ TEST_CASE_FIXTURE(
     constexpr auto vertex_id = constants::id1;
     REQUIRE_EQ(sut.degree(vertex_id), 0uz);
 
-    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
-    CHECK_EQ(sut.out_degree(vertex_id), tail_bound_vertices.size());
-    CHECK_EQ(sut.in_degree(vertex_id), head_bound_vertices.size());
+    CHECK_EQ(sut.out_degree(vertex_id), tail_bound_hyperedges.size());
+    CHECK_EQ(sut.in_degree(vertex_id), head_bound_hyperedges.size());
 }
 
 TEST_CASE_FIXTURE(
@@ -878,21 +880,38 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
-    "incident_vertices should return an empty view by default"
+    "incident_vertices should return a view of the hyperedge's incident vertex ids, "
+    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-        return std::ranges::empty(sut.incident_vertices(hyperedge_id));
-    }));
+
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_vertices(hyperedge_id)));
+
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
+    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
-    test_bf_directed_vertex_major_incidence_matrix, "hyperedge_size should return 0 by default"
+    test_bf_directed_vertex_major_incidence_matrix,
+    "hyperedge_size should return the number of the hyperedge's incident vertices, "
+    "tail_size should return the number of the hyperedge's tail vertices: |T(e)|, "
+    "head_size should return the number of the hyperedge's head vertices: |H(e)|"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-        return sut.hyperedge_size(hyperedge_id) == 0uz;
-    }));
+
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE_EQ(sut.hyperedge_size(hyperedge_id), 0uz);
+
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
+
+    CHECK_EQ(sut.hyperedge_size(hyperedge_id), constants::n_vertices);
+    CHECK_EQ(sut.tail_size(hyperedge_id), tail_bound_vertices.size());
+    CHECK_EQ(sut.head_size(hyperedge_id), head_bound_vertices.size());
 }
 
 TEST_CASE_FIXTURE(
@@ -973,282 +992,333 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.is_head(constants::id3, constants::id1));
 }
 
-// struct test_undirected_hyperedge_major_incidence_matrix : public test_incidence_matrix {
-//     using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, hgl::impl::hyperedge_major_t>;
-// };
+struct test_bf_directed_hyperedge_major_incidence_matrix : public test_bf_directed_incidence_matrix {
+    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::hyperedge_major_t>;
+    using incidence_type = incidence_descriptor_type<sut_type>;
+};
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix, "should initialize empty matrix by default"
-// ) {
-//     sut_type sut{};
-//     CHECK(matrix(sut).empty());
-// }
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix, "should initialize empty matrix by default"
+) {
+    sut_type sut{};
+    CHECK(matrix(sut).empty());
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "initialization with size parameters should properly initialize the matrix"
-// ) {
-//     sut_type sut(constants::n_vertices, constants::n_hyperedges);
-//     CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
-//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
-//         return row.size() == constants::n_vertices;
-//     }));
-//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
-//         return std::ranges::none_of(row, [](bool bit) { return bit; });
-//     }));
-// }
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "initialization with size parameters should properly initialize the matrix"
+) {
+    sut_type sut(constants::n_vertices, constants::n_hyperedges);
+    CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_vertices;
+    }));
+    CHECK(std::ranges::all_of(matrix(sut), [this](const auto& row) {
+        return std::ranges::none_of(row, is_incident_pred<sut_type>());
+    }));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "add_vertices should properly extend the hypergraph matrix (resize columns)"
-// ) {
-//     sut_type sut{0uz, constants::n_hyperedges};
-//     REQUIRE_EQ(matrix(sut).size(), constants::n_hyperedges);
-//     REQUIRE(std::ranges::all_of(matrix(sut), [](const auto& row) { return row.size() == 0uz; }));
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "add_vertices should properly extend the hypergraph matrix (resize columns)"
+) {
+    sut_type sut{0uz, constants::n_hyperedges};
+    REQUIRE_EQ(matrix(sut).size(), constants::n_hyperedges);
+    REQUIRE(std::ranges::all_of(matrix(sut), [](const auto& row) { return row.size() == 0uz; }));
 
-//     sut.add_vertices(constants::n_vertices);
-//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
-//         return row.size() == constants::n_vertices;
-//     }));
-// }
+    sut.add_vertices(constants::n_vertices);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_vertices;
+    }));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "remove_vertex should properly erase the proper vertex matrix entries (column)"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "remove_vertex should properly erase the proper vertex matrix entries (column)"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-//     sut.remove_vertex(constants::id1);
+    sut.remove_vertex(constants::id1);
 
-//     CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
-//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
-//         return row.size() == constants::n_vertices - 1uz;
-//     }));
-// }
+    CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_vertices - 1uz;
+    }));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
-// ) {
-//     constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-//     constexpr hgl::types::id_type hyperedge_id = constants::id1;
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "remove_vertex should properly remove the column and implicitly shift vertex IDs"
+) {
+    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::types::id_type hyperedge_id = constants::id1;
 
-//     sut_type sut{n_vertices, n_hyperedges};
-//     sut.bind(constants::id2, hyperedge_id);
-//     sut.bind(constants::id4, hyperedge_id);
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind_tail(constants::id2, hyperedge_id);
+    sut.bind_head(constants::id4, hyperedge_id);
 
-//     hgl::types::id_type rem_vid;
-//     hgl::types::size_type expected_hyperedge_size;
-//     std::vector<hgl::types::id_type> expected_vertices;
+    hgl::types::id_type rem_vid;
+    hgl::types::size_type expected_hyperedge_size;
+    std::vector<hgl::types::id_type> expected_vertices;
 
-//     SUBCASE("not present vertex < first incident vertex") {
-//         rem_vid = constants::id1;
-//         expected_hyperedge_size = 2uz;
-//         expected_vertices = {constants::id2 - 1uz, constants::id4 - 1uz};
-//     }
+    SUBCASE("not present vertex < first incident vertex") {
+        rem_vid = constants::id1;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
 
-//     SUBCASE("present vertex = first incident vertex") {
-//         rem_vid = constants::id2;
-//         expected_hyperedge_size = 1uz;
-//         expected_vertices = {constants::id4 - 1uz};
-//     }
+    SUBCASE("present vertex = first incident vertex") {
+        rem_vid = constants::id2;
+        expected_hyperedge_size = 1uz;
+        expected_vertices = {constants::id4 - 1uz};
+    }
 
-//     SUBCASE("not present vertex > first incident vertex") {
-//         rem_vid = constants::id3;
-//         expected_hyperedge_size = 2uz;
-//         expected_vertices = {constants::id2, constants::id4 - 1uz};
-//     }
+    SUBCASE("not present vertex > first incident vertex") {
+        rem_vid = constants::id3;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2, constants::id4 - 1uz};
+    }
 
-//     SUBCASE("present vertex = last incident vertex") {
-//         rem_vid = constants::id4;
-//         expected_hyperedge_size = 1uz;
-//         expected_vertices = {constants::id2};
-//     }
+    SUBCASE("present vertex = last incident vertex") {
+        rem_vid = constants::id4;
+        expected_hyperedge_size = 1uz;
+        expected_vertices = {constants::id2};
+    }
 
-//     SUBCASE("not present vertex > last incident vertex") {
-//         rem_vid = constants::id4 + 1uz;
-//         expected_hyperedge_size = 2uz;
-//         expected_vertices = {constants::id2, constants::id4};
-//     }
+    SUBCASE("not present vertex > last incident vertex") {
+        rem_vid = constants::id4 + 1uz;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2, constants::id4};
+    }
 
-//     CAPTURE(rem_vid);
-//     CAPTURE(expected_hyperedge_size);
-//     CAPTURE(expected_vertices);
+    CAPTURE(rem_vid);
+    CAPTURE(expected_hyperedge_size);
+    CAPTURE(expected_vertices);
 
-//     sut.remove_vertex(rem_vid);
-//     CHECK_EQ(matrix(sut)[hyperedge_id].size(), n_vertices - 1uz);
-//     CHECK_EQ(sut.hyperedge_size(hyperedge_id), expected_hyperedge_size);
-//     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), expected_vertices));
-// }
+    sut.remove_vertex(rem_vid);
+    CHECK_EQ(matrix(sut)[hyperedge_id].size(), n_vertices - 1uz);
+    CHECK_EQ(sut.hyperedge_size(hyperedge_id), expected_hyperedge_size);
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), expected_vertices));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "incident_hyperedges should return a view of the vertex's incident hyperedge ids"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
+    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-//     constexpr auto vertex_id = constants::id1;
-//     REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
 
-//     for (const auto hyperedge_id : constants::hyperedge_ids_view)
-//         sut.bind(vertex_id, hyperedge_id);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
-//     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
-// }
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
+    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "degree should return the number of the vertex's incident hyperedges"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "degree should return the number of the vertex's incident hyperedges,"
+    "out_degree should return the number of the vertex's outgoing hyperedges (v in T(e)),"
+    "in_degree should return the number of the vertex's incoming hyperedges (v in H(e))"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-//     constexpr auto vertex_id = constants::id1;
-//     REQUIRE_EQ(sut.degree(vertex_id), 0uz);
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE_EQ(sut.degree(vertex_id), 0uz);
 
-//     for (const auto hyperedge_id : constants::hyperedge_ids_view)
-//         sut.bind(vertex_id, hyperedge_id);
+    const auto [tail_bound_hyperedges, head_bound_hyperedges] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
-//     CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
-// }
+    CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
+    CHECK_EQ(sut.out_degree(vertex_id), tail_bound_hyperedges.size());
+    CHECK_EQ(sut.in_degree(vertex_id), head_bound_hyperedges.size());
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix, "add_hyperedges should properly extend matrix"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-//     const auto initial_size = matrix(sut).size();
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix, "add_hyperedges should properly extend matrix"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    const auto initial_size = matrix(sut).size();
 
-//     sut.add_hyperedges(2uz);
+    sut.add_hyperedges(2uz);
 
-//     CHECK_EQ(matrix(sut).size(), initial_size + 2uz);
-//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
-//         return row.size() == constants::n_vertices;
-//     }));
-// }
+    CHECK_EQ(matrix(sut).size(), initial_size + 2uz);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_vertices;
+    }));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
-// ) {
-//     constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-//     constexpr hgl::types::id_type vertex_id = constants::id1;
+TEST_CASE_FIXTURE(
+    test_bf_directed_hyperedge_major_incidence_matrix,
+    "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
+) {
+    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::types::id_type vertex_id = constants::id1;
 
-//     sut_type sut{n_vertices, n_hyperedges};
-//     sut.bind(vertex_id, constants::id2);
-//     sut.bind(vertex_id, constants::id4);
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind_tail(vertex_id, constants::id2);
+    sut.bind_head(vertex_id, constants::id4);
 
-//     hgl::types::id_type rem_eid;
-//     hgl::types::size_type expected_vertex_degree;
-//     std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::types::id_type rem_eid;
+    hgl::types::size_type expected_vertex_degree;
+    std::vector<hgl::types::id_type> expected_hyperedges;
 
-//     SUBCASE("not present hyperedge < first incident hyperedge") {
-//         rem_eid = constants::id1;
-//         expected_vertex_degree = 2uz;
-//         expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
-//     }
+    SUBCASE("not present hyperedge < first incident hyperedge") {
+        rem_eid = constants::id1;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
 
-//     SUBCASE("present hyperedge = first incident hyperedge") {
-//         rem_eid = constants::id2;
-//         expected_vertex_degree = 1uz;
-//         expected_hyperedges = {constants::id4 - 1uz};
-//     }
+    SUBCASE("present hyperedge = first incident hyperedge") {
+        rem_eid = constants::id2;
+        expected_vertex_degree = 1uz;
+        expected_hyperedges = {constants::id4 - 1uz};
+    }
 
-//     SUBCASE("not present hyperedge > first incident hyperedge") {
-//         rem_eid = constants::id3;
-//         expected_vertex_degree = 2uz;
-//         expected_hyperedges = {constants::id2, constants::id4 - 1uz};
-//     }
+    SUBCASE("not present hyperedge > first incident hyperedge") {
+        rem_eid = constants::id3;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2, constants::id4 - 1uz};
+    }
 
-//     SUBCASE("present hyperedge = last incident hyperedge") {
-//         rem_eid = constants::id4;
-//         expected_vertex_degree = 1uz;
-//         expected_hyperedges = {constants::id2};
-//     }
+    SUBCASE("present hyperedge = last incident hyperedge") {
+        rem_eid = constants::id4;
+        expected_vertex_degree = 1uz;
+        expected_hyperedges = {constants::id2};
+    }
 
-//     SUBCASE("not present hyperedge > last incident hyperedge") {
-//         rem_eid = constants::id4 + 1uz;
-//         expected_vertex_degree = 2uz;
-//         expected_hyperedges = {constants::id2, constants::id4};
-//     }
+    SUBCASE("not present hyperedge > last incident hyperedge") {
+        rem_eid = constants::id4 + 1uz;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2, constants::id4};
+    }
 
-//     CAPTURE(rem_eid);
-//     CAPTURE(expected_vertex_degree);
-//     CAPTURE(expected_hyperedges);
+    CAPTURE(rem_eid);
+    CAPTURE(expected_vertex_degree);
+    CAPTURE(expected_hyperedges);
 
-//     sut.remove_hyperedge(rem_eid);
-//     CHECK_EQ(matrix(sut).size(), n_hyperedges - 1uz);
-//     CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
-//     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
-// }
+    sut.remove_hyperedge(rem_eid);
+    CHECK_EQ(matrix(sut).size(), n_hyperedges - 1uz);
+    CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "incident_vertices should return an empty view by default"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-//     CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-//         return std::ranges::empty(sut.incident_vertices(hyperedge_id));
-//     }));
-// }
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "incident_vertices should return a view of the hyperedge's incident vertex ids, "
+    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix, "hyperedge_size should return 0 by default"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-//     CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-//         return sut.hyperedge_size(hyperedge_id) == 0uz;
-//     }));
-// }
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_vertices(hyperedge_id)));
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix, "bind should set the corresponding bit"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-//     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
-//     sut.bind(constants::id1, constants::id1);
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
+    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+}
 
-//     CHECK(matrix(sut)[constants::id1][constants::id1]);
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "hyperedge_size should return the number of the hyperedge's incident vertices, "
+    "tail_size should return the number of the hyperedge's tail vertices: |T(e)|, "
+    "head_size should return the number of the hyperedge's head vertices: |H(e)|"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-//     const auto vertices1 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
-//     CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
-//     CHECK_EQ(std::ranges::size(vertices1), 1uz);
-//     CHECK(std::ranges::contains(vertices1, constants::id1));
+    constexpr auto hyperedge_id = constants::id1;
+    REQUIRE_EQ(sut.hyperedge_size(hyperedge_id), 0uz);
 
-//     sut.bind(constants::id1, constants::id1);
-//     const auto vertices2 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
-//     CHECK_EQ(std::ranges::size(vertices2), 1uz);
-//     CHECK(std::ranges::equal(vertices2, vertices1));
-// }
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix, "unbind should clear the corresponding bit"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK_EQ(sut.hyperedge_size(hyperedge_id), constants::n_vertices);
+    CHECK_EQ(sut.tail_size(hyperedge_id), tail_bound_vertices.size());
+    CHECK_EQ(sut.head_size(hyperedge_id), head_bound_vertices.size());
+}
 
-//     sut.bind(constants::id1, constants::id1);
-//     REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
-//     REQUIRE(matrix(sut)[constants::id1][constants::id1] == true);
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "bind_tail should set the corresponding matrix entry to backward incidence"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
 
-//     sut.unbind(constants::id1, constants::id2);
-//     CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
+    sut.bind_tail(constants::id1, constants::id1);
 
-//     sut.unbind(constants::id1, constants::id1);
-//     CHECK(std::ranges::empty(sut.incident_vertices(constants::id1)));
-//     CHECK(matrix(sut)[constants::id1][constants::id1] == false);
-// }
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
 
-// TEST_CASE_FIXTURE(
-//     test_undirected_hyperedge_major_incidence_matrix,
-//     "are_bound should return true only when the bit is set"
-// ) {
-//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    CHECK_EQ(sut.tail_size(constants::id1), 1uz);
+    CHECK_EQ(std::ranges::size(vertices), 1uz);
+    CHECK(std::ranges::contains(vertices, constants::id1));
+}
 
-//     sut.bind(constants::id1, constants::id1);
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "bind_head should set the corresponding matrix entry to forward incidence"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
 
-//     CHECK(sut.are_bound(constants::id1, constants::id1));
-//     CHECK_FALSE(sut.are_bound(constants::id1, constants::id2));
-//     CHECK_FALSE(sut.are_bound(constants::id2, constants::id1));
-// }
+    sut.bind_head(constants::id1, constants::id1);
+
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
+
+    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    CHECK_EQ(sut.head_size(constants::id1), 1uz);
+    CHECK_EQ(std::ranges::size(vertices), 1uz);
+    CHECK(std::ranges::contains(vertices, constants::id1));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "unbind should clear the corresponding bit"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    SUBCASE("tail bound") {
+        sut.bind_tail(constants::id1, constants::id1);
+    }
+    SUBCASE("head bound") {
+        sut.bind_head(constants::id1, constants::id1);
+    }
+    CAPTURE(sut);
+
+    REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
+    REQUIRE_NE(matrix(sut)[constants::id1][constants::id1], incidence_type::none);
+
+    sut.unbind(constants::id1, constants::id2);
+    CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
+
+    sut.unbind(constants::id1, constants::id1);
+    CHECK(std::ranges::empty(sut.incident_vertices(constants::id1)));
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::none);
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is set to a valid, matching incidence type"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    sut.bind_tail(constants::id1, constants::id1);
+    sut.bind_head(constants::id2, constants::id1);
+
+    CHECK(sut.are_bound(constants::id1, constants::id1));
+    CHECK(sut.is_tail(constants::id1, constants::id1));
+    CHECK_FALSE(sut.is_head(constants::id1, constants::id1));
+
+    CHECK(sut.are_bound(constants::id2, constants::id1));
+    CHECK_FALSE(sut.is_tail(constants::id2, constants::id1));
+    CHECK(sut.is_head(constants::id2, constants::id1));
+
+    CHECK_FALSE(sut.are_bound(constants::id3, constants::id1));
+    CHECK_FALSE(sut.is_tail(constants::id3, constants::id1));
+    CHECK_FALSE(sut.is_head(constants::id3, constants::id1));
+}
 
 TEST_SUITE_END(); // test_incidence_matrix
 

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <ranges>
 #include <vector>
+#include <iostream>
 
 namespace hgl_testing {
 
@@ -16,6 +17,12 @@ struct test_incidence_matrix {
     typename IncidenceMatrix::hypergraph_storage_type& matrix(IncidenceMatrix& sut) const noexcept {
         return sut._matrix;
     }
+
+    template <typename IncidenceMatrix>
+    using incidence_descriptor_type = std::conditional_t<
+        std::same_as<typename IncidenceMatrix::directional_tag, hgl::bf_directed_t>,
+        typename IncidenceMatrix::incidence_type,
+        bool>;
 };
 
 struct test_undirected_vertex_major_incidence_matrix : public test_incidence_matrix {
@@ -44,7 +51,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_undirected_vertex_major_incidence_matrix, "add_vertices should properly extend matrix"
+    test_undirected_vertex_major_incidence_matrix, "add_vertices should properly extend the matrix"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
     const auto initial_size = matrix(sut).size();
@@ -181,45 +188,45 @@ TEST_CASE_FIXTURE(
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_heid;
+    hgl::types::id_type rem_eid;
     hgl::types::size_type expected_vertex_degree;
     std::vector<hgl::types::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
-        rem_heid = constants::id1;
+        rem_eid = constants::id1;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
     }
 
     SUBCASE("present hyperedge = first incident hyperedge") {
-        rem_heid = constants::id2;
+        rem_eid = constants::id2;
         expected_vertex_degree = 1uz;
         expected_hyperedges = {constants::id4 - 1uz};
     }
 
     SUBCASE("not present hyperedge > first incident hyperedge") {
-        rem_heid = constants::id3;
+        rem_eid = constants::id3;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2, constants::id4 - 1uz};
     }
 
     SUBCASE("present hyperedge = last incident hyperedge") {
-        rem_heid = constants::id4;
+        rem_eid = constants::id4;
         expected_vertex_degree = 1uz;
         expected_hyperedges = {constants::id2};
     }
 
     SUBCASE("not present hyperedge > last incident hyperedge") {
-        rem_heid = constants::id4 + 1uz;
+        rem_eid = constants::id4 + 1uz;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2, constants::id4};
     }
 
-    CAPTURE(rem_heid);
+    CAPTURE(rem_eid);
     CAPTURE(expected_vertex_degree);
     CAPTURE(expected_hyperedges);
 
-    sut.remove_hyperedge(rem_heid);
+    sut.remove_hyperedge(rem_eid);
     CHECK_EQ(matrix(sut)[vertex_id].size(), n_hyperedges - 1uz);
     CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
@@ -458,45 +465,45 @@ TEST_CASE_FIXTURE(
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_heid;
+    hgl::types::id_type rem_eid;
     hgl::types::size_type expected_vertex_degree;
     std::vector<hgl::types::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
-        rem_heid = constants::id1;
+        rem_eid = constants::id1;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
     }
 
     SUBCASE("present hyperedge = first incident hyperedge") {
-        rem_heid = constants::id2;
+        rem_eid = constants::id2;
         expected_vertex_degree = 1uz;
         expected_hyperedges = {constants::id4 - 1uz};
     }
 
     SUBCASE("not present hyperedge > first incident hyperedge") {
-        rem_heid = constants::id3;
+        rem_eid = constants::id3;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2, constants::id4 - 1uz};
     }
 
     SUBCASE("present hyperedge = last incident hyperedge") {
-        rem_heid = constants::id4;
+        rem_eid = constants::id4;
         expected_vertex_degree = 1uz;
         expected_hyperedges = {constants::id2};
     }
 
     SUBCASE("not present hyperedge > last incident hyperedge") {
-        rem_heid = constants::id4 + 1uz;
+        rem_eid = constants::id4 + 1uz;
         expected_vertex_degree = 2uz;
         expected_hyperedges = {constants::id2, constants::id4};
     }
 
-    CAPTURE(rem_heid);
+    CAPTURE(rem_eid);
     CAPTURE(expected_vertex_degree);
     CAPTURE(expected_hyperedges);
 
-    sut.remove_hyperedge(rem_heid);
+    sut.remove_hyperedge(rem_eid);
     CHECK_EQ(matrix(sut).size(), n_hyperedges - 1uz);
     CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
@@ -571,6 +578,677 @@ TEST_CASE_FIXTURE(
     CHECK_FALSE(sut.are_bound(constants::id1, constants::id2));
     CHECK_FALSE(sut.are_bound(constants::id2, constants::id1));
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
+    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
+    using incidence_type = incidence_descriptor_type<sut_type>;
+
+    auto is_incident_pred() {
+        return [](const incidence_type t) { return t != incidence_type::none; };
+    }
+
+    auto is_tail_pred() {
+        return [](const incidence_type t) { return t == incidence_type::backward; };
+    }
+
+    auto is_head_pred() {
+        return [](const incidence_type t) { return t == incidence_type::forward; };
+    }
+
+    void print_matrix(sut_type& sut) {
+        for (const auto& [i, row] : std::views::enumerate(matrix(sut))) {
+            std::cout << i << ":";
+            for (const auto t : row)
+                std::cout << " " << static_cast<int>(t);
+            std::cout << std::endl;
+        }
+    }
+
+    auto altbind_to_vertex(sut_type& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges) {
+        std::vector<hgl::types::id_type> tail_bound, head_bound;
+
+        for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
+            if (i % 2 == 0) {
+                sut.bind_tail(vertex_id, i);
+                tail_bound.push_back(i);
+                // std::cout << "bind_tail(" << vertex_id << ", " << i << ")\n";
+                // print_matrix(sut);
+            }
+            else {
+                sut.bind_head(vertex_id, i);
+                head_bound.push_back(i);
+                // std::cout << "bind_head(" << vertex_id << ", " << i << ")\n";
+                // print_matrix(sut);
+            }
+        }
+
+        return std::make_pair(std::move(tail_bound), std::move(head_bound));
+    }
+
+    void altbind_to_hyperedge(sut_type& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices) {
+        for (std::size_t i = 0uz; i < n_vertices; ++i) {
+            if (i % 2 == 0)
+                sut.bind_tail(i, hyperedge_id);
+            else
+                sut.bind_head(i, hyperedge_id);
+        }
+    }
+};
+
+struct test_bf_directed_vertex_major_incidence_matrix : public test_bf_directed_incidence_matrix {};
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "should initialize empty matrix by default"
+) {
+    sut_type sut{};
+    CHECK(matrix(sut).empty());
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "initialization with size parameters should properly initialize the matrix"
+) {
+    sut_type sut(constants::n_vertices, constants::n_hyperedges);
+    CHECK_EQ(matrix(sut).size(), constants::n_vertices);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_hyperedges;
+    }));
+    CHECK(std::ranges::all_of(matrix(sut), [this](const auto& row) {
+        return std::ranges::none_of(row, is_incident_pred());
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "add_vertices should properly extend the matrix"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    const auto initial_size = matrix(sut).size();
+
+    sut.add_vertices(2uz);
+
+    CHECK_EQ(matrix(sut).size(), initial_size + 2uz);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_hyperedges;
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "remove_vertex should properly remove the row and implicitly shift vertex IDs"
+) {
+    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind_tail(constants::id2, hyperedge_id);
+    sut.bind_head(constants::id4, hyperedge_id);
+
+    hgl::types::id_type rem_vid;
+    hgl::types::size_type expected_hyperedge_size;
+    std::vector<hgl::types::id_type> expected_vertices;
+
+    SUBCASE("not present vertex < first incident vertex") {
+        rem_vid = constants::id1;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present vertex = first incident vertex") {
+        rem_vid = constants::id2;
+        expected_hyperedge_size = 1uz;
+        expected_vertices = {constants::id4 - 1uz};
+    }
+
+    SUBCASE("not present vertex > first incident vertex") {
+        rem_vid = constants::id3;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present vertex = last incident vertex") {
+        rem_vid = constants::id4;
+        expected_hyperedge_size = 1uz;
+        expected_vertices = {constants::id2};
+    }
+
+    SUBCASE("not present vertex > last incident vertex") {
+        rem_vid = constants::id4 + 1uz;
+        expected_hyperedge_size = 2uz;
+        expected_vertices = {constants::id2, constants::id4};
+    }
+
+    CAPTURE(rem_vid);
+    CAPTURE(expected_hyperedge_size);
+    CAPTURE(expected_vertices);
+
+    sut.remove_vertex(rem_vid);
+    CHECK_EQ(matrix(sut).size(), n_vertices - 1uz);
+    CHECK_EQ(sut.hyperedge_size(hyperedge_id), expected_hyperedge_size);
+    CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), expected_vertices));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
+    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
+    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_vertices));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "degree should return the number of the vertex's incident hyperedges,"
+    "out_degree should return the number of the vertex's outgoing hyperedges (v in T(e)),"
+    "in_degree should return the number of the vertex's incoming hyperedges (v in H(e))"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    constexpr auto vertex_id = constants::id1;
+    REQUIRE_EQ(sut.degree(vertex_id), 0uz);
+
+    const auto [tail_bound_vertices, head_bound_vertices] = altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
+
+    CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
+    CHECK_EQ(sut.out_degree(vertex_id), tail_bound_vertices.size());
+    CHECK_EQ(sut.in_degree(vertex_id), head_bound_vertices.size());
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "add_hyperedges should properly extend the hypergraph matrix (resize columns)"
+) {
+    sut_type sut{constants::n_vertices, 0uz};
+    REQUIRE_EQ(matrix(sut).size(), constants::n_vertices);
+    REQUIRE(std::ranges::all_of(matrix(sut), [](const auto& row) { return row.size() == 0uz; }));
+
+    sut.add_hyperedges(constants::n_hyperedges);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_hyperedges;
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "remove_hyperedge should properly erase the proper hyperedge matrix entries (column)"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    sut.remove_hyperedge(constants::id1);
+
+    CHECK_EQ(matrix(sut).size(), constants::n_vertices);
+    CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+        return row.size() == constants::n_hyperedges - 1uz;
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "remove_hyperedge should properly remove the column and implicitly shift hyperedge IDs"
+) {
+    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::types::id_type vertex_id = constants::id1;
+
+    sut_type sut{n_vertices, n_hyperedges};
+    sut.bind_tail(vertex_id, constants::id2);
+    sut.bind_head(vertex_id, constants::id4);
+
+    hgl::types::id_type rem_eid;
+    hgl::types::size_type expected_vertex_degree;
+    std::vector<hgl::types::id_type> expected_hyperedges;
+
+    SUBCASE("not present hyperedge < first incident hyperedge") {
+        rem_eid = constants::id1;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present hyperedge = first incident hyperedge") {
+        rem_eid = constants::id2;
+        expected_vertex_degree = 1uz;
+        expected_hyperedges = {constants::id4 - 1uz};
+    }
+
+    SUBCASE("not present hyperedge > first incident hyperedge") {
+        rem_eid = constants::id3;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2, constants::id4 - 1uz};
+    }
+
+    SUBCASE("present hyperedge = last incident hyperedge") {
+        rem_eid = constants::id4;
+        expected_vertex_degree = 1uz;
+        expected_hyperedges = {constants::id2};
+    }
+
+    SUBCASE("not present hyperedge > last incident hyperedge") {
+        rem_eid = constants::id4 + 1uz;
+        expected_vertex_degree = 2uz;
+        expected_hyperedges = {constants::id2, constants::id4};
+    }
+
+    CAPTURE(rem_eid);
+    CAPTURE(expected_vertex_degree);
+    CAPTURE(expected_hyperedges);
+
+    sut.remove_hyperedge(rem_eid);
+    CHECK_EQ(matrix(sut)[vertex_id].size(), n_hyperedges - 1uz);
+    CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
+    CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "incident_vertices should return an empty view by default"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+        return std::ranges::empty(sut.incident_vertices(hyperedge_id));
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "hyperedge_size should return 0 by default"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+        return sut.hyperedge_size(hyperedge_id) == 0uz;
+    }));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "bind_tail should set the corresponding matrix entry to backward incidence"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
+
+    sut.bind_tail(constants::id1, constants::id1);
+
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
+
+    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    CHECK_EQ(sut.tail_size(constants::id1), 1uz);
+    CHECK_EQ(std::ranges::size(vertices), 1uz);
+    CHECK(std::ranges::contains(vertices, constants::id1));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "bind_head should set the corresponding matrix entry to forward incidence"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
+
+    sut.bind_head(constants::id1, constants::id1);
+
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
+
+    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    CHECK_EQ(sut.head_size(constants::id1), 1uz);
+    CHECK_EQ(std::ranges::size(vertices), 1uz);
+    CHECK(std::ranges::contains(vertices, constants::id1));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix, "unbind should clear the corresponding bit"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    SUBCASE("tail bound") {
+        sut.bind_tail(constants::id1, constants::id1);
+    }
+    SUBCASE("head bound") {
+        sut.bind_head(constants::id1, constants::id1);
+    }
+    CAPTURE(sut);
+
+    REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
+    REQUIRE_NE(matrix(sut)[constants::id1][constants::id1], incidence_type::none);
+
+    sut.unbind(constants::id1, constants::id2);
+    CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
+
+    sut.unbind(constants::id1, constants::id1);
+    CHECK(std::ranges::empty(sut.incident_vertices(constants::id1)));
+    CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::none);
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_matrix,
+    "are_bound, is_tail, is_head should return true only when the corresponding matrix entry is set to a valid, matching incidence type"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+    sut.bind_tail(constants::id1, constants::id1);
+    sut.bind_head(constants::id2, constants::id1);
+
+    CHECK(sut.are_bound(constants::id1, constants::id1));
+    CHECK(sut.is_tail(constants::id1, constants::id1));
+    CHECK_FALSE(sut.is_head(constants::id1, constants::id1));
+
+    CHECK(sut.are_bound(constants::id2, constants::id1));
+    CHECK_FALSE(sut.is_tail(constants::id2, constants::id1));
+    CHECK(sut.is_head(constants::id2, constants::id1));
+
+    CHECK_FALSE(sut.are_bound(constants::id3, constants::id1));
+    CHECK_FALSE(sut.is_tail(constants::id3, constants::id1));
+    CHECK_FALSE(sut.is_head(constants::id3, constants::id1));
+}
+
+// struct test_undirected_hyperedge_major_incidence_matrix : public test_incidence_matrix {
+//     using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, hgl::impl::hyperedge_major_t>;
+// };
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix, "should initialize empty matrix by default"
+// ) {
+//     sut_type sut{};
+//     CHECK(matrix(sut).empty());
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "initialization with size parameters should properly initialize the matrix"
+// ) {
+//     sut_type sut(constants::n_vertices, constants::n_hyperedges);
+//     CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
+//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+//         return row.size() == constants::n_vertices;
+//     }));
+//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+//         return std::ranges::none_of(row, [](bool bit) { return bit; });
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "add_vertices should properly extend the hypergraph matrix (resize columns)"
+// ) {
+//     sut_type sut{0uz, constants::n_hyperedges};
+//     REQUIRE_EQ(matrix(sut).size(), constants::n_hyperedges);
+//     REQUIRE(std::ranges::all_of(matrix(sut), [](const auto& row) { return row.size() == 0uz; }));
+
+//     sut.add_vertices(constants::n_vertices);
+//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+//         return row.size() == constants::n_vertices;
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "remove_vertex should properly erase the proper vertex matrix entries (column)"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+//     sut.remove_vertex(constants::id1);
+
+//     CHECK_EQ(matrix(sut).size(), constants::n_hyperedges);
+//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+//         return row.size() == constants::n_vertices - 1uz;
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
+// ) {
+//     constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+//     constexpr hgl::types::id_type hyperedge_id = constants::id1;
+
+//     sut_type sut{n_vertices, n_hyperedges};
+//     sut.bind(constants::id2, hyperedge_id);
+//     sut.bind(constants::id4, hyperedge_id);
+
+//     hgl::types::id_type rem_vid;
+//     hgl::types::size_type expected_hyperedge_size;
+//     std::vector<hgl::types::id_type> expected_vertices;
+
+//     SUBCASE("not present vertex < first incident vertex") {
+//         rem_vid = constants::id1;
+//         expected_hyperedge_size = 2uz;
+//         expected_vertices = {constants::id2 - 1uz, constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("present vertex = first incident vertex") {
+//         rem_vid = constants::id2;
+//         expected_hyperedge_size = 1uz;
+//         expected_vertices = {constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("not present vertex > first incident vertex") {
+//         rem_vid = constants::id3;
+//         expected_hyperedge_size = 2uz;
+//         expected_vertices = {constants::id2, constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("present vertex = last incident vertex") {
+//         rem_vid = constants::id4;
+//         expected_hyperedge_size = 1uz;
+//         expected_vertices = {constants::id2};
+//     }
+
+//     SUBCASE("not present vertex > last incident vertex") {
+//         rem_vid = constants::id4 + 1uz;
+//         expected_hyperedge_size = 2uz;
+//         expected_vertices = {constants::id2, constants::id4};
+//     }
+
+//     CAPTURE(rem_vid);
+//     CAPTURE(expected_hyperedge_size);
+//     CAPTURE(expected_vertices);
+
+//     sut.remove_vertex(rem_vid);
+//     CHECK_EQ(matrix(sut)[hyperedge_id].size(), n_vertices - 1uz);
+//     CHECK_EQ(sut.hyperedge_size(hyperedge_id), expected_hyperedge_size);
+//     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), expected_vertices));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "incident_hyperedges should return a view of the vertex's incident hyperedge ids"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+//     constexpr auto vertex_id = constants::id1;
+//     REQUIRE(std::ranges::empty(sut.incident_hyperedges(vertex_id)));
+
+//     for (const auto hyperedge_id : constants::hyperedge_ids_view)
+//         sut.bind(vertex_id, hyperedge_id);
+
+//     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "degree should return the number of the vertex's incident hyperedges"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+//     constexpr auto vertex_id = constants::id1;
+//     REQUIRE_EQ(sut.degree(vertex_id), 0uz);
+
+//     for (const auto hyperedge_id : constants::hyperedge_ids_view)
+//         sut.bind(vertex_id, hyperedge_id);
+
+//     CHECK_EQ(sut.degree(vertex_id), constants::n_hyperedges);
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix, "add_hyperedges should properly extend matrix"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+//     const auto initial_size = matrix(sut).size();
+
+//     sut.add_hyperedges(2uz);
+
+//     CHECK_EQ(matrix(sut).size(), initial_size + 2uz);
+//     CHECK(std::ranges::all_of(matrix(sut), [](const auto& row) {
+//         return row.size() == constants::n_vertices;
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
+// ) {
+//     constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+//     constexpr hgl::types::id_type vertex_id = constants::id1;
+
+//     sut_type sut{n_vertices, n_hyperedges};
+//     sut.bind(vertex_id, constants::id2);
+//     sut.bind(vertex_id, constants::id4);
+
+//     hgl::types::id_type rem_eid;
+//     hgl::types::size_type expected_vertex_degree;
+//     std::vector<hgl::types::id_type> expected_hyperedges;
+
+//     SUBCASE("not present hyperedge < first incident hyperedge") {
+//         rem_eid = constants::id1;
+//         expected_vertex_degree = 2uz;
+//         expected_hyperedges = {constants::id2 - 1uz, constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("present hyperedge = first incident hyperedge") {
+//         rem_eid = constants::id2;
+//         expected_vertex_degree = 1uz;
+//         expected_hyperedges = {constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("not present hyperedge > first incident hyperedge") {
+//         rem_eid = constants::id3;
+//         expected_vertex_degree = 2uz;
+//         expected_hyperedges = {constants::id2, constants::id4 - 1uz};
+//     }
+
+//     SUBCASE("present hyperedge = last incident hyperedge") {
+//         rem_eid = constants::id4;
+//         expected_vertex_degree = 1uz;
+//         expected_hyperedges = {constants::id2};
+//     }
+
+//     SUBCASE("not present hyperedge > last incident hyperedge") {
+//         rem_eid = constants::id4 + 1uz;
+//         expected_vertex_degree = 2uz;
+//         expected_hyperedges = {constants::id2, constants::id4};
+//     }
+
+//     CAPTURE(rem_eid);
+//     CAPTURE(expected_vertex_degree);
+//     CAPTURE(expected_hyperedges);
+
+//     sut.remove_hyperedge(rem_eid);
+//     CHECK_EQ(matrix(sut).size(), n_hyperedges - 1uz);
+//     CHECK_EQ(sut.degree(vertex_id), expected_vertex_degree);
+//     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), expected_hyperedges));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "incident_vertices should return an empty view by default"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+//     CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+//         return std::ranges::empty(sut.incident_vertices(hyperedge_id));
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix, "hyperedge_size should return 0 by default"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+//     CHECK(std::ranges::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+//         return sut.hyperedge_size(hyperedge_id) == 0uz;
+//     }));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix, "bind should set the corresponding bit"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+//     REQUIRE(std::ranges::empty(sut.incident_vertices(constants::id1)));
+
+//     sut.bind(constants::id1, constants::id1);
+
+//     CHECK(matrix(sut)[constants::id1][constants::id1]);
+
+//     const auto vertices1 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
+//     CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
+//     CHECK_EQ(std::ranges::size(vertices1), 1uz);
+//     CHECK(std::ranges::contains(vertices1, constants::id1));
+
+//     sut.bind(constants::id1, constants::id1);
+//     const auto vertices2 = sut.incident_vertices(constants::id1) | std::ranges::to<std::vector>();
+//     CHECK_EQ(std::ranges::size(vertices2), 1uz);
+//     CHECK(std::ranges::equal(vertices2, vertices1));
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix, "unbind should clear the corresponding bit"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+//     sut.bind(constants::id1, constants::id1);
+//     REQUIRE_EQ(sut.hyperedge_size(constants::id1), 1uz);
+//     REQUIRE(matrix(sut)[constants::id1][constants::id1] == true);
+
+//     sut.unbind(constants::id1, constants::id2);
+//     CHECK_EQ(sut.hyperedge_size(constants::id1), 1uz);
+
+//     sut.unbind(constants::id1, constants::id1);
+//     CHECK(std::ranges::empty(sut.incident_vertices(constants::id1)));
+//     CHECK(matrix(sut)[constants::id1][constants::id1] == false);
+// }
+
+// TEST_CASE_FIXTURE(
+//     test_undirected_hyperedge_major_incidence_matrix,
+//     "are_bound should return true only when the bit is set"
+// ) {
+//     sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+//     sut.bind(constants::id1, constants::id1);
+
+//     CHECK(sut.are_bound(constants::id1, constants::id1));
+//     CHECK_FALSE(sut.are_bound(constants::id1, constants::id2));
+//     CHECK_FALSE(sut.are_bound(constants::id2, constants::id1));
+// }
 
 TEST_SUITE_END(); // test_incidence_matrix
 


### PR DESCRIPTION
1. Created the `impl::incidence_matrix` class specialization for the bf-directed model, which:
- Stores a |V| x |E| incidence matrix, where each entry specifies the incidence type between a given vertex and hyperedge
- Defines the following operations:
  - Adding and removing vertices
  - Adding and removing hyperedges
  - Binding (tail/head) and unbinding vertices to hyperedges
  - Retrieving the degree, in-degree, out-degree of a vertex
  - Retrieving the set of hyperedges incident with, outgoing from, incoming to a given vertex, 
  - Retrieving the number of vertices incident with a given hyperedge and the number of hyperedge's tail/head vertices
  - Retrieving the set of vertices incident with a given hyperedge and the hyperedge's tail/head vertices
2. Refactored the inner major/minor-specific logic in the existing undirected models to generically handle these operations
3. Renamed the `n_vertices` and `n_hyperedges` methods of the `hypergraph` class to `order` and `size` respectively to follow the proper terminology