### PR TITLE
YT-CPPHGL-16: Rename the n_vertices and n_edges method to use the same terminology as the hypergraph class

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ The core of the library is the template [graph class](/docs/graph.md) which hold
 ```cpp
 #include <gl/graph.hpp>
 
-#include <iostream>
-#include <format>
+#include <print>
 
 int main() {
     // initialize the graph with 5 vertices
@@ -101,8 +100,7 @@ int main() {
     graph.add_edge(4, 3);
 
     // print the size of the graph
-    std::cout << std::format("number of vertices: {}\n", graph.order())
-              << std::format("number of edges: {}\n", graph.size());
+    std::println("number of vertices: {}\nnumber of edges: {}", graph.order(), graph.size());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ int main() {
     graph.add_edge(4, 3);
 
     // print the size of the graph
-    std::cout << std::format("number of vertices: {}\n", graph.n_vertices())
+    std::cout << std::format("number of vertices: {}\n", graph.order())
               << std::format("number of edges: {}\n", graph.n_edges());
 }
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ int main() {
 
     // print the size of the graph
     std::cout << std::format("number of vertices: {}\n", graph.order())
-              << std::format("number of edges: {}\n", graph.n_edges());
+              << std::format("number of edges: {}\n", graph.size());
 }
 ```
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -128,7 +128,7 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Returned value*: $|V|$ where $V$ is the vertex set of the graph
   - *Return type*: `types::size_type`
 
-- **`graph.n_edges() const noexcept`**:
+- **`graph.size() const noexcept`**:
   - Returns the number of edges in the graph.
   - *Returned value*: $|E|$ where $E$ is the edge set of the graph
   - *Return type*: `types::size_type`

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -129,7 +129,7 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Return type*: `types::size_type`
 
 - **`graph.size() const noexcept`**:
-  - Returns the number of edges in the graph.
+  - *Description*: Returns the number of edges in the graph.
   - *Returned value*: $|E|$ where $E$ is the edge set of the graph
   - *Return type*: `types::size_type`
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -123,7 +123,7 @@ Based on the specified traits, the `graph` class defines the following types:
 
 ### Size Operations
 
-- **`graph.n_vertices() const noexcept`**:
+- **`graph.order() const noexcept`**:
   - *Description*: Returns the total number of vertices in the graph.
   - *Returned value*: $|V|$ where $V$ is the vertex set of the graph
   - *Return type*: `types::size_type`

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -24,8 +24,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> breadth_firs
     using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
 
-    std::vector<bool> visited(graph.n_vertices(), false);
-    std::vector<types::id_type> sources(graph.n_vertices());
+    std::vector<bool> visited(graph.order(), false);
+    std::vector<types::id_type> sources(graph.order());
 
     auto pd = impl::init_return_value<ResultDiscriminator, predecessors_descriptor>(graph);
 

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -23,7 +23,7 @@ template <
     using edge_type = typename GraphType::edge_type;
 
     std::optional<bicoloring_type> coloring_opt;
