### PR TITLE
YT-CPPGL-57: Add missing in/out edge getter methods

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -304,7 +304,7 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Return type*: A *random access view* with values of type `edge_type`.
 
 - **`graph.at(vertex) const`**:
-  - *Description*: An alias for `adjacent_edges(vertex)`. Returns a *random access view* over the adjacency storage entry for the given vertex.
+  - *Description*: Returns a *random access view* over the adjacency storage entry for the given vertex.
     - This is equivalent to calling `at(vertex.id())`.
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which to find adjacent edges.
@@ -323,6 +323,36 @@ Based on the specified traits, the `graph` class defines the following types:
     - This is equivalent to calling `adjacent_edges(vertex.id())`.
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which to find adjacent edges.
+  - *Return type*: A *forward view* with values of type `edge_type`.
+
+- **`graph.in_edges(vertex_id) const`**:
+  - *Description*: Returns a *forward view* over a collection of edges where the vertex with the specified ID is the target vertex (incoming edges).
+    - For directed graphs: edges where the vertex is the target.
+    - For undirected graphs: same as `adjacent_edges(vertex_id)`.
+  - *Parameters*:
+    - `vertex_id: types::id_type` – the ID of the vertex for which to find incoming edges.
+  - *Return type*: A *forward view* with values of type `edge_type`.
+
+- **`graph.in_edges(vertex) const`**:
+  - *Description*: Returns a *forward view* over a collection of edges where the specified vertex is the target vertex (incoming edges).
+    - This is equivalent to calling `in_edges(vertex.id())`.
+  - *Parameters*:
+    - `vertex: const vertex_type&` – the vertex for which to find incoming edges.
+  - *Return type*: A *forward view* with values of type `edge_type`.
+
+- **`graph.out_edges(vertex_id) const`**:
+  - *Description*: Returns a *forward view* over a collection of edges where the vertex with the specified ID is the source vertex (outgoing edges).
+    - For directed graphs: edges where the vertex is the source.
+    - For undirected graphs: same as `adjacent_edges(vertex_id)`.
+  - *Parameters*:
+    - `vertex_id: types::id_type` – the ID of the vertex for which to find outgoing edges.
+  - *Return type*: A *forward view* with values of type `edge_type`.
+
+- **`graph.out_edges(vertex) const`**:
+  - *Description*: Returns a *forward view* over a collection of edges where the specified vertex is the source vertex (outgoing edges).
+    - This is equivalent to calling `out_edges(vertex.id())`.
+  - *Parameters*:
+    - `vertex: const vertex_type&` – the vertex for which to find outgoing edges.
   - *Return type*: A *forward view* with values of type `edge_type`.
 
 <br />

--- a/include/gl/algorithm.hpp
+++ b/include/gl/algorithm.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "algorithm/breadth_first_search.hpp"
-#include "algorithm/coloring.hpp"
-#include "algorithm/depth_first_search.hpp"
-#include "algorithm/dijkstra.hpp"
-#include "algorithm/mst.hpp"
-#include "algorithm/topological_sort.hpp"
+#include "gl/algorithm/breadth_first_search.hpp"
+#include "gl/algorithm/coloring.hpp"
+#include "gl/algorithm/depth_first_search.hpp"
+#include "gl/algorithm/dijkstra.hpp"
+#include "gl/algorithm/mst.hpp"
+#include "gl/algorithm/topological_sort.hpp"

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "constants.hpp"
-#include "impl/bfs.hpp"
-#include "types.hpp"
+#include "gl/algorithm/constants.hpp"
+#include "gl/algorithm/impl/bfs.hpp"
+#include "gl/algorithm/types.hpp"
 
 namespace gl::algorithm {
 
@@ -21,9 +21,6 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> breadth_firs
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.order(), false);
     std::vector<types::id_type> sources(graph.order());
 

--- a/include/gl/algorithm/coloring.hpp
+++ b/include/gl/algorithm/coloring.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impl/bfs.hpp"
+#include "gl/algorithm/impl/bfs.hpp"
 
 namespace gl::algorithm {
 

--- a/include/gl/algorithm/depth_first_search.hpp
+++ b/include/gl/algorithm/depth_first_search.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "constants.hpp"
-#include "impl/dfs.hpp"
+#include "gl/algorithm/constants.hpp"
+#include "gl/algorithm/impl/dfs.hpp"
 
 namespace gl::algorithm {
 
@@ -20,9 +20,6 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> depth_first_
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.order(), false);
     std::vector<types::id_type> sources(graph.order());
 
@@ -67,9 +64,6 @@ impl::alg_return_type<ResultDiscriminator, predecessors_descriptor> recursive_de
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.order(), false);
     std::vector<types::id_type> sources(graph.order());
 

--- a/include/gl/algorithm/dijkstra.hpp
+++ b/include/gl/algorithm/dijkstra.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impl/pfs.hpp"
+#include "gl/algorithm/impl/pfs.hpp"
 
 #include <deque>
 
@@ -72,7 +72,6 @@ template <
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
     using distance_type = types::vertex_distance_type<GraphType>;
 
