### PR TITLE
YT-CPPHGL-25: Implement the bidirectional incidence list model

### DIFF
--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -36,7 +36,7 @@ using list_hypergraph_traits =
     hypergraph_traits<DirectionalTag, VertexProperties, HyperedgeProperties, impl::list_t<LayoutTag>>;
 
 template <
-    type_traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
+    type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag = impl::hyperedge_major_t,
     type_traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     type_traits::c_properties VertexProperties = types::empty_properties,
     type_traits::c_properties HyperedgeProperties = types::empty_properties>

--- a/include/hgl/impl/impl_tags.hpp
+++ b/include/hgl/impl/impl_tags.hpp
@@ -23,7 +23,7 @@ struct list_t {
     using implementation_type = incidence_list<DirectionalTag, LayoutTag>;
 };
 
-template <type_traits::c_hypergraph_layout_tag LayoutTag>
+template <type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 struct matrix_t {
     using layout_tag = LayoutTag;
 

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -29,7 +29,7 @@ template <
     type_traits::c_hypergraph_layout_tag LayoutTag>
 class incidence_list;
 
-template <type_traits::c_hypergraph_layout_tag LayoutTag>
+template <type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 class incidence_list<hgl::undirected_t, LayoutTag> final {
 public:
     using directional_tag = hgl::undirected_t;
@@ -223,7 +223,7 @@ private:
     major_storage_type _major_storage;
 };
 
-template <type_traits::c_hypergraph_layout_tag LayoutTag>
+template <type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 class incidence_list<hgl::bf_directed_t, LayoutTag> final {
 public:
     using directional_tag = hgl::bf_directed_t;
@@ -547,6 +547,245 @@ private:
     }
 
     major_storage_type _major_storage;
+};
+
+template <type_traits::c_hypergraph_directional_tag DirectionalTag>
+class incidence_list<DirectionalTag, bidirectional_t> final {
+public:
+    using directional_tag = DirectionalTag;
+    using layout_tag = bidirectional_t;
+
+    incidence_list(const incidence_list&) = delete;
+    incidence_list& operator=(const incidence_list&) = delete;
+
+    incidence_list() = default;
+
+    incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    : _v_list{n_vertices, n_hyperedges}, _e_list{n_vertices, n_hyperedges} {}
+
+    incidence_list(incidence_list&&) = default;
+    incidence_list& operator=(incidence_list&&) = default;
+
+    ~incidence_list() = default;
+
+    // --- vertex methods : general ---
+
+    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+        this->_v_list.add_vertices(n);
+        this->_e_list.add_vertices(n);
+    }
+
+    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+        this->_v_list.remove_vertex(vertex_id);
+        this->_e_list.remove_vertex(vertex_id);
+    }
+
+    // --- vertex methods : incidence queries ---
+
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    ) const noexcept {
+        return this->_v_list.incident_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
+    ) const noexcept {
+        return this->_v_list.degree(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
+        const types::size_type n_vertices
+    ) const noexcept {
+        return this->_v_list.degree_map(n_vertices);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.out_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.out_degree(vertex_id);
+    }
+
+    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.out_degree_map(n_vertices);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.in_hyperedges(vertex_id);
+    }
+
+    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.in_degree(vertex_id);
+    }
+
+    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_v_list.in_degree_map(n_vertices);
+    }
+
+    // --- hyperedge methods : general ---
+
+    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+        this->_v_list.add_hyperedges(n);
+        this->_e_list.add_hyperedges(n);
+    }
+
+    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+        this->_v_list.remove_hyperedge(hyperedge_id);
+        this->_e_list.remove_hyperedge(hyperedge_id);
+    }
+
+    // --- hyperedge methods : incidence queries ---
+
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_e_list.incident_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
+        const types::id_type hyperedge_id
+    ) const noexcept {
+        return this->_e_list.hyperedge_size(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> hyperedge_size_map(
+        const types::size_type n_hyperedges
+    ) const noexcept {
+        return this->_e_list.hyperedge_size_map(n_hyperedges);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.tail_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.tail_size(hyperedge_id);
+    }
+
+    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.tail_size_map(n_hyperedges);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.head_vertices(hyperedge_id);
+    }
+
+    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.head_size(hyperedge_id);
+    }
+
+    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        return this->_e_list.head_size_map(n_hyperedges);
+    }
+
+    // --- binding methods ---
+
+    gl_attr_force_inline void bind(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept
+    requires std::same_as<DirectionalTag, hgl::undirected_t>
+    {
+        this->_v_list.bind(vertex_id, hyperedge_id);
+        this->_e_list.bind(vertex_id, hyperedge_id);
+    }
+
+    gl_attr_force_inline void unbind(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept {
+        this->_v_list.unbind(vertex_id, hyperedge_id);
+        this->_e_list.unbind(vertex_id, hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool are_bound(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept {
+        if (this->degree(vertex_id) <= this->hyperedge_size(hyperedge_id))
+            return this->_v_list.are_bound(vertex_id, hyperedge_id);
+        else
+            return this->_e_list.are_bound(vertex_id, hyperedge_id);
+    }
+
+    gl_attr_force_inline void bind_tail(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        this->_v_list.bind_tail(vertex_id, hyperedge_id);
+        this->_e_list.bind_tail(vertex_id, hyperedge_id);
+    }
+
+    gl_attr_force_inline void bind_head(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        this->_v_list.bind_head(vertex_id, hyperedge_id);
+        this->_e_list.bind_head(vertex_id, hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool is_tail(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        if (this->out_degree(vertex_id) <= this->tail_size(hyperedge_id))
+            return this->_v_list.is_tail(vertex_id, hyperedge_id);
+        else
+            return this->_e_list.is_tail(vertex_id, hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool is_head(
+        const types::id_type vertex_id, const types::id_type hyperedge_id
+    ) const noexcept
+    requires std::same_as<DirectionalTag, hgl::bf_directed_t>
+    {
+        if (this->in_degree(vertex_id) <= this->head_size(hyperedge_id))
+            return this->_v_list.is_head(vertex_id, hyperedge_id);
+        else
+            return this->_e_list.is_head(vertex_id, hyperedge_id);
+    }
+
+#ifdef HGL_TESTING
+    friend struct hgl_testing::test_incidence_list;
+#endif
+
+private:
+    using vertex_major_list = incidence_list<DirectionalTag, vertex_major_t>;
+    using hyperedge_major_list = incidence_list<DirectionalTag, hyperedge_major_t>;
+
+    vertex_major_list _v_list;
+    hyperedge_major_list _e_list;
 };
 
 } // namespace hgl::impl

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -24,10 +24,10 @@ namespace hgl::impl {
 
 template <
     type_traits::c_hypergraph_directional_tag DirectionalTag,
-    type_traits::c_hypergraph_layout_tag LayoutTag>
+    type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 class incidence_matrix;
 
-template <type_traits::c_hypergraph_layout_tag LayoutTag>
+template <type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 class incidence_matrix<hgl::undirected_t, LayoutTag> final {
 public:
     using directional_tag = hgl::undirected_t;
@@ -220,7 +220,7 @@ private:
     hypergraph_storage_type _matrix;
 };
 
-template <type_traits::c_hypergraph_layout_tag LayoutTag>
+template <type_traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
 class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
 public:
     using directional_tag = hgl::bf_directed_t;

--- a/include/hgl/impl/layout_tags.hpp
+++ b/include/hgl/impl/layout_tags.hpp
@@ -67,12 +67,19 @@ struct hyperedge_major_t {
     }
 };
 
+struct bidirectional_t {};
+
 } // namespace impl
 
 namespace type_traits {
 
 template <typename T>
-concept c_hypergraph_layout_tag = c_one_of<T, impl::vertex_major_t, impl::hyperedge_major_t>;
+concept c_hypergraph_layout_tag =
+    c_one_of<T, impl::vertex_major_t, impl::hyperedge_major_t, impl::bidirectional_t>;
+
+template <typename T>
+concept c_hypergraph_asymmetric_layout_tag =
+    c_one_of<T, impl::vertex_major_t, impl::hyperedge_major_t>;
 
 } // namespace type_traits
 

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -1,5 +1,7 @@
 #include "hgl/directional_tags.hpp"
 #include "hgl/hypergraph.hpp"
+#include "hgl/hypergraph_traits.hpp"
+#include "hgl/impl/layout_tags.hpp"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
 
@@ -833,6 +835,9 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     hypergraph_traits_template,
     hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::undirected_t>, // undirected bidirectional incidence list
+    hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t>, // undirected hyperedge-major incidence list
     hgl::list_hypergraph_traits<
@@ -844,6 +849,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hgl::matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::undirected_t>, // undirected vertex-major incidence matrix
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bf-directed bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t>, // bf-directed hyperedge-major incidence list
@@ -978,6 +986,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     undirected_property_hypergraph_traits_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::undirected_t,
+        hgl::types::name_property,
+        hgl::types::name_property>, // undirected bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t,
@@ -1195,6 +1208,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     bf_directed_property_hypergraph_traits_template,
     hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t,
+        hgl::types::name_property,
+        hgl::types::name_property>, // bf-directed bidirectional incidence list
+    hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t,
         hgl::types::name_property,
@@ -1391,6 +1409,9 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     hypergraph_traits_util_template,
     hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::undirected_t>, // undirected bidirectional incidence list
+    hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t>, // undirected hyperedge-major incidence list
     hgl::list_hypergraph_traits<
@@ -1402,6 +1423,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hgl::matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::undirected_t>, // undirected vertex-major incidence matrix
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bf-directed bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t>, // bf-directed hyperedge-major incidence list


### PR DESCRIPTION
- Added a new layout tag for the bidirectional implementation layout
- Defined a specialization of the `incidence_list` class for the new layout tag which stores both the vertex-major and hyperedge-major lists and delegates operations between them based on the computational complexity