-    coloring_opt.emplace(graph.n_vertices(), bin_color_value::unset);
+    coloring_opt.emplace(graph.order(), bin_color_value::unset);
     auto& coloring = coloring_opt.value();
 
     for (const auto root_id : graph.vertex_ids()) {
@@ -78,7 +78,7 @@ requires(type_traits::c_binary_color_properties_type<typename GraphType::vertex_
 bool apply_coloring(GraphType& graph, const ColorRange& color_range) {
     using color_type = typename GraphType::vertex_properties_type::color_type;
 
-    if (std::ranges::size(color_range) != graph.n_vertices())
+    if (std::ranges::size(color_range) != graph.order())
         return false;
 
     auto vertices = graph.vertices(); // store the view to extend its lifetime

--- a/include/gl/algorithm/depth_first_search.hpp
+++ b/include/gl/algorithm/depth_first_search.hpp
@@ -23,8 +23,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> depth_first_
     using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
 
-    std::vector<bool> visited(graph.n_vertices(), false);
-    std::vector<types::id_type> sources(graph.n_vertices());
+    std::vector<bool> visited(graph.order(), false);
+    std::vector<types::id_type> sources(graph.order());
 
     auto pd = impl::init_return_value<ResultDiscriminator, predecessors_descriptor>(graph);
 
@@ -70,8 +70,8 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> recursive_de
     using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
 
-    std::vector<bool> visited(graph.n_vertices(), false);
-    std::vector<types::id_type> sources(graph.n_vertices());
+    std::vector<bool> visited(graph.order(), false);
+    std::vector<types::id_type> sources(graph.order());
 
     auto pd = impl::init_return_value<ResultDiscriminator, predecessors_descriptor>(graph);
 

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -59,7 +59,7 @@ template <type_traits::c_graph GraphType>
 [[nodiscard]] gl_attr_force_inline paths_descriptor_type<GraphType> make_paths_descriptor(
     const GraphType& graph
 ) {
-    return paths_descriptor_type<GraphType>{graph.n_vertices()};
+    return paths_descriptor_type<GraphType>{graph.order()};
 }
 
 template <

--- a/include/gl/algorithm/impl/common.hpp
+++ b/include/gl/algorithm/impl/common.hpp
@@ -18,7 +18,7 @@ template <
 init_return_value(const GraphType& graph) {
     using return_type = alg_return_type_non_void<ResultDiscriminator, ReturnType>;
     if constexpr (ResultDiscriminator == algorithm::ret)
-        return return_type(graph.n_vertices());
+        return return_type(graph.order());
     else
         return return_type();
 }

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -47,7 +47,7 @@ template <type_traits::c_undirected_graph GraphType>
     using queue_type = std::priority_queue<edge_type, std::vector<edge_type>, edge_comparator>;
 
     // prepare the necessary utility
-    const auto n_vertices = graph.n_vertices();
+    const auto n_vertices = graph.order();
     mst_descriptor<GraphType> mst(n_vertices);
     std::vector<bool> visited(n_vertices, false);
     queue_type edge_queue;
@@ -96,7 +96,7 @@ requires type_traits::c_has_numeric_limits_max<types::vertex_distance_type<Graph
     using distance_type = types::vertex_distance_type<GraphType>;
 
     // Prepare the necessary utility
-    const auto n_vertices = graph.n_vertices();
+    const auto n_vertices = graph.order();
     mst_descriptor<GraphType> mst(n_vertices);
 
     std::vector<bool> in_mst(n_vertices, false);

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -25,7 +25,7 @@ template <
 
     // prepare the initial queue content (source vertices)
     std::vector<algorithm::vertex_info> source_vertex_list;
-    source_vertex_list.reserve(graph.n_vertices());
+    source_vertex_list.reserve(graph.order());
     for (const auto id : graph.vertex_ids())
         if (in_degree_map[id] == 0uz)
             source_vertex_list.emplace_back(id);
@@ -33,7 +33,7 @@ template <
     std::optional<std::vector<types::id_type>> topological_order_opt =
         std::vector<types::id_type>{};
     auto& topological_order = topological_order_opt.value();
-    topological_order.reserve(graph.n_vertices());
+    topological_order.reserve(graph.order());
 
     impl::bfs(
         graph,
@@ -55,7 +55,7 @@ template <
         post_visit
     );
 
-    if (topological_order.size() != graph.n_vertices())
+    if (topological_order.size() != graph.order())
         return std::nullopt;
 
     return topological_order_opt;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -59,7 +59,7 @@ public:
 
     // --- general methods ---
 
-    [[nodiscard]] gl_attr_force_inline types::size_type n_vertices() const noexcept {
+    [[nodiscard]] gl_attr_force_inline types::size_type order() const noexcept {
         return this->_n_vertices;
     }
 
@@ -568,7 +568,7 @@ private:
         os << std::format(
             "type: {}\nnumber of vertices: {}\nnumber of edges: {}\nvertices:\n",
             _directed_type_str(),
-            this->n_vertices(),
+            this->order(),
             this->n_edges()
         );
 
@@ -580,7 +580,7 @@ private:
     }
 
     void _concise_write(std::ostream& os) const {
-        os << std::format("{} {} {}\n", _directed_type_str(), this->n_vertices(), this->n_edges());
+        os << std::format("{} {} {}\n", _directed_type_str(), this->order(), this->n_edges());
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << " :";
@@ -600,7 +600,7 @@ private:
         os << std::format(
             "{} {} {} {} {}\n",
             static_cast<int>(type_traits::c_directed_edge<edge_type>),
-            this->n_vertices(),
+            this->order(),
             this->n_edges(),
             static_cast<int>(with_vertex_properties),
             static_cast<int>(with_edge_properties)

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -63,7 +63,7 @@ public:
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type n_edges() const noexcept {
+    [[nodiscard]] gl_attr_force_inline types::size_type size() const noexcept {
         return this->_n_edges;
     }
 
@@ -569,7 +569,7 @@ private:
             "type: {}\nnumber of vertices: {}\nnumber of edges: {}\nvertices:\n",
             _directed_type_str(),
             this->order(),
-            this->n_edges()
+            this->size()
         );
 
         for (const auto& vertex : this->vertices()) {
@@ -580,7 +580,7 @@ private:
     }
 
     void _concise_write(std::ostream& os) const {
-        os << std::format("{} {} {}\n", _directed_type_str(), this->order(), this->n_edges());
+        os << std::format("{} {} {}\n", _directed_type_str(), this->order(), this->size());
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << " :";
@@ -601,7 +601,7 @@ private:
             "{} {} {} {} {}\n",
             static_cast<int>(type_traits::c_directed_edge<edge_type>),
             this->order(),
-            this->n_edges(),
+            this->size(),
             static_cast<int>(with_vertex_properties),
             static_cast<int>(with_edge_properties)
         );

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -9,7 +9,7 @@ namespace gl_testing::io_common {
 template <gl::type_traits::c_graph GraphType>
 void verify_graph_structure(const GraphType& actual, const GraphType& expected) {
     REQUIRE_EQ(actual.order(), expected.order());
-    REQUIRE_EQ(actual.n_edges(), expected.n_edges());
+    REQUIRE_EQ(actual.size(), expected.size());
 
     // verify that the edges of the in graph are equivalent to the edges of the out graph
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -8,7 +8,7 @@ namespace gl_testing::io_common {
 
 template <gl::type_traits::c_graph GraphType>
 void verify_graph_structure(const GraphType& actual, const GraphType& expected) {
-    REQUIRE_EQ(actual.n_vertices(), expected.n_vertices());
+    REQUIRE_EQ(actual.order(), expected.order());
     REQUIRE_EQ(actual.n_edges(), expected.n_edges());
 
     // verify that the edges of the in graph are equivalent to the edges of the out graph

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -164,7 +164,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto pd = gl::algorithm::breadth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
+    REQUIRE_EQ(pd.predecessors.size(), graph.order());
     CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
 }
 

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -85,7 +85,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
                 alg_common::data_path / "bicoloring_bipartite_graph_coloring.txt";
 
             const auto coloring_values =
-                alg_common::load_list<std::uint16_t>(sut.n_vertices(), coloring_file_path);
+                alg_common::load_list<std::uint16_t>(sut.order(), coloring_file_path);
 
             std::transform(
                 coloring_values.begin(),

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -172,7 +172,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto pd = gl::algorithm::depth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
+    REQUIRE_EQ(pd.predecessors.size(), graph.order());
     CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
 }
 
@@ -356,7 +356,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         gl::algorithm::recursive_depth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pd.predecessors.size(), graph.n_vertices());
+    REQUIRE_EQ(pd.predecessors.size(), graph.order());
     CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pd)));
 }
 

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -95,12 +95,12 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path predecessors_file_path =
                 alg_common::data_path / (file_name_prefix + "predecessors.txt");
             expected_predecessors =
-                alg_common::load_list<gl::types::id_type>(sut.n_vertices(), predecessors_file_path);
+                alg_common::load_list<gl::types::id_type>(sut.order(), predecessors_file_path);
 
             const fs::path distances_file_path =
                 alg_common::data_path / (file_name_prefix + "distances.txt");
             expected_distances =
-                alg_common::load_list<distance_type>(sut.n_vertices(), distances_file_path);
+                alg_common::load_list<distance_type>(sut.order(), distances_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_mst.cpp
+++ b/tests/source/gl/test_alg_mst.cpp
@@ -46,7 +46,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
+            expected_weight = edge_weight * (sut.order() - constants::one);
         }
 
         SUBCASE("custom graph") {
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_element_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
+            const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
             const auto vertex_id_list =
                 alg_common::load_list<gl::types::id_type>(n_vertex_ids, edges_file_path);
             for (gl::types::size_type i = 0; i < n_vertex_ids; i += constants::two)
@@ -74,7 +74,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+        REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -125,11 +125,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.adjacent_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const weight_type expected_weight = sut.n_vertices() - constants::one;
+    const weight_type expected_weight = sut.order() - constants::one;
 
     const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+    REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -184,7 +184,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * (sut.n_vertices() - constants::one);
+            expected_weight = edge_weight * (sut.order() - constants::one);
         }
 
         SUBCASE("custom graph") {
@@ -194,7 +194,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_element_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.n_vertices() - constants::one) * constants::two;
+            const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
             const auto vertex_id_list =
                 alg_common::load_list<gl::types::id_type>(n_vertex_ids, edges_file_path);
             for (gl::types::size_type i = 0; i < n_vertex_ids; i += constants::two)
@@ -212,7 +212,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+        REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -263,11 +263,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.adjacent_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const weight_type expected_weight = sut.n_vertices() - constants::one;
+    const weight_type expected_weight = sut.order() - constants::one;
 
     const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - constants::one);
+    REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -57,7 +57,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path order_file_path =
                 alg_common::data_path / "topological_sort_directed_acyclic_order.txt";
             expected_topological_order =
-                alg_common::load_list<gl::types::id_type>(sut.n_vertices(), order_file_path);
+                alg_common::load_list<gl::types::id_type>(sut.order(), order_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -31,7 +31,7 @@ struct test_graph {
         const gl::types::size_type n_unique_edges_in_full_graph =
             n_incident_edges_for_fully_connected_vertex(graph) * graph.order();
 
-        REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
+        REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
     }
 
@@ -47,7 +47,7 @@ struct test_graph {
         const gl::types::size_type n_unique_edges_in_full_graph =
             (n_incident_edges_for_fully_connected_vertex(graph) * graph.order()) / 2;
 
-        REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
+        REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
     }
 
@@ -107,7 +107,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut;
 
         CHECK_EQ(sut.order(), constants::zero_elements);
-        CHECK_EQ(sut.n_edges(), constants::zero_elements);
+        CHECK_EQ(sut.size(), constants::zero_elements);
     }
 
     SUBCASE("graph constructed with n_vertices parameter should contain n_vertices vertices and no "
@@ -165,7 +165,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut.add_vertices(constants::n_elements);
 
         CHECK_EQ(sut.order(), constants::n_elements);
-        CHECK_EQ(sut.n_edges(), constants::zero_elements);
+        CHECK_EQ(sut.size(), constants::zero_elements);
     }
 
     SUBCASE("add_vertices_with should properly extend the current adjacency list with the given "
@@ -181,7 +181,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut.add_vertices_with(properties_list);
 
         REQUIRE_EQ(sut.order(), expected_n_vertices);
-        CHECK_EQ(sut.n_edges(), constants::zero_elements);
+        CHECK_EQ(sut.size(), constants::zero_elements);
 
         CHECK(std::ranges::equal(
             sut.vertices(),
@@ -370,7 +370,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
             REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
@@ -398,7 +398,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_from(vertex_1.id()));
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
@@ -417,13 +417,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         }
 
         SUBCASE("add_edges_from(ids) should throw if any id is invalid and not extend the graph") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(constants::out_of_range_element_idx, vertex_id_list{}),
                 std::out_of_range
             );
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -432,11 +432,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
         }
 
         SUBCASE("add_edges_from(ids) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             constexpr auto source_id = constants::vertex_id_1;
             const std::vector<gl::types::id_type> target_id_list{
@@ -445,7 +445,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             sut.add_edges_from(source_id, target_id_list);
 
-            REQUIRE_EQ(sut.n_edges(), constants::n_elements);
+            REQUIRE_EQ(sut.size(), constants::n_elements);
             CHECK(std::ranges::all_of(target_id_list, [&sut, source_id](const auto vertex_id) {
                 return sut.has_edge(source_id, vertex_id);
             }));
@@ -453,13 +453,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edges_from(vertices) should throw if any vertex is invalid and not extend the "
                 "graph") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(fixture.out_of_range_vertex, std::vector<vertex_type>{}),
                 std::out_of_range
             );
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -467,18 +467,18 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
         }
 
         SUBCASE("add_edges_from(vertices) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             const auto source = vertex_1;
             const std::vector<vertex_type> target_list{vertex_1, vertex_2, vertex_3};
 
             sut.add_edges_from(source, target_list);
 
-            REQUIRE_EQ(sut.n_edges(), constants::n_elements);
+            REQUIRE_EQ(sut.size(), constants::n_elements);
             CHECK(std::ranges::all_of(target_list, [&sut, &source](const auto& vertex) {
                 return sut.has_edge(source, vertex);
             }));
@@ -487,7 +487,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
             const auto added_edge = sut.add_edge(vertex_1, vertex_2);
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
@@ -497,7 +497,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
 
             adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
@@ -507,7 +507,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             const auto edge_1 = sut.add_edge(vertex_1, vertex_2);
             const auto edge_2 = sut.add_edge(vertex_2, vertex_3);
@@ -517,7 +517,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge(vertex_1, vertex_4);
 
-            REQUIRE_EQ(sut.n_edges(), constants::n_elements + constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::n_elements + constants::one_element);
 
             std::vector<edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -528,7 +528,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.n_edges(), constants::one_element);
