### PR TITLE
YT-CPPHGL-17: Implement basic hypergraph converters

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -18,6 +18,9 @@ cmake --build build # -j<n>
 
 This will build the test executables `gl` (GL module tests) and `hgl` (HGL module tests) in the `<project-root>/build/tests` directory.
 
+> [!TIP]
+> Add the `-DCMAKE_EXPORT_COMPILE_COMMANDS=1` flag to the `cmake` command to generate the `compile_commands.json` file which is used by some code editors and tools for better code analysis and navigation.
+
 ### Run the tests
 
 ```shell

--- a/include/hgl/converters.hpp
+++ b/include/hgl/converters.hpp
@@ -15,7 +15,7 @@
 namespace hgl {
 
 template <type_traits::c_undirected_graph G>
-[[nodiscard]] G projection(const type_traits::c_undirected_hypergraph auto& h) noexcept {
+[[nodiscard]] G projection(const type_traits::c_undirected_hypergraph auto& h) {
     using edge_vertices = std::pair<types::id_type, types::id_type>;
     std::vector<edge_vertices> edges;
 
@@ -39,16 +39,49 @@ template <type_traits::c_undirected_graph G>
     return g;
 }
 
-template <type_traits::c_undirected_graph G>
-[[nodiscard]] G incidence_graph(const type_traits::c_undirected_hypergraph auto& h) noexcept {
-    G g{h.order() + h.size()};
+template <type_traits::c_directed_graph G>
+[[nodiscard]] G projection(const type_traits::c_bf_directed_hypergraph auto& h) {
+    G g{h.order()};
 
-    const auto get_aligned_edge_id = [shift = h.order()](const auto eid) { return eid + shift; };
+    for (const auto eid : h.hyperedge_ids()) {
+        auto sources = h.tail_vertex_ids(eid);
+        const auto targets = h.head_vertex_ids(eid) | std::ranges::to<std::vector>();
+        for (const auto vid : sources)
+            g.add_edges_from(vid, targets);
+    }
+
+    return g;
+}
+
+template <type_traits::c_undirected_graph G>
+[[nodiscard]] G incidence_graph(const type_traits::c_undirected_hypergraph auto& h) {
+    G g{h.order() + h.size()};
+    const auto align_edge_id = [shift = h.order()](const auto eid) { return eid + shift; };
+
     for (const auto vid : h.vertex_ids()) {
         const auto targets =
-            h.incident_hyperedge_ids(vid) | std::views::transform(get_aligned_edge_id)
+            h.incident_hyperedge_ids(vid) | std::views::transform(align_edge_id)
             | std::ranges::to<std::vector>();
         g.add_edges_from(vid, targets);
+    }
+
+    return g;
+}
+
+template <type_traits::c_directed_graph G>
+[[nodiscard]] G incidence_graph(const type_traits::c_bf_directed_hypergraph auto& h) {
+    G g{h.order() + h.size()};
+    const auto align_edge_id = [shift = h.order()](const auto eid) { return eid + shift; };
+
+    for (const auto vid : h.vertex_ids()) {
+        const auto targets =
+            h.out_hyperedge_ids(vid) | std::views::transform(align_edge_id)
+            | std::ranges::to<std::vector>();
+        g.add_edges_from(vid, targets);
+    }
+    for (const auto eid : h.hyperedge_ids()) {
+        const auto targets = h.head_vertex_ids(eid) | std::ranges::to<std::vector>();
+        g.add_edges_from(align_edge_id(eid), targets);
     }
 
     return g;

--- a/include/hgl/converters.hpp
+++ b/include/hgl/converters.hpp
@@ -10,28 +10,12 @@
 #include "hgl/hypergraph.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 namespace hgl {
 
-/*
-0. Common prefix: make_, to_, as_
-
-1. Clique expansion:
-- make_clique_graph
-- make_projection, project, project_as<G>
-
-2. Star expansion / bipartite representation
-- make_bipartite_graph
-- make_star_graph
-- make_incidence_graph
-- make_flow_graph (for BF hypergraphs)
-
-3. Line graph
-- make_line_graph
-*/
-
 template <type_traits::c_undirected_graph G>
-[[nodiscard]] G make_clique_graph(const type_traits::c_undirected_hypergraph auto& h) noexcept {
+[[nodiscard]] G projection(const type_traits::c_undirected_hypergraph auto& h) noexcept {
     using edge_vertices = std::pair<types::id_type, types::id_type>;
     std::vector<edge_vertices> edges;
 
@@ -52,6 +36,21 @@ template <type_traits::c_undirected_graph G>
     G g{h.order()};
     for (const auto& edge : edges)
         g.add_edge(edge.first, edge.second);
+    return g;
+}
+
+template <type_traits::c_undirected_graph G>
+[[nodiscard]] G incidence_graph(const type_traits::c_undirected_hypergraph auto& h) noexcept {
+    G g{h.order() + h.size()};
+
+    const auto get_aligned_edge_id = [shift = h.order()](const auto eid) { return eid + shift; };
+    for (const auto vid : h.vertex_ids()) {
+        const auto targets =
+            h.incident_hyperedge_ids(vid) | std::views::transform(get_aligned_edge_id)
+            | std::ranges::to<std::vector>();
+        g.add_edges_from(vid, targets);
+    }
+
     return g;
 }
 

--- a/include/hgl/converters.hpp
+++ b/include/hgl/converters.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "gl/graph.hpp"
+#include "gl/types/types.hpp"
+#include "hgl/hypergraph.hpp"
+
+#include <algorithm>
+
+namespace hgl {
+
+/*
+0. Common prefix: make_, to_, as_
+
+1. Clique expansion:
+- make_clique_graph
+- make_projection, project, project_as<G>
+
+2. Star expansion / bipartite representation
+- make_bipartite_graph
+- make_star_graph
+- make_incidence_graph
+- make_flow_graph (for BF hypergraphs)
+
+3. Line graph
+- make_line_graph
+*/
+
+template <type_traits::c_undirected_graph G>
+[[nodiscard]] G make_clique_graph(const type_traits::c_undirected_hypergraph auto& h) noexcept {
+    using edge_vertices = std::pair<types::id_type, types::id_type>;
+    std::vector<edge_vertices> edges;
+
+    for (const auto eid : h.hyperedge_ids()) {
+        const auto clique_vertices = h.incident_vertex_ids(eid) | std::ranges::to<std::vector>;
+        for (std::size_t i = 0uz; i < clique_vertices.size(); i++) {
+            for (std::size_t j = 0uz; j < i; j++) {
+                const auto [u, v] = std::minmax(clique_vertices[i], clique_vertices[j]);
+                edges.emplace_back(u, v);
+            }
+        }
+    }
+
+    std::ranges::sort(edges);
+    edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
+
+    G g{h.order()};
+    for (const auto& edge : edges)
+        g.add_edge(edge.first, edge.second);
+    return g;
+}
+
+} // namespace hgl

--- a/include/hgl/converters.hpp
+++ b/include/hgl/converters.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "gl/graph.hpp"
 #include "gl/types/types.hpp"
 #include "hgl/hypergraph.hpp"
@@ -35,7 +36,7 @@ template <type_traits::c_undirected_graph G>
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {
-        const auto clique_vertices = h.incident_vertex_ids(eid) | std::ranges::to<std::vector>;
+        const auto clique_vertices = h.incident_vertex_ids(eid) | std::ranges::to<std::vector>();
         for (std::size_t i = 0uz; i < clique_vertices.size(); i++) {
             for (std::size_t j = 0uz; j < i; j++) {
                 const auto [u, v] = std::minmax(clique_vertices[i], clique_vertices[j]);
@@ -45,7 +46,8 @@ template <type_traits::c_undirected_graph G>
     }
 
     std::ranges::sort(edges);
-    edges.erase(std::unique(edges.begin(), edges.end()), edges.end());
+    const auto rem = std::ranges::unique(edges);
+    edges.erase(rem.begin(), rem.end());
 
     G g{h.order()};
     for (const auto& edge : edges)

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -445,12 +445,13 @@ public:
         return this->incident_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto incident_hyperedge_ids(const types::id_type vertex_id) {
+    [[nodiscard]] auto incident_hyperedge_ids(const types::id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.incident_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedge_ids(const vertex_type& vertex) {
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedge_ids(const vertex_type& vertex
+    ) const {
         return this->incident_hyperedge_ids(vertex.id());
     }
 

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -542,12 +542,13 @@ public:
         return this->incident_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto incident_vertex_ids(const types::id_type hyperedge_id) {
+    [[nodiscard]] auto incident_vertex_ids(const types::id_type hyperedge_id) const {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.incident_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertex_ids(const hyperedge_type& hyperedge) {
+    [[nodiscard]] gl_attr_force_inline auto incident_vertex_ids(const hyperedge_type& hyperedge
+    ) const {
         return this->incident_vertex_ids(hyperedge.id());
     }
 
@@ -579,14 +580,14 @@ public:
         return this->tail_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto tail_vertex_ids(const types::id_type hyperedge_id)
+    [[nodiscard]] auto tail_vertex_ids(const types::id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.tail_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertex_ids(const hyperedge_type& hyperedge)
+    [[nodiscard]] gl_attr_force_inline auto tail_vertex_ids(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->tail_vertex_ids(hyperedge.id());
@@ -625,14 +626,14 @@ public:
         return this->head_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto head_vertex_ids(const types::id_type hyperedge_id)
+    [[nodiscard]] auto head_vertex_ids(const types::id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.head_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertex_ids(const hyperedge_type& hyperedge)
+    [[nodiscard]] gl_attr_force_inline auto head_vertex_ids(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->head_vertex_ids(hyperedge.id());

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -468,18 +468,26 @@ public:
         return this->_impl.degree_map(this->_n_vertices);
     }
 
-    [[nodiscard]] auto outgoing_hyperedges(const types::id_type vertex_id)
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        this->_verify_vertex_id(vertex_id);
-        return this->_impl.outgoing_hyperedges(vertex_id)
+        return this->out_hyperedge_ids(vertex_id)
              | std::views::transform(this->_create_hyperedge_descriptor());
     }
 
-    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(const vertex_type& vertex)
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const vertex_type& vertex)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->outgoing_hyperedges(vertex.id());
+        return this->out_hyperedges(vertex.id());
+    }
+
+    [[nodiscard]] auto out_hyperedge_ids(const types::id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        return this->_impl.out_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedge_ids(const vertex_type& vertex) const {
+        return this->out_hyperedge_ids(vertex.id());
     }
 
     [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const
@@ -501,18 +509,26 @@ public:
         return this->_impl.out_degree_map(this->_n_vertices);
     }
 
-    [[nodiscard]] auto incoming_hyperedges(const types::id_type vertex_id)
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        this->_verify_vertex_id(vertex_id);
-        return this->_impl.incoming_hyperedges(vertex_id)
+        return this->in_hyperedge_ids(vertex_id)
              | std::views::transform(this->_create_hyperedge_descriptor());
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(const vertex_type& vertex)
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const vertex_type& vertex)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->incoming_hyperedges(vertex.id());
+        return this->in_hyperedges(vertex.id());
+    }
+
+    [[nodiscard]] auto in_hyperedge_ids(const types::id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        return this->_impl.in_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedge_ids(const vertex_type& vertex) const {
+        return this->in_hyperedge_ids(vertex.id());
     }
 
     [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "gl/types/types.hpp"
 #include "hgl/constants.hpp"
 #include "hgl/directional_tags.hpp"
@@ -435,14 +436,22 @@ public:
         return this->is_head(vertex.id(), hyperedge.id());
     }
 
-    [[nodiscard]] auto incident_hyperedges(const types::id_type vertex_id) {
-        this->_verify_vertex_id(vertex_id);
-        return this->_impl.incident_hyperedges(vertex_id)
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id) {
+        return this->incident_hyperedge_ids(vertex_id)
              | std::views::transform(this->_create_hyperedge_descriptor());
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const vertex_type& vertex) {
         return this->incident_hyperedges(vertex.id());
+    }
+
+    [[nodiscard]] auto incident_hyperedge_ids(const types::id_type vertex_id) {
+        this->_verify_vertex_id(vertex_id);
+        return this->_impl.incident_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedge_ids(const vertex_type& vertex) {
+        return this->incident_hyperedge_ids(vertex.id());
     }
 
     [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const {
@@ -525,13 +534,21 @@ public:
     }
 
     [[nodiscard]] auto incident_vertices(const types::id_type hyperedge_id) {
-        this->_verify_hyperedge_id(hyperedge_id);
-        return this->_impl.incident_vertices(hyperedge_id)
+        return this->incident_vertex_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const hyperedge_type& hyperedge) {
         return this->incident_vertices(hyperedge.id());
+    }
+
+    [[nodiscard]] auto incident_vertex_ids(const types::id_type hyperedge_id) {
+        this->_verify_hyperedge_id(hyperedge_id);
+        return this->_impl.incident_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_vertex_ids(const hyperedge_type& hyperedge) {
+        return this->incident_vertex_ids(hyperedge.id());
     }
 
     [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const {
@@ -549,11 +566,10 @@ public:
         return this->_impl.hyperedge_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] auto tail_vertices(const types::id_type hyperedge_id)
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        this->_verify_hyperedge_id(hyperedge_id);
-        return this->_impl.tail_vertices(hyperedge_id)
+        return this->tail_vertex_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
 
@@ -561,6 +577,19 @@ public:
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->tail_vertices(hyperedge.id());
+    }
+
+    [[nodiscard]] auto tail_vertex_ids(const types::id_type hyperedge_id)
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
+        this->_verify_hyperedge_id(hyperedge_id);
+        return this->_impl.tail_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto tail_vertex_ids(const hyperedge_type& hyperedge)
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
+        return this->tail_vertex_ids(hyperedge.id());
     }
 
     [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const
@@ -583,11 +612,10 @@ public:
         return this->_impl.tail_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] auto head_vertices(const types::id_type hyperedge_id)
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        this->_verify_hyperedge_id(hyperedge_id);
-        return this->_impl.head_vertices(hyperedge_id)
+        return this->head_vertex_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
 
@@ -595,6 +623,19 @@ public:
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->head_vertices(hyperedge.id());
+    }
+
+    [[nodiscard]] auto head_vertex_ids(const types::id_type hyperedge_id)
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
+        this->_verify_hyperedge_id(hyperedge_id);
+        return this->_impl.head_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto head_vertex_ids(const hyperedge_type& hyperedge)
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
+        return this->head_vertex_ids(hyperedge.id());
     }
 
     [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -268,7 +268,7 @@ public:
         return this->_size_map<impl::element_type::vertex>(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id, &major_element_type::tail);
     }
@@ -282,7 +282,7 @@ public:
         return this->_size_map<impl::element_type::vertex>(n_vertices, &major_element_type::tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id, &major_element_type::head);
     }

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -269,7 +269,7 @@ public:
         return this->_count_map<impl::element_type::vertex>(n_vertices, _is_incident);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto outgoing_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         return this->_query<impl::element_type::vertex>(vertex_id, _is_tail);
     }
@@ -283,7 +283,7 @@ public:
         return this->_count_map<impl::element_type::vertex>(n_vertices, _is_tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incoming_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
     ) const noexcept {
         return this->_query<impl::element_type::vertex>(vertex_id, _is_head);
     }

--- a/tests/source/hgl/test_converters.cpp
+++ b/tests/source/hgl/test_converters.cpp
@@ -35,12 +35,14 @@ using add_hyperedge_property = hgl::hypergraph_traits<
 inline constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "Undirected hypergraph converters tests", HypergraphTraits, undirected_hypergraph_traits_converters_template
+    "Undirected hypergraph converters tests",
+    HypergraphTraits,
+    undirected_hypergraph_traits_converters_template
 ) {
     using sut_type = hgl::hypergraph<HypergraphTraits>;
     using graph_type = gl::graph<gl::undirected_graph_traits<>>;
 
-    SUBCASE("make_clique_graph should produce a clique for each hyperedge") {
+    SUBCASE("projection should produce a clique for each hyperedge") {
         sut_type sut{4ull, 4ull};
 
         // e0 = {0,1,2}
@@ -60,21 +62,71 @@ TEST_CASE_TEMPLATE_DEFINE(
         // e3 = {0} (should not add any edge)
         sut.bind(0ull, 3ull);
 
-        const auto clique = hgl::make_clique_graph<graph_type>(sut);
+        const auto clique = hgl::projection<graph_type>(sut);
 
         CHECK_EQ(clique.order(), sut.order());
 
         const std::vector<std::pair<gl::types::id_type, gl::types::id_type>> expected_edges{
             // e0: (0,1), (0,2), (1,2)
-            {0ull, 1ull}, {0ull, 2ull}, {1ull, 2ull}, {1ull, 3ull},
+            {0ull, 1ull},
+            {0ull, 2ull},
+            {1ull, 2ull},
+            {1ull, 3ull},
             // e1: (1,2) - exists, (1,3), (2,3)
-            {2ull, 3ull}, {0ull, 3ull},
+            {2ull, 3ull},
+            {0ull, 3ull},
             // e3: none
         };
 
         CHECK_EQ(clique.size(), expected_edges.size());
         for (const auto& [u, v] : expected_edges)
             CHECK(clique.has_edge(u, v));
+    }
+
+    SUBCASE("incidence_graph should produce a bipartite graph connecting vertices to hyperedges") {
+        sut_type sut{4ull, 4ull};
+
+        // e0 = {0,1,2}
+        sut.bind(0ull, 0ull);
+        sut.bind(1ull, 0ull);
+        sut.bind(2ull, 0ull);
+
+        // e1 = {1,2,3}
+        sut.bind(1ull, 1ull);
+        sut.bind(2ull, 1ull);
+        sut.bind(3ull, 1ull);
+
+        // e2 = {0,3}
+        sut.bind(0ull, 2ull);
+        sut.bind(3ull, 2ull);
+
+        // e3 = {0}
+        sut.bind(0ull, 3ull);
+
+        const auto incidence = hgl::incidence_graph<graph_type>(sut);
+
+        CHECK_EQ(incidence.order(), sut.order() + sut.size());
+
+        // Expected edges: vertices 0-3, hyperedges 4-7
+        const std::vector<std::pair<gl::types::id_type, gl::types::id_type>> expected_edges{
+            // e0 (4): {0,1,2}
+            {0ull, 4ull},
+            {1ull, 4ull},
+            {2ull, 4ull},
+            // e1 (5): {1,2,3}
+            {1ull, 5ull},
+            {2ull, 5ull},
+            {3ull, 5ull},
+            // e2 (6): {0,3}
+            {0ull, 6ull},
+            {3ull, 6ull},
+            // e3 (7): {0}
+            {0ull, 7ull}
+        };
+
+        CHECK_EQ(incidence.size(), expected_edges.size());
+        for (const auto& [u, v] : expected_edges)
+            CHECK(incidence.has_edge(u, v));
     }
 }
 

--- a/tests/source/hgl/test_converters.cpp
+++ b/tests/source/hgl/test_converters.cpp
@@ -1,0 +1,97 @@
+#include "hgl/converters.hpp"
+#include "hgl/hypergraph.hpp"
+
+#include <doctest.h>
+
+#include <algorithm>
+#include <concepts>
+#include <vector>
+
+namespace rng = std::ranges;
+namespace vw = std::views;
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_hypergraph");
+
+template <
+    gl::type_traits::c_instantiation_of<hgl::hypergraph_traits> HypergraphTraits,
+    gl::type_traits::c_properties VertexProperties>
+using add_vertex_property = hgl::hypergraph_traits<
+    typename HypergraphTraits::directional_tag,
+    VertexProperties,
+    typename HypergraphTraits::hyperedge_properties_type,
+    typename HypergraphTraits::implementation_tag>;
+
+template <
+    gl::type_traits::c_instantiation_of<hgl::hypergraph_traits> HypergraphTraits,
+    gl::type_traits::c_properties HyperedgeProperties>
+using add_hyperedge_property = hgl::hypergraph_traits<
+    typename HypergraphTraits::directional_tag,
+    typename HypergraphTraits::vertex_properties_type,
+    HyperedgeProperties,
+    typename HypergraphTraits::implementation_tag>;
+
+inline constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "Undirected hypergraph converters tests", HypergraphTraits, undirected_hypergraph_traits_converters_template
+) {
+    using sut_type = hgl::hypergraph<HypergraphTraits>;
+    using graph_type = gl::graph<gl::undirected_graph_traits<>>;
+
+    SUBCASE("make_clique_graph should produce a clique for each hyperedge") {
+        sut_type sut{4ull, 4ull};
+
+        // e0 = {0,1,2}
+        sut.bind(0ull, 0ull);
+        sut.bind(1ull, 0ull);
+        sut.bind(2ull, 0ull);
+
+        // e1 = {1,2,3}
+        sut.bind(1ull, 1ull);
+        sut.bind(2ull, 1ull);
+        sut.bind(3ull, 1ull);
+
+        // e2 = {0,3}
+        sut.bind(0ull, 2ull);
+        sut.bind(3ull, 2ull);
+
+        // e3 = {0} (should not add any edge)
+        sut.bind(0ull, 3ull);
+
+        const auto clique = hgl::make_clique_graph<graph_type>(sut);
+
+        CHECK_EQ(clique.order(), sut.order());
+
+        const std::vector<std::pair<gl::types::id_type, gl::types::id_type>> expected_edges{
+            // e0: (0,1), (0,2), (1,2)
+            {0ull, 1ull}, {0ull, 2ull}, {1ull, 2ull}, {1ull, 3ull},
+            // e1: (1,2) - exists, (1,3), (2,3)
+            {2ull, 3ull}, {0ull, 3ull},
+            // e3: none
+        };
+
+        CHECK_EQ(clique.size(), expected_edges.size());
+        for (const auto& [u, v] : expected_edges)
+            CHECK(clique.has_edge(u, v));
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    undirected_hypergraph_traits_converters_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t>, // vertex-major incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t> // vertex-major incidence matrix
+);
+
+} // namespace hgl_testing

--- a/tests/source/hgl/test_converters.cpp
+++ b/tests/source/hgl/test_converters.cpp
@@ -12,7 +12,7 @@ namespace vw = std::views;
 
 namespace hgl_testing {
 
-TEST_SUITE_BEGIN("test_hypergraph");
+TEST_SUITE_BEGIN("test_converters");
 
 template <
     gl::type_traits::c_instantiation_of<hgl::hypergraph_traits> HypergraphTraits,
@@ -145,5 +145,104 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::impl::vertex_major_t,
         hgl::undirected_t> // vertex-major incidence matrix
 );
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "BF-directed hypergraph converters tests",
+    HypergraphTraits,
+    bf_directed_hypergraph_traits_converters_template
+) {
+    using sut_type = hgl::hypergraph<HypergraphTraits>;
+    using graph_type = gl::graph<gl::directed_graph_traits<>>;
+
+    SUBCASE("projection should produce directed edges from tails to heads for each hyperedge") {
+        sut_type sut{4ull, 2ull};
+
+        // e0: T={0,1} -> H={2,3}
+        sut.bind_tail(0ull, 0ull);
+        sut.bind_tail(1ull, 0ull);
+        sut.bind_head(2ull, 0ull);
+        sut.bind_head(3ull, 0ull);
+
+        // e1: T={2} -> H={0,1}
+        sut.bind_tail(2ull, 1ull);
+        sut.bind_head(0ull, 1ull);
+        sut.bind_head(1ull, 1ull);
+
+        const auto proj = hgl::projection<graph_type>(sut);
+
+        CHECK_EQ(proj.order(), sut.order());
+
+        // Expected directed edges
+        const std::vector<std::pair<gl::types::id_type, gl::types::id_type>> expected_edges{
+            // e0: 0->2, 0->3, 1->2, 1->3
+            {0ull, 2ull},
+            {0ull, 3ull},
+            {1ull, 2ull},
+            {1ull, 3ull},
+            // e1: 2->0, 2->1
+            {2ull, 0ull},
+            {2ull, 1ull}
+        };
+
+        CHECK_EQ(proj.size(), expected_edges.size());
+        for (const auto& [u, v] : expected_edges)
+            CHECK(proj.has_edge(u, v));
+    }
+
+    SUBCASE("incidence_graph should produce a directed bipartite graph connecting tails to "
+            "hyperedges and hyperedges to heads") {
+        sut_type sut{4ull, 2ull};
+
+        // e0: T={0,1} -> H={2,3}
+        sut.bind_tail(0ull, 0ull);
+        sut.bind_tail(1ull, 0ull);
+        sut.bind_head(2ull, 0ull);
+        sut.bind_head(3ull, 0ull);
+
+        // e1: T={2} -> H={0,1}
+        sut.bind_tail(2ull, 1ull);
+        sut.bind_head(0ull, 1ull);
+        sut.bind_head(1ull, 1ull);
+
+        const auto incidence = hgl::incidence_graph<graph_type>(sut);
+
+        CHECK_EQ(incidence.order(), sut.order() + sut.size());
+
+        // Expected directed edges: vertices 0-3, hyperedges 4-5
+        const std::vector<std::pair<gl::types::id_type, gl::types::id_type>> expected_edges{
+            // Tails to hyperedges: 0->4, 1->4, 2->5
+            {0ull, 4ull},
+            {1ull, 4ull},
+            {2ull, 5ull},
+            // Hyperedges to heads: 4->2, 4->3, 5->0, 5->1
+            {4ull, 2ull},
+            {4ull, 3ull},
+            {5ull, 0ull},
+            {5ull, 1ull}
+        };
+
+        CHECK_EQ(incidence.size(), expected_edges.size());
+        for (const auto& [u, v] : expected_edges)
+            CHECK(incidence.has_edge(u, v));
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bf_directed_hypergraph_traits_converters_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major incidence matrix
+);
+
+TEST_SUITE_END(); // test_converters
 
 } // namespace hgl_testing

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -581,15 +581,12 @@ TEST_CASE_TEMPLATE_DEFINE(
                     CHECK_EQ(sut.degree(vertex_id), expected_hyperedges.size());
 
                     CHECK(std::ranges::equal(
-                        sut.incoming_hyperedges(vertex_id),
-                        expected_in_hyperedges,
-                        std::equal_to{},
-                        get_id
+                        sut.in_hyperedges(vertex_id), expected_in_hyperedges, std::equal_to{}, get_id
                     ));
                     CHECK_EQ(sut.in_degree(vertex_id), expected_in_hyperedges.size());
 
                     CHECK(std::ranges::equal(
-                        sut.outgoing_hyperedges(vertex_id),
+                        sut.out_hyperedges(vertex_id),
                         expected_out_hyperedges,
                         std::equal_to{},
                         get_id
@@ -626,7 +623,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 CHECK_EQ(sut.degree(vertex_id), 2uz);
 
                 CHECK(std::ranges::equal(
-                    sut.incoming_hyperedges(vertex_id),
+                    sut.in_hyperedges(vertex_id),
                     std::vector<hgl::types::id_type>{constants::id2},
                     std::equal_to{},
                     get_id
@@ -634,7 +631,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 CHECK_EQ(sut.in_degree(vertex_id), 1uz);
 
                 CHECK(std::ranges::equal(
-                    sut.outgoing_hyperedges(vertex_id),
+                    sut.out_hyperedges(vertex_id),
                     std::vector<hgl::types::id_type>{constants::id4},
                     std::equal_to{},
                     get_id
@@ -1076,14 +1073,14 @@ TEST_CASE_TEMPLATE_DEFINE(
                 ));
 
                 CHECK(std::ranges::equal(
-                    sut.incoming_hyperedges(vertex_id),
+                    sut.in_hyperedges(vertex_id),
                     expected_in_properties,
                     std::equal_to{},
                     get_property_addr
                 ));
 
                 CHECK(std::ranges::equal(
-                    sut.outgoing_hyperedges(vertex_id),
+                    sut.out_hyperedges(vertex_id),
                     expected_out_properties,
                     std::equal_to{},
                     get_property_addr
@@ -1106,7 +1103,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             ));
 
             CHECK(std::ranges::equal(
-                sut.incoming_hyperedges(vertex_id),
+                sut.in_hyperedges(vertex_id),
                 std::vector<hyperedge_properties_type*>{&sut.get_hyperedge_properties(constants::id2
                 )},
                 std::equal_to{},
@@ -1114,7 +1111,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             ));
 
             CHECK(std::ranges::equal(
-                sut.outgoing_hyperedges(vertex_id),
+                sut.out_hyperedges(vertex_id),
                 std::vector<hyperedge_properties_type*>{&sut.get_hyperedge_properties(constants::id4
                 )},
                 std::equal_to{},

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -1,9 +1,9 @@
 #include "hgl/directional_tags.hpp"
+#include "hgl/hypergraph.hpp"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
 
 #include <doctest.h>
-#include <hgl/hypergraph.hpp>
 
 #include <algorithm>
 #include <concepts>
@@ -1219,8 +1219,6 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::types::name_property> // bf-directed vertex-major incidence matrix
 );
 
-TEST_SUITE_END(); // test_hypergraph
-
 TEST_CASE_TEMPLATE_DEFINE(
     "hypergraph size utility tests", HypergraphTraits, hypergraph_traits_util_template
 ) {
@@ -1420,5 +1418,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::impl::vertex_major_t,
         hgl::bf_directed_t> // bf-directed vertex-major incidence matrix
 );
+
+TEST_SUITE_END(); // test_hypergraph
 
 } // namespace hgl_testing

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -653,8 +653,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_list,
     "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
-    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
-    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+    "out_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "in_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -667,8 +667,8 @@ TEST_CASE_FIXTURE(
     CHECK(std::ranges::is_permutation(
         sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view
     ));
-    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
-    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.out_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.in_hyperedges(vertex_id), head_bound_hyperedges));
 }
 
 TEST_CASE_FIXTURE(
@@ -1081,8 +1081,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list,
     "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
-    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
-    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+    "out_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "in_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1095,8 +1095,8 @@ TEST_CASE_FIXTURE(
     CHECK(std::ranges::is_permutation(
         sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view
     ));
-    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
-    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.out_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.in_hyperedges(vertex_id), head_bound_hyperedges));
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -773,8 +773,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
     "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
-    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
-    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+    "out_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "in_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -785,8 +785,8 @@ TEST_CASE_FIXTURE(
         altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
-    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
-    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.out_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.in_hyperedges(vertex_id), head_bound_hyperedges));
 }
 
 TEST_CASE_FIXTURE(
@@ -1205,8 +1205,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_matrix,
     "incident_hyperedges should return a view of the vertex's incident hyperedge ids,"
-    "outgoing_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
-    "incoming_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
+    "out_hyperedges should return a view of the vertex's outgoing hyperedge ids (v in T(e)),"
+    "in_hyperedges should return a view of the vertex's incoming hyperedge ids (v in H(e))"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1217,8 +1217,8 @@ TEST_CASE_FIXTURE(
         altbind_to_vertex(sut, vertex_id, constants::n_hyperedges);
 
     CHECK(std::ranges::equal(sut.incident_hyperedges(vertex_id), constants::hyperedge_ids_view));
-    CHECK(std::ranges::equal(sut.outgoing_hyperedges(vertex_id), tail_bound_hyperedges));
-    CHECK(std::ranges::equal(sut.incoming_hyperedges(vertex_id), head_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.out_hyperedges(vertex_id), tail_bound_hyperedges));
+    CHECK(std::ranges::equal(sut.in_hyperedges(vertex_id), head_bound_hyperedges));
 }
 
 TEST_CASE_FIXTURE(


### PR DESCRIPTION
- Implemented the following hypergraph conversions:
  - Undirected hypergraph projection (clique expansion)
  - BF-directed hypergraph projection
  - Incidence graph conversions
- Renamed the incoming/outgoing methods of the hypergraph class to use shorter in/out prefixes
- Added missing methods for obtaining in/out element id collections
- Added missing const qualifierst to element id collection getters