@@ -110,7 +109,9 @@ template <
             }
 
             return false;
-        }
+        },
+        pre_visit,
+        post_visit
     );
 
     if (negative_edge.has_value()) {

--- a/include/gl/algorithm/impl/bfs.hpp
+++ b/include/gl/algorithm/impl/bfs.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "common.hpp"
+#include "gl/algorithm/impl/common.hpp"
 
 #include <queue>
 

--- a/include/gl/algorithm/impl/dfs.hpp
+++ b/include/gl/algorithm/impl/dfs.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "common.hpp"
+#include "gl/algorithm/impl/common.hpp"
 
 #include <stack>
 

--- a/include/gl/algorithm/impl/pfs.hpp
+++ b/include/gl/algorithm/impl/pfs.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "common.hpp"
+#include "gl/algorithm/impl/common.hpp"
 
 #include <queue>
 

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "constants.hpp"
-#include "impl/common.hpp"
+#include "gl/algorithm/impl/common.hpp"
+#include "gl/constants.hpp"
 
 #include <numeric>
 #include <queue>

--- a/include/gl/algorithm/topological_sort.hpp
+++ b/include/gl/algorithm/topological_sort.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impl/bfs.hpp"
+#include "gl/algorithm/impl/bfs.hpp"
 
 namespace gl::algorithm {
 

--- a/include/gl/decl/graph_traits.hpp
+++ b/include/gl/decl/graph_traits.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include "gl/decl/impl_tags.hpp"
 #include "gl/types/type_traits.hpp"
-#include "impl_tags.hpp"
 
 namespace gl {
 

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -4,9 +4,10 @@
 
 #pragma once
 
-#include "edge_tags.hpp"
-#include "io/format.hpp"
-#include "vertex_descriptor.hpp"
+#include "gl/constants.hpp"
+#include "gl/edge_tags.hpp"
+#include "gl/io/format.hpp"
+#include "gl/vertex_descriptor.hpp"
 
 namespace gl {
 

--- a/include/gl/edge_tags.hpp
+++ b/include/gl/edge_tags.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "gl/attributes/force_inline.hpp"
-#include "types/properties.hpp"
-#include "types/type_traits.hpp"
+#include "gl/types/properties.hpp"
+#include "gl/types/type_traits.hpp"
 
 namespace gl {
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "constants.hpp"
-#include "graph_traits.hpp"
-#include "impl/impl_tags.hpp"
-#include "io/stream_options_manipulator.hpp"
-#include "util/ranges.hpp"
+#include "gl/constants.hpp"
+#include "gl/graph_traits.hpp"
+#include "gl/impl/impl_tags.hpp"
+#include "gl/io/stream_options_manipulator.hpp"
+#include "gl/util/ranges.hpp"
 
 #include <set>
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -261,6 +261,30 @@ public:
         return this->adjacent_edges(vertex.id());
     }
 
+    [[nodiscard]] inline auto in_edges(const types::id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (type_traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.in_edges(vertex_id, this->_edge_properties);
+        else
+            return this->_impl.in_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const vertex_type& vertex) const {
+        return this->in_edges(vertex.id());
+    }
+
+    [[nodiscard]] inline auto out_edges(const types::id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (type_traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.out_edges(vertex_id, this->_edge_properties);
+        else
+            return this->_impl.out_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const vertex_type& vertex) const {
+        return this->out_edges(vertex.id());
+    }
+
     // --- edge methods ---
 
     const edge_type add_edge(const types::id_type source_id, const types::id_type target_id) {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -175,7 +175,7 @@ public:
         const type_traits::c_forward_range_of<types::id_type> auto& vertex_id_range
     ) {
         // sorts the ids in a descending order and removes duplicate ids
-        std::set<types::id_type, std::greater<types::id_type>> vertex_id_set(
+        std::set<types::id_type, std::greater<>> vertex_id_set(
             std::ranges::begin(vertex_id_range), std::ranges::end(vertex_id_range)
         );
 

--- a/include/gl/graph_file_io.hpp
+++ b/include/gl/graph_file_io.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "graph.hpp"
+#include "gl/graph.hpp"
 
 #include <filesystem>
 #include <fstream>

--- a/include/gl/graph_io.hpp
+++ b/include/gl/graph_io.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include "io/stream_options_manipulator.hpp"
+#include "gl/io/stream_options_manipulator.hpp"
 
-namespace gl {
-namespace io {
+namespace gl::io {
 
 enum class graph_option : bit_position_type {
     verbose = 0ul,
@@ -37,6 +36,4 @@ inline const stream_options_manipulator without_properties =
 inline const stream_options_manipulator enable_gsf = set_option(graph_option::gsf);
 inline const stream_options_manipulator disable_gsf = unset_option(graph_option::gsf);
 
-} // namespace io
-
-} // namespace gl
+} // namespace gl::io

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "decl/graph_traits.hpp"
-#include "decl/impl_tags.hpp"
-#include "edge_descriptor.hpp"
+#include "gl/decl/graph_traits.hpp"
+#include "gl/decl/impl_tags.hpp"
+#include "gl/edge_descriptor.hpp"
 
 namespace gl {
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -46,6 +46,11 @@ public:
         this->_list.resize(this->_list.size() + n, edge_item_list_type{});
     }
 
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
+    ) const {
+        return specialized_impl::degree(*this, vertex_id);
+    }
+
     [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id
     ) const {
         return specialized_impl::in_degree(*this, vertex_id);
@@ -56,9 +61,8 @@ public:
         return specialized_impl::out_degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const {
-        return specialized_impl::degree(*this, vertex_id);
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+        return specialized_impl::degree_map(*this);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
@@ -67,10 +71,6 @@ public:
 
     [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
         return specialized_impl::out_degree_map(*this);
-    }
-
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
-        return specialized_impl::degree_map(*this);
     }
 
     std::vector<types::id_type> remove_vertex(const types::id_type vertex_id) {
@@ -99,13 +99,13 @@ public:
         const types::id_type source_id, const types::id_type target_id
     ) const {
         return std::ranges::contains(this->_list[source_id], target_id, [](const auto& item) {
-            return item.target_id;
+            return item.vertex_id;
         });
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(const edge_type& edge) const {
         return std::ranges::contains(
-            this->_list[edge.source()], specialized::adjacency_list_item{edge.id(), edge.target()}
+            this->_list[edge.source()], specialized::adjacency_list_item{edge.target(), edge.id()}
         );
     }
 
@@ -116,7 +116,7 @@ public:
     {
         const auto& adjacent_edges = this->_list[source_id];
         const auto item_it = std::ranges::find(adjacent_edges, target_id, [](const auto& item) {
-            return item.target_id;
+            return item.vertex_id;
         });
         if (item_it == adjacent_edges.cend())
             return std::nullopt;
@@ -132,7 +132,7 @@ public:
     {
         const auto& adjacent_edges = this->_list[source_id];
         const auto item_it = std::ranges::find(adjacent_edges, target_id, [](const auto& item) {
-            return item.target_id;
+            return item.vertex_id;
         });
         if (item_it == adjacent_edges.cend())
             return std::nullopt;
@@ -147,10 +147,10 @@ public:
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[source_id] | std::views::filter([&target_id](const auto& item) {
-                   return item.target_id == target_id;
+                   return item.vertex_id == target_id;
                })
              | std::views::transform([source_id](const auto& item) {
-                   return edge_type{item.edge_id, source_id, item.target_id};
+                   return edge_type{item.edge_id, source_id, item.vertex_id};
                })
              | std::ranges::to<std::vector>();
     }
@@ -163,11 +163,11 @@ public:
     requires(type_traits::c_has_non_empty_properties<edge_type>)
     {
         return this->_list[source_id] | std::views::filter([&target_id](const auto& item) {
-                   return item.target_id == target_id;
+                   return item.vertex_id == target_id;
                })
              | std::views::transform([source_id, &edge_properties_map](const auto& item) {
                    return edge_type{
-                       item.edge_id, source_id, item.target_id, *edge_properties_map[item.edge_id]
+                       item.edge_id, source_id, item.vertex_id, *edge_properties_map[item.edge_id]
                    };
                })
              | std::ranges::to<std::vector>();
@@ -194,7 +194,7 @@ public:
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[vertex_id] | std::views::transform([vertex_id](const auto& item) {
-                   return edge_type{item.edge_id, vertex_id, item.target_id};
+                   return edge_type{item.edge_id, vertex_id, item.vertex_id};
                });
     }
 
@@ -206,7 +206,51 @@ public:
         return this->_list[vertex_id]
              | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
                    return edge_type{
-                       item.edge_id, vertex_id, item.target_id, *edge_properties_map[item.edge_id]
+                       item.edge_id, vertex_id, item.vertex_id, *edge_properties_map[item.edge_id]
+                   };
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const types::id_type vertex_id) const
+    requires(type_traits::c_has_empty_properties<edge_type>)
+    {
+        return specialized_impl::in_edges(*this, vertex_id)
+             | std::views::transform([vertex_id](const auto& item) {
+                   return edge_type{item.edge_id, item.vertex_id, vertex_id};
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(
+        const types::id_type vertex_id, const auto& edge_properties_map
+    ) const
+    requires(type_traits::c_has_non_empty_properties<edge_type>)
+    {
+        return specialized_impl::in_edges(*this, vertex_id)
+             | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
+                   return edge_type{
+                       item.edge_id, item.vertex_id, vertex_id, *edge_properties_map[item.edge_id]
+                   };
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const types::id_type vertex_id) const
+    requires(type_traits::c_has_empty_properties<edge_type>)
+    {
+        return specialized_impl::out_edges(*this, vertex_id)
+             | std::views::transform([vertex_id](const auto& item) {
+                   return edge_type{item.edge_id, vertex_id, item.vertex_id};
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_edges(
+        const types::id_type vertex_id, const auto& edge_properties_map
+    ) const
+    requires(type_traits::c_has_non_empty_properties<edge_type>)
+    {
+        return specialized_impl::out_edges(*this, vertex_id)
+             | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
+                   return edge_type{
+                       item.edge_id, vertex_id, item.vertex_id, *edge_properties_map[item.edge_id]
                    };
                });
     }
@@ -253,7 +297,7 @@ private:
                     edge_item.edge_id -= std::ranges::distance(removed_edge_ids.begin(), it);
 
                 // align the vertex id
-                edge_item.target_id -= edge_item.target_id > removed_vertex_id;
+                edge_item.vertex_id -= edge_item.vertex_id > removed_vertex_id;
             }
         }
     }

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/impl/specialized/adjacency_list.hpp"
 #include "gl/types/types.hpp"
-#include "specialized/adjacency_list.hpp"
 
 #ifdef GL_TESTING
 namespace gl_testing {

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -193,9 +193,7 @@ public:
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const types::id_type vertex_id) const
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
-        return this->_list[vertex_id] | std::views::transform([vertex_id](const auto& item) {
-                   return edge_type{item.edge_id, vertex_id, item.vertex_id};
-               });
+        return this->out_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
@@ -203,12 +201,7 @@ public:
     ) const
     requires(type_traits::c_has_non_empty_properties<edge_type>)
     {
-        return this->_list[vertex_id]
-             | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
-                   return edge_type{
-                       item.edge_id, vertex_id, item.vertex_id, *edge_properties_map[item.edge_id]
-                   };
-               });
+        return this->out_edges(vertex_id, edge_properties_map);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_edges(const types::id_type vertex_id) const
@@ -236,8 +229,7 @@ public:
     [[nodiscard]] gl_attr_force_inline auto out_edges(const types::id_type vertex_id) const
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
-        return specialized_impl::out_edges(*this, vertex_id)
-             | std::views::transform([vertex_id](const auto& item) {
+        return this->_list[vertex_id] | std::views::transform([vertex_id](const auto& item) {
                    return edge_type{item.edge_id, vertex_id, item.vertex_id};
                });
     }
@@ -247,7 +239,7 @@ public:
     ) const
     requires(type_traits::c_has_non_empty_properties<edge_type>)
     {
-        return specialized_impl::out_edges(*this, vertex_id)
+        return this->_list[vertex_id]
              | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
                    return edge_type{
                        item.edge_id, vertex_id, item.vertex_id, *edge_properties_map[item.edge_id]

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -39,7 +39,7 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertex() {
-        this->_list.emplace_back(edge_item_list_type{});
+        this->_list.emplace_back();
     }
 
     inline void add_vertices(const types::size_type n) {
@@ -120,7 +120,7 @@ public:
         });
         if (item_it == adjacent_edges.cend())
             return std::nullopt;
-        return std::make_optional<edge_type>(item_it->id, source_id, target_id);
+        return std::make_optional<edge_type>(item_it->edge_id, source_id, target_id);
     }
 
     [[nodiscard]] std::optional<edge_type> get_edge(
@@ -137,7 +137,7 @@ public:
         if (item_it == adjacent_edges.cend())
             return std::nullopt;
         return std::make_optional<edge_type>(
-            item_it->id, source_id, target_id, *edge_properties_map[item_it->id]
+            item_it->edge_id, source_id, target_id, *edge_properties_map[item_it->edge_id]
         );
     }
 
@@ -150,7 +150,7 @@ public:
                    return item.target_id == target_id;
                })
              | std::views::transform([source_id](const auto& item) {
-                   return edge_type{item.id, source_id, item.target_id};
+                   return edge_type{item.edge_id, source_id, item.target_id};
                })
              | std::ranges::to<std::vector>();
     }
@@ -167,7 +167,7 @@ public:
                })
              | std::views::transform([source_id, &edge_properties_map](const auto& item) {
                    return edge_type{
-                       item.id, source_id, item.target_id, *edge_properties_map[item.id]
+                       item.edge_id, source_id, item.target_id, *edge_properties_map[item.edge_id]
                    };
                })
              | std::ranges::to<std::vector>();
@@ -177,7 +177,7 @@ public:
         specialized_impl::remove_edge(*this, edge);
         for (auto& adj : this->_list)
             for (auto& item : adj)
-                item.id -= static_cast<types::id_type>(item.id > edge.id());
+                item.edge_id -= static_cast<types::id_type>(item.edge_id > edge.id());
     }
 
     std::vector<types::id_type> remove_edges(const type_traits::c_range_of<edge_type> auto& edges) {
@@ -194,7 +194,7 @@ public:
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[vertex_id] | std::views::transform([vertex_id](const auto& item) {
-                   return edge_type{item.id, vertex_id, item.target_id};
+                   return edge_type{item.edge_id, vertex_id, item.target_id};
                });
     }
 
@@ -206,7 +206,7 @@ public:
         return this->_list[vertex_id]
              | std::views::transform([vertex_id, &edge_properties_map](const auto& item) {
                    return edge_type{
-                       item.id, vertex_id, item.target_id, *edge_properties_map[item.id]
+                       item.edge_id, vertex_id, item.target_id, *edge_properties_map[item.edge_id]
                    };
                });
     }
@@ -245,12 +245,12 @@ private:
 
         for (auto& adj : this->_list) {
             for (auto& edge_item : adj) {
-                auto it = std::ranges::lower_bound(removed_edge_ids, edge_item.id);
-                if (it != removed_edge_ids.end() && *it == edge_item.id)
-                    edge_item.id = constants::invalid_id; // edge was removed
+                auto it = std::ranges::lower_bound(removed_edge_ids, edge_item.edge_id);
+                if (it != removed_edge_ids.end() && *it == edge_item.edge_id)
+                    edge_item.edge_id = constants::invalid_id; // edge was removed
                 else
                     // shift by the number of removed IDs < edge-id
-                    edge_item.id -= std::ranges::distance(removed_edge_ids.begin(), it);
+                    edge_item.edge_id -= std::ranges::distance(removed_edge_ids.begin(), it);
 
                 // align the vertex id
                 edge_item.target_id -= edge_item.target_id > removed_vertex_id;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/impl/specialized/adjacency_matrix.hpp"
 #include "gl/types/types.hpp"
-#include "specialized/adjacency_matrix.hpp"
 
 #ifdef GL_TESTING
 namespace gl_testing {

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -193,6 +193,48 @@ public:
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const types::id_type vertex_id) const
     requires(type_traits::c_has_empty_properties<edge_type>)
     {
+        return this->out_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
+        const types::id_type vertex_id, const auto& edge_properties_map
+    ) const
+    requires(type_traits::c_has_non_empty_properties<edge_type>)
+    {
+        return this->out_edges(vertex_id, edge_properties_map);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const types::id_type vertex_id) const
+    requires(type_traits::c_has_empty_properties<edge_type>)
+    {
+        return std::views::iota(0uz, this->_matrix.size())
+             | std::views::filter([this, vertex_id](const auto& source_id) {
+                   return this->_matrix[source_id][vertex_id] != constants::invalid_id;
+               })
+             | std::views::transform([this, vertex_id](const auto& source_id) {
+                   const auto edge_id = this->_matrix[source_id][vertex_id];
+                   return edge_type{edge_id, source_id, vertex_id};
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(
+        const types::id_type vertex_id, const auto& edge_properties_map
+    ) const
+    requires(type_traits::c_has_non_empty_properties<edge_type>)
+    {
+        return std::views::iota(0uz, this->_matrix.size())
+             | std::views::filter([this, vertex_id](const auto& source_id) {
+                   return this->_matrix[source_id][vertex_id] != constants::invalid_id;
+               })
+             | std::views::transform([this, vertex_id, &edge_properties_map](const auto& source_id) {
+                   const auto edge_id = this->_matrix[source_id][vertex_id];
+                   return edge_type{edge_id, source_id, vertex_id, *edge_properties_map[edge_id]};
+               });
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const types::id_type vertex_id) const
+    requires(type_traits::c_has_empty_properties<edge_type>)
+    {
         return this->_matrix[vertex_id] | std::views::enumerate
              | std::views::filter([](const auto& edge_info) {
                    const auto& [target_id, edge_id] = edge_info;
@@ -204,7 +246,7 @@ public:
                });
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline auto out_edges(
         const types::id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(type_traits::c_has_non_empty_properties<edge_type>)

--- a/include/gl/impl/impl_tags.hpp
+++ b/include/gl/impl/impl_tags.hpp
@@ -4,13 +4,11 @@
 
 #pragma once
 
-#include "adjacency_list.hpp"
-#include "adjacency_matrix.hpp"
 #include "gl/decl/impl_tags.hpp"
+#include "gl/impl/adjacency_list.hpp"
+#include "gl/impl/adjacency_matrix.hpp"
 
-namespace gl {
-
-namespace impl {
+namespace gl::impl {
 
 struct list_t {
     template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
@@ -24,6 +22,4 @@ struct matrix_t {
     using type = adjacency_matrix<GraphTraits>;
 };
 
-} // namespace impl
-
-} // namespace gl
+} // namespace gl::impl

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -55,15 +55,16 @@ struct directed_adjacency_list {
 
     [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
         std::vector<adjacency_list_item> in_edges;
-        for (types::id_type src_id = constants::initial_id; src_id < self._list.size(); ++src_id)
-            in_edges.append_range(
+        for (types::id_type src_id = constants::initial_id; src_id < self._list.size(); ++src_id) {
+            auto in_edges_view =
                 self._list[src_id] | std::views::filter([tgt_id = vertex_id](const auto& item) {
                     return item.vertex_id == tgt_id;
                 })
                 | std::views::transform([src_id](const auto& item) {
                       return adjacency_list_item{src_id, item.edge_id};
-                  })
-            );
+                  });
+            in_edges.insert(in_edges.end(), in_edges_view.begin(), in_edges_view.end());
+        }
         return in_edges;
     }
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include "gl/constants.hpp"
 #include "gl/decl/impl_tags.hpp"
+#include "gl/graph_traits.hpp"
 
 #include <algorithm>
 #include <format>

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -22,8 +22,8 @@ class adjacency_list;
 namespace specialized {
 
 struct adjacency_list_item {
+    types::id_type vertex_id;
     types::id_type edge_id;
-    types::id_type target_id;
 
     [[nodiscard]] bool operator==(const adjacency_list_item&) const = default;
 };
@@ -53,10 +53,25 @@ struct directed_adjacency_list {
     using impl_type = AdjacencyList;
     using edge_type = typename impl_type::edge_type;
 
-    // [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
-    //     std::vector<types::id_type> in_edges;
-    //     for (const auto& adjacent_edges : self._list)
-    // }
+    [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
+        std::vector<adjacency_list_item> in_edges;
+        for (types::id_type src_id = constants::initial_id; src_id < self._list.size(); ++src_id)
+            in_edges.append_range(
+                self._list[src_id] | std::views::filter([tgt_id = vertex_id](const auto& item) {
+                    return item.vertex_id == tgt_id;
+                })
+                | std::views::transform([src_id](const auto& item) {
+                      return adjacency_list_item{src_id, item.edge_id};
+                  })
+            );
+        return in_edges;
+    }
+
+    [[nodiscard]] gl_attr_force_inline static auto out_edges(
+        const impl_type& self, const types::id_type vertex_id
+    ) {
+        return std::views::all(self._list[vertex_id]);
+    }
 
     [[nodiscard]] static types::size_type in_degree(
         const impl_type& self, const types::id_type vertex_id
@@ -64,7 +79,7 @@ struct directed_adjacency_list {
         types::size_type in_deg = 0uz;
         for (const auto& adjacent_edges : self._list)
             in_deg +=
-                std::ranges::count(adjacent_edges, vertex_id, &adjacency_list_item::target_id);
+                std::ranges::count(adjacent_edges, vertex_id, &adjacency_list_item::vertex_id);
 
         return in_deg;
     }
@@ -86,7 +101,7 @@ struct directed_adjacency_list {
 
         for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
             std::ranges::for_each(self._list[id], [&in_degree_map](const auto& item) {
-                ++in_degree_map[item.target_id];
+                ++in_degree_map[item.vertex_id];
             });
         }
 
@@ -107,7 +122,7 @@ struct directed_adjacency_list {
         for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
             degree_map[id] += self._list[id].size();
             std::ranges::for_each(self._list[id], [&degree_map](const auto& item) {
-                ++degree_map[item.target_id];
+                ++degree_map[item.vertex_id];
             });
         }
 
@@ -129,7 +144,7 @@ struct directed_adjacency_list {
 
             const auto removed_subrng =
                 std::ranges::remove_if(adj_edges, [vertex_id, &removed_edges](const auto& item) {
-                    if (item.target_id == vertex_id) {
+                    if (item.vertex_id == vertex_id) {
                         removed_edges.push_back(item.edge_id);
                         return true;
                     }
@@ -146,7 +161,7 @@ struct directed_adjacency_list {
     gl_attr_force_inline static void add_edge(
         impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
     ) {
-        self._list[source_id].emplace_back(edge_id, target_id);
+        self._list[source_id].emplace_back(target_id, edge_id);
     }
 
     static void add_edges_from(
@@ -159,7 +174,7 @@ struct directed_adjacency_list {
         adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());
 
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids))
-            adjacent_edges_source.emplace_back(edge_id, target_id);
+            adjacent_edges_source.emplace_back(target_id, edge_id);
     }
 
     gl_attr_force_inline static void remove_edge(impl_type& self, const edge_type& edge) {
@@ -173,6 +188,18 @@ requires(type_traits::c_undirected_edge<typename AdjacencyList::edge_type>)
 struct undirected_adjacency_list {
     using impl_type = AdjacencyList;
     using edge_type = typename impl_type::edge_type;
+
+    [[nodiscard]] gl_attr_force_inline static auto in_edges(
+        const impl_type& self, const types::id_type vertex_id
+    ) {
+        return std::views::all(self._list[vertex_id]);
+    }
+
+    [[nodiscard]] gl_attr_force_inline static auto out_edges(
+        const impl_type& self, const types::id_type vertex_id
+    ) {
+        return std::views::all(self._list[vertex_id]);
+    }
 
     [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
         const impl_type& self, const types::id_type vertex_id
@@ -191,7 +218,7 @@ struct undirected_adjacency_list {
     ) {
         types::size_type degree = 0uz;
         for (const auto& item : self._list[vertex_id])
-            degree += 1uz + static_cast<types::size_type>(item.target_id == vertex_id);
+            degree += 1uz + static_cast<types::size_type>(item.vertex_id == vertex_id);
         return degree;
     }
 
@@ -220,12 +247,12 @@ struct undirected_adjacency_list {
     ) {
         // remove all edges incident with the vertex (scan only the selected vertices)
         for (const auto& item : self._list[vertex_id]) {
-            if (item.target_id == vertex_id)
+            if (item.vertex_id == vertex_id)
                 continue; // will be removed with the vertex's list
 
-            auto& adj_edges = self._list[item.target_id];
+            auto& adj_edges = self._list[item.vertex_id];
             const auto removed_subrng = std::ranges::remove_if(
-                adj_edges, [vertex_id](const auto& item) { return item.target_id == vertex_id; }
+                adj_edges, [vertex_id](const auto& item) { return item.vertex_id == vertex_id; }
             );
             adj_edges.erase(removed_subrng.begin(), removed_subrng.end());
         }
@@ -241,9 +268,9 @@ struct undirected_adjacency_list {
     static void add_edge(
         impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
     ) {
-        self._list[source_id].emplace_back(edge_id, target_id);
+        self._list[source_id].emplace_back(target_id, edge_id);
         if (target_id != source_id)
-            self._list[target_id].emplace_back(edge_id, source_id);
+            self._list[target_id].emplace_back(source_id, edge_id);
     }
 
     static void add_edges_from(
@@ -256,9 +283,9 @@ struct undirected_adjacency_list {
         adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());
 
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids)) {
-            adjacent_edges_source.emplace_back(edge_id, target_id);
+            adjacent_edges_source.emplace_back(target_id, edge_id);
             if (source_id != target_id)
-                self._list[target_id].emplace_back(edge_id, source_id);
+                self._list[target_id].emplace_back(source_id, edge_id);
         }
     }
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -67,12 +67,6 @@ struct directed_adjacency_list {
         return in_edges;
     }
 
-    [[nodiscard]] gl_attr_force_inline static auto out_edges(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
-        return std::views::all(self._list[vertex_id]);
-    }
-
     [[nodiscard]] static types::size_type in_degree(
         const impl_type& self, const types::id_type vertex_id
     ) {
@@ -190,12 +184,6 @@ struct undirected_adjacency_list {
     using edge_type = typename impl_type::edge_type;
 
     [[nodiscard]] gl_attr_force_inline static auto in_edges(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
-        return std::views::all(self._list[vertex_id]);
-    }
-
-    [[nodiscard]] gl_attr_force_inline static auto out_edges(
         const impl_type& self, const types::id_type vertex_id
     ) {
         return std::views::all(self._list[vertex_id]);

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -22,7 +22,7 @@ class adjacency_list;
 namespace specialized {
 
 struct adjacency_list_item {
-    types::id_type id;
+    types::id_type edge_id;
     types::id_type target_id;
 
     [[nodiscard]] bool operator==(const adjacency_list_item&) const = default;
@@ -33,8 +33,7 @@ namespace detail {
 [[nodiscard]] auto strict_find(
     type_traits::c_range_of<adjacency_list_item> auto& edge_list, const auto& edge
 ) {
-    // find the edge by address
-    const auto it = std::ranges::find(edge_list, edge.id(), &adjacency_list_item::id);
+    const auto it = std::ranges::find(edge_list, edge.id(), &adjacency_list_item::edge_id);
     if (it == edge_list.end())
         throw std::invalid_argument(std::format(
             "Got invalid edge [id = {} | vertices = ({}, {})]",
@@ -53,6 +52,11 @@ requires(type_traits::c_directed_edge<typename AdjacencyList::edge_type>)
 struct directed_adjacency_list {
     using impl_type = AdjacencyList;
     using edge_type = typename impl_type::edge_type;
+
+    // [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
+    //     std::vector<types::id_type> in_edges;
+    //     for (const auto& adjacent_edges : self._list)
+    // }
 
     [[nodiscard]] static types::size_type in_degree(
         const impl_type& self, const types::id_type vertex_id
@@ -114,7 +118,7 @@ struct directed_adjacency_list {
         impl_type& self, const types::id_type vertex_id
     ) {
         auto removed_edges =
-            self._list[vertex_id] | std::views::transform(&adjacency_list_item::id)
+            self._list[vertex_id] | std::views::transform(&adjacency_list_item::edge_id)
             | std::ranges::to<std::vector>();
 
         // remove all edges incident to the vertex
@@ -126,7 +130,7 @@ struct directed_adjacency_list {
             const auto removed_subrng =
                 std::ranges::remove_if(adj_edges, [vertex_id, &removed_edges](const auto& item) {
                     if (item.target_id == vertex_id) {
-                        removed_edges.push_back(item.id);
+                        removed_edges.push_back(item.edge_id);
                         return true;
                     }
                     return false;
@@ -228,7 +232,7 @@ struct undirected_adjacency_list {
 
         // remove the list of edges incident from the vertex entirely
         const auto removed_edges =
-            self._list[vertex_id] | std::views::transform(&adjacency_list_item::id)
+            self._list[vertex_id] | std::views::transform(&adjacency_list_item::edge_id)
             | std::ranges::to<std::vector>();
         self._list.erase(std::next(std::begin(self._list), vertex_id));
         return removed_edges;

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include "gl/constants.hpp"
 #include "gl/decl/impl_tags.hpp"
+#include "gl/graph_traits.hpp"
 
 #include <algorithm>
 #include <vector>

--- a/include/gl/io.hpp
+++ b/include/gl/io.hpp
@@ -4,5 +4,5 @@
 
 #pragma once
 
-#include "io/format.hpp"
-#include "io/stream_options_manipulator.hpp"
+#include "gl/io/format.hpp"
+#include "gl/io/stream_options_manipulator.hpp"

--- a/include/gl/topologies.hpp
+++ b/include/gl/topologies.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "topology/binary_tree.hpp"
-#include "topology/bipartite.hpp"
-#include "topology/clique.hpp"
-#include "topology/cycle.hpp"
-#include "topology/path.hpp"
+#include "gl/topology/binary_tree.hpp"
+#include "gl/topology/bipartite.hpp"
+#include "gl/topology/clique.hpp"
+#include "gl/topology/cycle.hpp"
+#include "gl/topology/path.hpp"

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "gl/attributes/force_inline.hpp"
-#include "type_traits.hpp"
+#include "gl/types/type_traits.hpp"
 
 #include <any>
 #include <iomanip>

--- a/include/gl/util/pow.hpp
+++ b/include/gl/util/pow.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "gl/constants.hpp"
 #include "gl/types/types.hpp"
 
 #include <algorithm>

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
-#include "decl/graph_traits.hpp"
-#include "graph_io.hpp"
-#include "types/properties.hpp"
-#include "types/type_traits.hpp"
-#include "types/types.hpp"
+#include "gl/constants.hpp"
+#include "gl/decl/graph_traits.hpp"
+#include "gl/graph_io.hpp"
+#include "gl/types/properties.hpp"
+#include "gl/types/type_traits.hpp"
+#include "gl/types/types.hpp"
 
 #include <compare>
 #include <format>

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <vector>
 
 namespace gl_testing {
 
@@ -251,6 +252,32 @@ TEST_CASE_FIXTURE(
     );
     // validate that the adjacent edges list has been properly aligned
     CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list, "in_edges should return edges where the vertex is the target"
+) {
+    const auto edge1 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
+    const auto edge2 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+
+    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    REQUIRE_EQ(in_edges.size(), 2uz);
+    CHECK(std::ranges::contains(in_edges, edge1));
+    CHECK(std::ranges::contains(in_edges, edge2));
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_list, "out_edges should return edges where the vertex is the source"
+) {
+    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
+
+    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    REQUIRE_EQ(out_edges.size(), 2uz);
+    CHECK(std::ranges::contains(out_edges, edge1));
+    CHECK(std::ranges::contains(out_edges, edge2));
 }
 
 TEST_CASE_FIXTURE(
@@ -593,6 +620,20 @@ TEST_CASE_FIXTURE(
     const auto adjacent_edges_second = sut.adjacent_edges(target_id);
     REQUIRE_EQ(adjacent_edges_second.size(), constants::zero_elements);
     CHECK_EQ(std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_list,
+    "in_edges and out_edges should return the same edges for undirected graphs"
+) {
+    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    add_edge(constants::vertex_id_1, constants::vertex_id_3);
+
+    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::vertex_id_1)));
+    CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::vertex_id_1)));
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -298,6 +298,32 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "in_edges should return edges where the vertex is the target"
+) {
+    const auto edge1 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
+    const auto edge2 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+
+    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    REQUIRE_EQ(in_edges.size(), 2uz);
+    CHECK(std::ranges::contains(in_edges, edge1));
+    CHECK(std::ranges::contains(in_edges, edge2));
+}
+
+TEST_CASE_FIXTURE(
+    test_directed_adjacency_matrix, "out_edges should return edges where the vertex is the source"
+) {
+    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
+
+    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    REQUIRE_EQ(out_edges.size(), 2uz);
+    CHECK(std::ranges::contains(out_edges, edge1));
+    CHECK(std::ranges::contains(out_edges, edge2));
+}
+
+TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
 ) {
@@ -429,8 +455,6 @@ TEST_CASE_FIXTURE(
 struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
     using edge_type = gl::undirected_edge<>;
     using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>;
-
-    test_undirected_adjacency_matrix() {}
 
     edge_type add_edge(const gl::types::id_type source_id, const gl::types::id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
@@ -637,6 +661,20 @@ TEST_CASE_FIXTURE(
     auto adjacent_edges_second = sut.adjacent_edges(target_id);
     REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), constants::zero_elements);
     CHECK_EQ(std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end());
+}
+
+TEST_CASE_FIXTURE(
+    test_undirected_adjacency_matrix,
+    "in_edges and out_edges should return the same edges for undirected graphs"
+) {
+    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    add_edge(constants::vertex_id_1, constants::vertex_id_3);
+
+    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+
+    CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::vertex_id_1)));
+    CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::vertex_id_1)));
 }
 
 TEST_CASE_FIXTURE(


### PR DESCRIPTION
- Extended the `graph` class with `in/out_edges` methods
- Replaced relative includes in the `gl` directory with root-relative includes