+            CHECK_EQ(sut.size(), constants::one_element);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
@@ -568,7 +568,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
@@ -603,7 +603,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
@@ -624,7 +624,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
             const auto added_edge = sut.add_edge_with(vertex_1, vertex_2, constants::used);
 
-            REQUIRE_EQ(sut.n_edges(), constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::one_element);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
@@ -634,7 +634,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.n_edges(), constants::zero_elements);
+            CHECK_EQ(sut.size(), constants::zero_elements);
 
             adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
             adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
@@ -644,7 +644,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             const auto edge_1 = sut.add_edge_with(vertex_1, vertex_2, constants::not_used);
             const auto edge_2 = sut.add_edge_with(vertex_2, vertex_3, constants::not_used);
@@ -654,7 +654,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge_with(vertex_1, vertex_4, constants::used);
 
-            REQUIRE_EQ(sut.n_edges(), constants::n_elements + constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::n_elements + constants::one_element);
 
             const std::vector<property_edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -665,7 +665,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.n_edges(), constants::one_element);
+            CHECK_EQ(sut.size(), constants::one_element);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -29,7 +29,7 @@ struct test_graph {
                     graph.add_edge(first, second);
 
         const gl::types::size_type n_unique_edges_in_full_graph =
-            n_incident_edges_for_fully_connected_vertex(graph) * graph.n_vertices();
+            n_incident_edges_for_fully_connected_vertex(graph) * graph.order();
 
         REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
@@ -45,7 +45,7 @@ struct test_graph {
                     graph.add_edge(first, second);
 
         const gl::types::size_type n_unique_edges_in_full_graph =
-            (n_incident_edges_for_fully_connected_vertex(graph) * graph.n_vertices()) / 2;
+            (n_incident_edges_for_fully_connected_vertex(graph) * graph.order()) / 2;
 
         REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
@@ -63,7 +63,7 @@ struct test_graph {
 
     template <gl::type_traits::c_instantiation_of<gl::graph> GraphType>
     gl::types::size_type n_incident_edges_for_fully_connected_vertex(const GraphType& graph) {
-        return graph.n_vertices() - constants::one_element;
+        return graph.order() - constants::one_element;
     }
 
     const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
@@ -106,7 +106,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("graph should be initialized with no vertices and no edges by default") {
         sut_type sut;
 
-        CHECK_EQ(sut.n_vertices(), constants::zero_elements);
+        CHECK_EQ(sut.order(), constants::zero_elements);
         CHECK_EQ(sut.n_edges(), constants::zero_elements);
     }
 
@@ -142,11 +142,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         for (gl::types::id_type v_id = constants::zero_elements; v_id < target_n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
-            CHECK_EQ(sut.n_vertices(), v_id + constants::one_element);
+            CHECK_EQ(sut.order(), v_id + constants::one_element);
             CHECK(sut.adjacent_edges(v_id).empty());
         }
 
-        CHECK_EQ(sut.n_vertices(), target_n_vertices);
+        CHECK_EQ(sut.order(), target_n_vertices);
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
@@ -154,7 +154,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         gl::graph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::visited);
-        REQUIRE_EQ(sut.n_vertices(), constants::one_element);
+        REQUIRE_EQ(sut.order(), constants::one_element);
 
         CHECK_EQ(vertex.id(), constants::vertex_id_1);
         CHECK_EQ(vertex.properties(), constants::visited);
@@ -164,7 +164,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{};
         sut.add_vertices(constants::n_elements);
 
-        CHECK_EQ(sut.n_vertices(), constants::n_elements);
+        CHECK_EQ(sut.order(), constants::n_elements);
         CHECK_EQ(sut.n_edges(), constants::zero_elements);
     }
 
@@ -180,7 +180,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.add_vertices_with(properties_list);
 
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
         CHECK_EQ(sut.n_edges(), constants::zero_elements);
 
         CHECK(std::ranges::equal(
@@ -203,7 +203,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("get_vertex should throw if the given id is invalid") {
         sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(static_cast<void>(sut.get_vertex(sut.n_vertices())), std::out_of_range);
+        CHECK_THROWS_AS(static_cast<void>(sut.get_vertex(sut.order())), std::out_of_range);
     }
 
     SUBCASE("get_vertex should return a vertex with the given id") {
@@ -307,7 +307,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
 
         constexpr auto expected_n_vertices = n_vertices - constants::two;
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
 
         constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
         CHECK(std::ranges::all_of(
@@ -332,7 +332,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
         constexpr auto expected_n_vertices = n_vertices - constants::two;
-        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        REQUIRE_EQ(sut.order(), expected_n_vertices);
 
         constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
         CHECK(std::ranges::all_of(

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -27,7 +27,7 @@ void verify_graph_size(
     const gl::types::size_type expected_n_connections
 ) {
     REQUIRE_EQ(graph.order(), expected_n_vertices);
-    REQUIRE_EQ(graph.n_edges(), expected_n_connections);
+    REQUIRE_EQ(graph.size(), expected_n_connections);
 }
 
 template <gl::type_traits::c_graph GraphType>
@@ -37,9 +37,7 @@ void verify_bidir_graph_size(
     const gl::types::size_type expected_n_connections
 ) {
     REQUIRE_EQ(graph.order(), expected_n_vertices);
-    REQUIRE_EQ(
-        graph.n_edges(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections)
-    );
+    REQUIRE_EQ(graph.size(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections));
 }
 
 } // namespace
@@ -241,14 +239,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             const auto complete_bin_tree =
                 gl::topology::regular_binary_tree<graph_type>(constants::zero);
             REQUIRE_EQ(complete_bin_tree.order(), constants::zero_elements);
-            REQUIRE_EQ(complete_bin_tree.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(complete_bin_tree.size(), constants::zero_elements);
         }
 
         SUBCASE("depth = 1 : graph with one vertex and no edges") {
             const auto complete_bin_tree =
                 gl::topology::regular_binary_tree<graph_type>(constants::one);
             REQUIRE_EQ(complete_bin_tree.order(), constants::one_element);
-            REQUIRE_EQ(complete_bin_tree.n_edges(), constants::zero_elements);
+            REQUIRE_EQ(complete_bin_tree.size(), constants::zero_elements);
         }
     }
 }

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -26,7 +26,7 @@ void verify_graph_size(
     const gl::types::size_type expected_n_vertices,
     const gl::types::size_type expected_n_connections
 ) {
-    REQUIRE_EQ(graph.n_vertices(), expected_n_vertices);
+    REQUIRE_EQ(graph.order(), expected_n_vertices);
     REQUIRE_EQ(graph.n_edges(), expected_n_connections);
 }
 
@@ -36,7 +36,7 @@ void verify_bidir_graph_size(
     const gl::types::size_type expected_n_vertices,
     const gl::types::size_type expected_n_connections
 ) {
-    REQUIRE_EQ(graph.n_vertices(), expected_n_vertices);
+    REQUIRE_EQ(graph.order(), expected_n_vertices);
     REQUIRE_EQ(
         graph.n_edges(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections)
     );
@@ -84,7 +84,7 @@ template <gl::type_traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex =
-            graph.get_vertex((source.id() + constants::one_element) % graph.n_vertices());
+            graph.get_vertex((source.id() + constants::one_element) % graph.order());
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == next_vertex) == graph.has_edge(source, vertex);
@@ -97,7 +97,7 @@ template <gl::type_traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto prev_vertex = graph.get_vertex(
-            (source.id() + graph.n_vertices() - constants::one_element) % graph.n_vertices()
+            (source.id() + graph.order() - constants::one_element) % graph.order()
         );
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
@@ -111,10 +111,10 @@ template <gl::type_traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex =
-            graph.get_vertex((source.id() + constants::one_element) % graph.n_vertices());
+            graph.get_vertex((source.id() + constants::one_element) % graph.order());
 
         const auto prev_vertex = graph.get_vertex(
-            (source.id() + graph.n_vertices() - constants::one_element) % graph.n_vertices()
+            (source.id() + graph.order() - constants::one_element) % graph.order()
         );
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
@@ -130,7 +130,7 @@ template <gl::type_traits::c_graph GraphType>
     return [&graph](const vertex_type& source) {
         const auto target_ids = gl::topology::detail::get_binary_target_ids(source.id());
 
-        if (target_ids.first >= graph.n_vertices())
+        if (target_ids.first >= graph.order())
             // no need to check second as second = first + 1
             return gl::util::range_size(graph.adjacent_edges(source)) == constants::zero;
 
@@ -155,7 +155,7 @@ template <gl::type_traits::c_graph GraphType>
                 ? constants::zero
                 : (source_id - constants::one) / constants::two;
 
-        if (target_ids.first >= graph.n_vertices()) {
+        if (target_ids.first >= graph.order()) {
             // no need to check second as second = first + 1
             auto adjacent_edges = graph.adjacent_edges(source_id);
 
@@ -240,14 +240,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         SUBCASE("depth = 0 : empty graph") {
             const auto complete_bin_tree =
                 gl::topology::regular_binary_tree<graph_type>(constants::zero);
-            REQUIRE_EQ(complete_bin_tree.n_vertices(), constants::zero_elements);
+            REQUIRE_EQ(complete_bin_tree.order(), constants::zero_elements);
             REQUIRE_EQ(complete_bin_tree.n_edges(), constants::zero_elements);
         }
 
         SUBCASE("depth = 1 : graph with one vertex and no edges") {
             const auto complete_bin_tree =
                 gl::topology::regular_binary_tree<graph_type>(constants::one);
-            REQUIRE_EQ(complete_bin_tree.n_vertices(), constants::one_element);
+            REQUIRE_EQ(complete_bin_tree.order(), constants::one_element);
             REQUIRE_EQ(complete_bin_tree.n_edges(), constants::zero_elements);
         }
     }
@@ -291,7 +291,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("path(n_vertices) should build a one-way path graph of size n_vertices") {
         const auto path = gl::topology::path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.n_vertices() - constants::one_element;
+        const auto n_source_vertices = path.order() - constants::one_element;
 
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
 
@@ -304,7 +304,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("bidirectional_path(n_vertices) should build a two-way path graph of size n_vertices") {
         const auto path = gl::topology::bidirectional_path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.n_vertices() - constants::one_element;
+        const auto n_source_vertices = path.order() - constants::one_element;
 
         verify_graph_size(path, constants::n_elements_top, constants::two * n_source_vertices);
 
@@ -396,7 +396,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CAPTURE(path);
 
-        const auto n_source_vertices = path.n_vertices() - constants::one_element;
+        const auto n_source_vertices = path.order() - constants::one_element;
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
 
         const auto vertices = path.vertices();


### PR DESCRIPTION
Changed the name of the `n_vertices` method to `order` and the name of the `n_edges` method to `size` to follow the hypergraph terminology