### PR TITLE
[NONE] segment_vector class alignment

### DIFF
--- a/include/gl/types/segment_vector.hpp
+++ b/include/gl/types/segment_vector.hpp
@@ -268,6 +268,17 @@ public:
     /// @brief Destructor cleans up all managed memory.
     ~segment_vector() = default;
 
+    /// @brief Constructs a `segment_vector` with a specified number of segments and initial segment size.
+    /// @param n_segments The number of segments to create
+    /// @param segment_size The initial size of each segment (default is 0)
+    /// @post `size() == n_segments` and each segment is initialized with `segment_size` default-constructed elements
+    /// @exception std::bad_alloc May throw if memory allocation fails
+    segment_vector(size_type n_segments, size_type segment_size = 0uz)
+    : _data(n_segments * segment_size), _offsets(n_segments + 1uz) {
+        for (size_type i = 0uz; i <= n_segments; ++i)
+            this->_offsets[i] = i * segment_size;
+    }
+
     /// @brief Constructs a `segment_vector` from an initializer list of segments.
     /// @param ilist Initializer list of initializer lists, each representing a segment
     /// @post `size() == ilist.size()` and `data_size()` equals the sum of all segment sizes

--- a/include/gl/types/segment_vector.hpp
+++ b/include/gl/types/segment_vector.hpp
@@ -13,6 +13,8 @@
 #include <stdexcept>
 #include <vector>
 
+namespace gl::types {
+
 /// @brief A flattened 2D vector (jagged array) providing efficient storage for variable-length segments.
 ///
 /// This container stores all elements in a single contiguous memory block (`_data`) while maintaining
@@ -958,3 +960,5 @@ private:
     std::vector<value_type> _data;
     std::vector<size_type> _offsets{0uz};
 };
+
+} // namespace gl::types

--- a/tests/source/gl/test_segment_vector.cpp
+++ b/tests/source/gl/test_segment_vector.cpp
@@ -88,6 +88,32 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
+    test_segment_vector_constructors, "(n_segments) constructor should initialize segments"
+) {
+    sut_type sut(3uz);
+
+    CHECK_EQ(sut.size(), 3uz);
+    CHECK_EQ(sut.data_size(), 0uz);
+    for (std::size_t i = 0uz; i < 3uz; ++i)
+        CHECK_EQ(sut.segment_size(i), 0uz);
+}
+
+TEST_CASE_FIXTURE(
+    test_segment_vector_constructors,
+    "(n_segments, segment_size) constructor should initialize segments"
+) {
+    sut_type sut(3uz, 5uz);
+
+    CHECK_EQ(sut.size(), 3uz);
+    CHECK_EQ(sut.data_size(), 15uz);
+    for (std::size_t i = 0uz; i < 3uz; ++i) {
+        CHECK_EQ(sut.segment_size(i), 5uz);
+        for (std::size_t j = 0uz; j < 5uz; ++j)
+            CHECK_EQ(sut[i, j], 0);
+    }
+}
+
+TEST_CASE_FIXTURE(
     test_segment_vector_constructors, "initializer list constructor should initialize segments"
 ) {
     sut_type sut{

--- a/tests/source/gl/test_segment_vector.cpp
+++ b/tests/source/gl/test_segment_vector.cpp
@@ -12,7 +12,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_segment_vector");
 
 struct test_segment_vector_constructors {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -147,7 +147,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_segment_vector_comparison {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -195,7 +195,7 @@ TEST_CASE_FIXTURE(test_segment_vector_comparison, "empty segment_vectors should 
 }
 
 struct test_segment_vector_capacity {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
     sut_type sut;
 };
 
@@ -255,7 +255,7 @@ TEST_CASE_FIXTURE(test_segment_vector_capacity, "clear should remove all segment
 }
 
 struct test_segment_vector_segment_accessors {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 
     sut_type sut{
         {1, 2, 3},
@@ -420,7 +420,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_segment_vector_element_accessors {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 
     std::vector<int> seg0{1, 2, 3};
     std::vector<int> seg1{4, 5};
@@ -549,7 +549,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_segment_vector_segment_modifiers {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 
     sut_type sut;
     std::vector<int> seg0{1, 2, 3};
@@ -705,7 +705,7 @@ TEST_CASE_FIXTURE(test_segment_vector_segment_modifiers, "erase should update of
 }
 
 struct test_segment_vector_element_modifiers {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
     sut_type sut{
         {1, 2, 3},
         {4, 5}
@@ -800,7 +800,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_segment_vector_complex_operations {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -865,7 +865,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_segment_vector_iterators {
-    using sut_type = segment_vector<int>;
+    using sut_type = gl::types::segment_vector<int>;
 
     sut_type sut{
         {1, 2, 3},
@@ -922,7 +922,7 @@ TEST_CASE_FIXTURE(
     test_segment_vector_iterators, "non-const iterator should convert to const iterator implicitly"
 ) {
     auto non_const_it = sut.begin();
-    segment_vector<int>::const_iterator const_it = non_const_it;
+    typename sut_type::const_iterator const_it = non_const_it;
     CHECK(std::ranges::equal(*const_it, segments.front()));
 }
 


### PR DESCRIPTION
- Moved the segment_vector class to the gl::types namespace
- Extended the segment_vector class with a `(n_segments, segment_size)` constructor