### PR TITLE
YT-CPPHGL-15: Validate bf-directed hypergraph binding operations for the incidence list model

### DIFF
--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -289,7 +289,7 @@ public:
     gl_attr_force_inline void bind_tail(
         const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
-        // TODO: validate if minor_id is not in head
+        // TODO: validate if minor_id is not in head - if yes, unbind
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_unique_insert(this->_major_storage[major_id].tail, minor_id);
     }
@@ -297,7 +297,7 @@ public:
     gl_attr_force_inline void bind_head(
         const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
-        // TODO: validate if minor_id is not in tail
+        // TODO: validate if minor_id is not in tail - if yes, unbind
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_unique_insert(this->_major_storage[major_id].head, minor_id);
     }

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -289,16 +289,16 @@ public:
     gl_attr_force_inline void bind_tail(
         const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
-        // TODO: validate if minor_id is not in head - if yes, unbind
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        this->_remove_no_align(this->_major_storage[major_id].head, minor_id);
         this->_unique_insert(this->_major_storage[major_id].tail, minor_id);
     }
 
     gl_attr_force_inline void bind_head(
         const types::id_type vertex_id, const types::id_type hyperedge_id
     ) noexcept {
-        // TODO: validate if minor_id is not in tail - if yes, unbind
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        this->_remove_no_align(this->_major_storage[major_id].tail, minor_id);
         this->_unique_insert(this->_major_storage[major_id].head, minor_id);
     }
 

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -785,6 +785,36 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_list,
+    "binding methods should rebind the elements if they are already bound"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    constexpr auto vertex_id = constants::id1, hyperedge_id = constants::id2;
+
+    REQUIRE_FALSE(sut.are_bound(vertex_id, hyperedge_id));
+    REQUIRE_FALSE(sut.is_head(vertex_id, hyperedge_id));
+    REQUIRE_FALSE(sut.is_head(vertex_id, hyperedge_id));
+
+    // initial bind
+    sut.bind_head(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_head(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_tail(vertex_id, hyperedge_id));
+
+    // rebind tail
+    sut.bind_tail(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_tail(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_head(vertex_id, hyperedge_id));
+
+    // rebind head
+    sut.bind_head(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_head(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_tail(vertex_id, hyperedge_id));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_list,
     "unbind should erase the hyperedge id from a proper vertex entry"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
@@ -1102,6 +1132,36 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(hyperedges), 1uz);
     CHECK(std::ranges::contains(hyperedges, constants::id1));
+}
+
+TEST_CASE_FIXTURE(
+    test_bf_directed_vertex_major_incidence_list,
+    "binding methods should rebind the elements if they are already bound"
+) {
+    sut_type sut{constants::n_vertices, constants::n_hyperedges};
+    constexpr auto vertex_id = constants::id1, hyperedge_id = constants::id2;
+
+    REQUIRE_FALSE(sut.are_bound(vertex_id, hyperedge_id));
+    REQUIRE_FALSE(sut.is_head(vertex_id, hyperedge_id));
+    REQUIRE_FALSE(sut.is_head(vertex_id, hyperedge_id));
+
+    // initial bind
+    sut.bind_head(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_head(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_tail(vertex_id, hyperedge_id));
+
+    // rebind tail
+    sut.bind_tail(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_tail(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_head(vertex_id, hyperedge_id));
+
+    // rebind head
+    sut.bind_head(vertex_id, hyperedge_id);
+    CHECK(sut.are_bound(vertex_id, hyperedge_id));
+    CHECK(sut.is_head(vertex_id, hyperedge_id));
+    CHECK_FALSE(sut.is_tail(vertex_id, hyperedge_id));
 }
 
 TEST_CASE_FIXTURE(


### PR DESCRIPTION
Aligned the implementation of the bf-directed incidence list model to properly rebind the given vertex and hyperedge if they are already bound in a different set