### PR TITLE
YT-CPPGL-62: Implement graph representation model converters

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -158,7 +158,7 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Return type*: A *random access view* with values of type `vertex_type`.
 
 - **`graph.vertex_ids() const`**:
-  - *Description*: Returns a range of vertex IDs, starting from the initial vertex ID to the number of vertices in the grap.
+  - *Description*: Returns a view of vertex IDs, starting from the initial vertex ID to the number of vertices in the grap.
   - *Returned value*: $(v_{id} : v \in V)$
   - *Return type*: A *random access view* with values of type `types::id_type` : `std::ranges::iota_view`.
 
@@ -373,6 +373,11 @@ Based on the specified traits, the `graph` class defines the following types:
 <br />
 
 ### Edge Operations
+
+- **`graph.edge_ids() const`**:
+  - *Description*: Returns a view of edge IDs, starting from the initial edge ID to the number of edges in the grap.
+  - *Returned value*: $(e_{id} : e \in E)$
+  - *Return type*: A *random access view* with values of type `types::id_type` : `std::ranges::iota_view`.
 
 - **`graph.add_edge(source_id, target_id)`**:
   - *Description*: Adds a new edge between the vertices with the specified IDs and returns a reference to the newly added edge.

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "gl/decl/impl_tags.hpp"
+#include "gl/graph.hpp"
+#include "gl/impl/impl_tags.hpp"
+#include "gl/types/type_traits.hpp"
+
+#include <utility>
+
+namespace gl {
+
+namespace detail {
+
+template <
+    type_traits::c_instantiation_of<graph_traits> Traits,
+    type_traits::c_graph_impl_tag NewImplTag>
+struct rebind_impl_tag;
+
+template <
+    type_traits::c_edge_directional_tag Dir,
+    type_traits::c_properties VP,
+    type_traits::c_properties EP,
+    type_traits::c_graph_impl_tag OldImplTag,
+    type_traits::c_graph_impl_tag NewImplTag>
+struct rebind_impl_tag<graph_traits<Dir, VP, EP, OldImplTag>, NewImplTag> {
+    using type = graph_traits<Dir, VP, EP, NewImplTag>;
+};
+
+template <
+    type_traits::c_instantiation_of<graph_traits> Traits,
+    type_traits::c_graph_impl_tag NewImplTag>
+using rebind_impl_tag_t = typename rebind_impl_tag<Traits, NewImplTag>::type;
+
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
+struct to_impl {
+    template <typename TargetGraph, typename SourceGraph>
+    requires std::same_as<typename TargetGraph::implementation_tag, TargetImplTag>
+         and std::same_as<typename SourceGraph::implementation_tag, SourceImplTag>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        for (const auto u : source.vertex_ids()) {
+            for (const auto& edge : source.out_edges(u)) {
+                if constexpr (type_traits::c_undirected_graph<SourceGraph>)
+                    if (edge.source() > edge.target())
+                        continue; // prevent double insertion
+
+                target._impl.add_edge(edge.id(), edge.source(), edge.target());
+            }
+        }
+    }
+};
+
+// Conversion: identity
+template <type_traits::c_graph_impl_tag Tag>
+struct to_impl<Tag, Tag> {
+    template <typename TargetGraph, typename SourceGraph>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        target._impl = std::move(source._impl);
+    }
+};
+
+// Conversion: list -> flat list
+template <>
+struct to_impl<impl::flat_list_t, impl::list_t> {
+    template <type_traits::c_flat_list_graph TargetGraph, type_traits::c_list_graph SourceGraph>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        auto& target_list = target._impl._list;
+        auto& source_list = source._impl._list;
+
+        std::size_t total_items = 0uz;
+        for (const auto& adj : source_list)
+            total_items += adj.size();
+
+        target_list.reserve_segments(source_list.size());
+        target_list.reserve_data(total_items);
+        target_list = std::move(source_list);
+    }
+};
+
+// Conversion: flat list -> list
+template <>
+struct to_impl<impl::list_t, impl::flat_list_t> {
+    template <type_traits::c_list_graph TargetGraph, type_traits::c_flat_list_graph SourceGraph>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        auto& target_list = target._impl._list;
+        auto& source_list = source._impl._list;
+
+        target_list.reserve(source_list.size());
+        for (auto adj : source_list)
+            target_list.emplace_back(adj.begin(), adj.end());
+    }
+};
+
+} // namespace detail
+
+/// @brief Converts a graph from one implementation layout to another.
+/// @tparam TargetImplTag The desired implementation tag (e.g., gl::impl::flat_list_t)
+/// @tparam Graph The automatically deduced type of the source graph
+/// @param source The graph to convert. After the operation it will be left in a valid, empty state.
+/// @return A new graph containing the moved data, structured according to TargetImplTag.
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph Graph>
+[[nodiscard]] auto to(Graph&& source) {
+    using source_traits = typename Graph::traits_type;
+    using source_impl_tag = typename source_traits::implementation_tag;
+
+    using target_traits = detail::rebind_impl_tag_t<source_traits, TargetImplTag>;
+    using target_graph = graph<target_traits>;
+
+    target_graph target(source.order());
+
+    detail::to_impl<TargetImplTag, source_impl_tag>::convert(target, source);
+
+    target._n_vertices = std::exchange(source._n_vertices, 0uz);
+    target._n_edges = std::exchange(source._n_edges, 0uz);
+    target._vertex_properties = std::move(source._vertex_properties);
+    target._edge_properties = std::move(source._edge_properties);
+    source._impl = typename Graph::implementation_type();
+
+    return target;
+}
+
+} // namespace gl

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -50,9 +50,9 @@ namespace detail {
 template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
 struct to_impl {
     template <typename TargetGraph, typename SourceGraph>
-    requires std::same_as<typename TargetGraph::implementation_tag, TargetImplTag>
-         and std::same_as<typename SourceGraph::implementation_tag, SourceImplTag>
     static void convert(TargetGraph& target, SourceGraph& source) {
+        target._impl.add_vertices(source.order());
+
         for (const auto u : source.vertex_ids()) {
             for (const auto& edge : source.out_edges(u)) {
                 if constexpr (type_traits::c_undirected_graph<SourceGraph>)
@@ -77,7 +77,7 @@ struct to_impl<Tag, Tag> {
 // Conversion: list -> flat list
 template <>
 struct to_impl<impl::flat_list_t, impl::list_t> {
-    template <type_traits::c_flat_list_graph TargetGraph, type_traits::c_list_graph SourceGraph>
+    template <typename TargetGraph, typename SourceGraph>
     static void convert(TargetGraph& target, SourceGraph& source) {
         auto& target_list = target._impl._list;
         auto& source_list = source._impl._list;
@@ -89,15 +89,15 @@ struct to_impl<impl::flat_list_t, impl::list_t> {
         target_list.reserve_segments(source_list.size());
         target_list.reserve_data(total_items);
 
-        using target_list_type = std::remove_reference_t<decltype(target_list)>;
-        target_list = target_list_type(std::move(source_list));
+        for (auto& adj : source_list)
+            target_list.push_back(std::move(adj));
     }
 };
 
 // Conversion: flat list -> list
 template <>
 struct to_impl<impl::list_t, impl::flat_list_t> {
-    template <type_traits::c_list_graph TargetGraph, type_traits::c_flat_list_graph SourceGraph>
+    template <typename TargetGraph, typename SourceGraph>
     static void convert(TargetGraph& target, SourceGraph& source) {
         auto& target_list = target._impl._list;
         auto& source_list = source._impl._list;
@@ -123,7 +123,7 @@ template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph Grap
     using target_traits = type_traits::swap_impl_tag_t<source_traits, TargetImplTag>;
     using target_graph = graph<target_traits>;
 
-    target_graph target(source.order());
+    target_graph target;
 
     detail::to_impl<TargetImplTag, source_impl_tag>::convert(target, source);
 

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -13,12 +13,11 @@
 
 namespace gl {
 
-namespace detail {
+namespace type_traits {
 
-template <
-    type_traits::c_instantiation_of<graph_traits> Traits,
-    type_traits::c_graph_impl_tag NewImplTag>
-struct rebind_impl_tag;
+template <typename GT, type_traits::c_graph_impl_tag NewImplTag>
+requires c_graph<GT> or c_instantiation_of<GT, graph_traits>
+struct swap_impl_tag;
 
 template <
     type_traits::c_edge_directional_tag Dir,
@@ -26,14 +25,27 @@ template <
     type_traits::c_properties EP,
     type_traits::c_graph_impl_tag OldImplTag,
     type_traits::c_graph_impl_tag NewImplTag>
-struct rebind_impl_tag<graph_traits<Dir, VP, EP, OldImplTag>, NewImplTag> {
+struct swap_impl_tag<graph_traits<Dir, VP, EP, OldImplTag>, NewImplTag> {
     using type = graph_traits<Dir, VP, EP, NewImplTag>;
 };
 
 template <
-    type_traits::c_instantiation_of<graph_traits> Traits,
+    type_traits::c_edge_directional_tag Dir,
+    type_traits::c_properties VP,
+    type_traits::c_properties EP,
+    type_traits::c_graph_impl_tag OldImplTag,
     type_traits::c_graph_impl_tag NewImplTag>
-using rebind_impl_tag_t = typename rebind_impl_tag<Traits, NewImplTag>::type;
+struct swap_impl_tag<graph<graph_traits<Dir, VP, EP, OldImplTag>>, NewImplTag> {
+    using type = graph<graph_traits<Dir, VP, EP, NewImplTag>>;
+};
+
+template <typename GT, type_traits::c_graph_impl_tag NewImplTag>
+requires c_graph<GT> or c_instantiation_of<GT, graph_traits>
+using swap_impl_tag_t = typename swap_impl_tag<GT, NewImplTag>::type;
+
+} // namespace type_traits
+
+namespace detail {
 
 template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
 struct to_impl {
@@ -108,7 +120,7 @@ template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph Grap
     using source_traits = typename Graph::traits_type;
     using source_impl_tag = typename source_traits::implementation_tag;
 
-    using target_traits = detail::rebind_impl_tag_t<source_traits, TargetImplTag>;
+    using target_traits = type_traits::swap_impl_tag_t<source_traits, TargetImplTag>;
     using target_graph = graph<target_traits>;
 
     target_graph target(source.order());

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -66,8 +66,8 @@ struct to_impl {
 };
 
 // Conversion: identity
-template <type_traits::c_graph_impl_tag Tag>
-struct to_impl<Tag, Tag> {
+template <type_traits::c_graph_impl_tag ImplTag>
+struct to_impl<ImplTag, ImplTag> {
     template <typename TargetGraph, typename SourceGraph>
     static void convert(TargetGraph& target, SourceGraph& source) {
         target._impl = std::move(source._impl);

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -76,7 +76,9 @@ struct to_impl<impl::flat_list_t, impl::list_t> {
 
         target_list.reserve_segments(source_list.size());
         target_list.reserve_data(total_items);
-        target_list = std::move(source_list);
+
+        using target_list_type = std::remove_reference_t<decltype(target_list)>;
+        target_list = target_list_type(std::move(source_list));
     }
 };
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -332,6 +332,10 @@ public:
 
     // --- edge methods ---
 
+    [[nodiscard]] gl_attr_force_inline auto edge_ids() const noexcept {
+        return std::views::iota(constants::initial_id, this->_n_edges);
+    }
+
     const edge_type add_edge(const types::id_type source_id, const types::id_type target_id) {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -15,6 +15,51 @@
 namespace gl {
 
 template <type_traits::c_instantiation_of<graph_traits> GraphTraits = graph_traits<>>
+class graph;
+
+// --- general graph utility ---
+
+namespace type_traits {
+
+template <typename G>
+concept c_graph = c_instantiation_of<G, graph>;
+
+template <typename G>
+concept c_directed_graph = c_graph<G> and c_directed_edge<typename G::edge_type>;
+
+template <typename G>
+concept c_undirected_graph = c_graph<G> and c_undirected_edge<typename G::edge_type>;
+
+template <typename G>
+concept c_list_graph = c_graph<G> and std::same_as<typename G::implementation_tag, impl::list_t>;
+
+template <typename G>
+concept c_flat_list_graph =
+    c_graph<G> and std::same_as<typename G::implementation_tag, impl::flat_list_t>;
+
+template <typename G>
+concept c_adjacency_list_graph = c_list_graph<G> or c_flat_list_graph<G>;
+
+template <typename G>
+concept c_matrix_graph =
+    c_graph<G> and std::same_as<typename G::implementation_tag, impl::matrix_t>;
+
+template <typename G>
+concept c_adjacency_matrix_graph = c_matrix_graph<G>;
+
+} // namespace type_traits
+
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph Graph>
+auto to(Graph&& source);
+
+namespace detail {
+
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
+struct to_impl;
+
+} // namespace detail
+
+template <type_traits::c_instantiation_of<graph_traits> GraphTraits>
 class graph final {
 public:
     using traits_type = GraphTraits;
@@ -546,6 +591,14 @@ public:
         return is;
     }
 
+    template <
+        type_traits::c_graph_impl_tag TargetImplTag,
+        type_traits::c_graph_impl_tag SourceImplTag>
+    friend struct detail::to_impl;
+
+    template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph Graph>
+    friend auto to(Graph&& source);
+
 private:
     [[nodiscard]] static constexpr std::string _directed_type_str() {
         return type_traits::c_directed_edge<edge_type> ? "directed" : "undirected";
@@ -739,38 +792,6 @@ private:
 
     implementation_type _impl{};
 };
-
-// --- general graph utility ---
-
-namespace type_traits {
-
-template <typename G>
-concept c_graph = c_instantiation_of<G, graph>;
-
-template <typename G>
-concept c_directed_graph = c_graph<G> and c_directed_edge<typename G::edge_type>;
-
-template <typename G>
-concept c_undirected_graph = c_graph<G> and c_undirected_edge<typename G::edge_type>;
-
-template <typename G>
-concept c_list_graph = c_graph<G> and std::same_as<typename G::implementation_tag, impl::list_t>;
-
-template <typename G>
-concept c_flat_list_graph =
-    c_graph<G> and std::same_as<typename G::implementation_tag, impl::flat_list_t>;
-
-template <typename G>
-concept c_adjacency_list_graph = c_list_graph<G> or c_flat_list_graph<G>;
-
-template <typename G>
-concept c_matrix_graph =
-    c_graph<G> and std::same_as<typename G::implementation_tag, impl::matrix_t>;
-
-template <typename G>
-concept c_adjacency_matrix_graph = c_matrix_graph<G>;
-
-} // namespace type_traits
 
 // --- utility associated with graph's elements' properties ---
 

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -279,7 +279,7 @@ public:
     template <
         type_traits::c_graph_impl_tag TargetImplTag,
         type_traits::c_graph_impl_tag SourceImplTag>
-    friend struct to_impl;
+    friend struct gl::detail::to_impl;
 
 #ifdef GL_TESTING
     friend struct gl_testing::test_adjacency_list;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -16,7 +16,16 @@ struct test_adjacency_list;
 } // namespace gl_testing
 #endif
 
-namespace gl::impl {
+namespace gl {
+
+namespace detail {
+
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
+struct to_impl;
+
+} // namespace detail
+
+namespace impl {
 
 template <type_traits::c_adjacency_list_graph_traits GraphTraits>
 class adjacency_list final {
@@ -267,6 +276,11 @@ public:
         return this->adjacent_edges(vertex_id, edge_properties_map);
     }
 
+    template <
+        type_traits::c_graph_impl_tag TargetImplTag,
+        type_traits::c_graph_impl_tag SourceImplTag>
+    friend struct to_impl;
+
 #ifdef GL_TESTING
     friend struct gl_testing::test_adjacency_list;
 #endif
@@ -301,4 +315,5 @@ private:
     adjacency_list_type _list{};
 };
 
-} // namespace gl::impl
+} // namespace impl
+} // namespace gl

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -311,7 +311,7 @@ public:
     template <
         type_traits::c_graph_impl_tag TargetImplTag,
         type_traits::c_graph_impl_tag SourceImplTag>
-    friend struct to_impl;
+    friend struct gl::detail::to_impl;
 
 #ifdef GL_TESTING
     friend struct gl_testing::test_adjacency_matrix;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -14,8 +14,16 @@ struct test_adjacency_matrix;
 } // namespace gl_testing
 #endif
 
+namespace gl {
 
-namespace gl::impl {
+namespace detail {
+
+template <type_traits::c_graph_impl_tag TargetImplTag, type_traits::c_graph_impl_tag SourceImplTag>
+struct to_impl;
+
+} // namespace detail
+
+namespace impl {
 
 template <type_traits::c_adjacency_matrix_graph_traits GraphTraits>
 class adjacency_matrix final {
@@ -300,6 +308,11 @@ public:
                });
     }
 
+    template <
+        type_traits::c_graph_impl_tag TargetImplTag,
+        type_traits::c_graph_impl_tag SourceImplTag>
+    friend struct to_impl;
+
 #ifdef GL_TESTING
     friend struct gl_testing::test_adjacency_matrix;
 #endif
@@ -333,4 +346,5 @@ private:
     matrix_type _matrix{};
 };
 
-} // namespace gl::impl
+} // namespace impl
+} // namespace gl

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/conversion.hpp"
 #include "gl/graph.hpp"
 #include "gl/util/pow.hpp"
 
@@ -44,6 +45,12 @@ template <type_traits::c_graph GraphType>
     return graph;
 }
 
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType regular_binary_tree(const types::size_type depth) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(regular_binary_tree<base_graph_type>(depth));
+}
+
 template <type_traits::c_graph GraphType>
 [[nodiscard]] GraphType bidirectional_regular_binary_tree(const types::size_type depth) {
     if constexpr (type_traits::c_directed_graph<GraphType>) {
@@ -73,6 +80,12 @@ template <type_traits::c_graph GraphType>
     else {
         return regular_binary_tree<GraphType>(depth);
     }
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType bidirectional_regular_binary_tree(const types::size_type depth) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(bidirectional_regular_binary_tree<base_graph_type>(depth));
 }
 
 } // namespace gl::topology

--- a/include/gl/topology/bipartite.hpp
+++ b/include/gl/topology/bipartite.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/conversion.hpp"
 #include "gl/graph.hpp"
+#include "gl/impl/impl_tags.hpp"
 
 namespace gl::topology {
 
@@ -25,6 +27,14 @@ template <type_traits::c_graph GraphType>
     }
 
     return graph;
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType biclique(
+    const types::size_type n_vertices_a, const types::size_type n_vertices_b
+) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(biclique<base_graph_type>(n_vertices_a, n_vertices_b));
 }
 
 } // namespace gl::topology

--- a/include/gl/topology/clique.hpp
+++ b/include/gl/topology/clique.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/conversion.hpp"
 #include "gl/graph.hpp"
 
 namespace gl::topology {
@@ -22,6 +23,12 @@ template <type_traits::c_graph GraphType>
     }
 
     return graph;
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType clique(const types::size_type n_vertices) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(clique<base_graph_type>(n_vertices));
 }
 
 } // namespace gl::topology

--- a/include/gl/topology/cycle.hpp
+++ b/include/gl/topology/cycle.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/conversion.hpp"
 #include "gl/graph.hpp"
 
 namespace gl::topology {
@@ -17,6 +18,12 @@ template <type_traits::c_graph GraphType>
         graph.add_edge(source_id, (source_id + 1uz) % n_vertices);
 
     return graph;
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType cycle(const types::size_type n_vertices) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(cycle<base_graph_type>(n_vertices));
 }
 
 template <type_traits::c_graph GraphType>
@@ -36,6 +43,12 @@ template <type_traits::c_graph GraphType>
     else {
         return cycle<GraphType>(n_vertices);
     }
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType bidirectional_cycle(const types::size_type n_vertices) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(bidirectional_cycle<base_graph_type>(n_vertices));
 }
 
 } // namespace gl::topology

--- a/include/gl/topology/path.hpp
+++ b/include/gl/topology/path.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/constants.hpp"
+#include "gl/conversion.hpp"
 #include "gl/graph.hpp"
 
 namespace gl::topology {
@@ -17,6 +18,12 @@ template <type_traits::c_graph GraphType>
         graph.add_edge(source_id, source_id + 1uz);
 
     return graph;
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType path(const types::size_type n_vertices) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(path<base_graph_type>(n_vertices));
 }
 
 template <type_traits::c_graph GraphType>
@@ -35,6 +42,12 @@ template <type_traits::c_graph GraphType>
     else {
         return path<GraphType>(n_vertices);
     }
+}
+
+template <type_traits::c_flat_list_graph GraphType>
+[[nodiscard]] GraphType bidirectional_path(const types::size_type n_vertices) {
+    using base_graph_type = type_traits::swap_impl_tag_t<GraphType, impl::list_t>;
+    return to<impl::flat_list_t>(bidirectional_path<base_graph_type>(n_vertices));
 }
 
 } // namespace gl::topology

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -1,0 +1,158 @@
+#include "gl/conversion.hpp"
+#include "gl/edge_tags.hpp"
+#include "gl/graph.hpp"
+#include "testing/gl/types.hpp"
+
+#include <doctest.h>
+
+#include <algorithm>
+#include <concepts>
+#include <tuple>
+#include <vector>
+
+namespace rng = std::ranges;
+namespace vw = std::views;
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_conversion");
+
+constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
+
+struct test_conversion {
+    using property_type = gl::types::name_property;
+
+    template <gl::type_traits::c_graph GraphType>
+    [[nodiscard]] GraphType create_test_graph() {
+        GraphType graph{this->test_order};
+        for (const auto& [source, target] : this->test_edges)
+            graph.add_edge(source, target);
+
+        this->set_properties(graph);
+
+        return graph;
+    }
+
+    void set_properties(gl::type_traits::c_graph auto& graph) {
+        if constexpr (std::same_as<
+                          typename std::decay_t<decltype(graph)>::vertex_properties_type,
+                          property_type>)
+            for (const auto& vid : graph.vertex_ids())
+                graph.get_vertex_properties(vid) = property_type("vertex_" + std::to_string(vid));
+
+        if constexpr (std::same_as<
+                          typename std::decay_t<decltype(graph)>::edge_properties_type,
+                          property_type>)
+            for (const auto& eid : graph.edge_ids())
+                graph.get_edge_properties(eid) = property_type("edge_" + std::to_string(eid));
+    }
+
+    void validate_graph(const gl::type_traits::c_graph auto& graph) {
+        REQUIRE_EQ(graph.order(), this->test_order);
+        REQUIRE_EQ(graph.size(), this->test_edges.size());
+        for (const auto& [source, target] : this->test_edges)
+            CHECK(graph.has_edge(source, target));
+
+        this->validate_properties(graph);
+    }
+
+    void validate_properties(const gl::type_traits::c_graph auto& graph) {
+        if constexpr (std::same_as<
+                          typename std::decay_t<decltype(graph)>::vertex_properties_type,
+                          property_type>)
+            for (const auto& vid : graph.vertex_ids())
+                CHECK_EQ(graph.get_vertex_properties(vid), "vertex_" + std::to_string(vid));
+
+        if constexpr (std::same_as<
+                          typename std::decay_t<decltype(graph)>::edge_properties_type,
+                          property_type>)
+            for (const auto& eid : graph.edge_ids())
+                CHECK_EQ(graph.get_edge_properties(eid), "edge_" + std::to_string(eid));
+    }
+
+    gl::types::size_type test_order{5};
+    std::vector<gl::types::homogeneous_pair<gl::types::id_type>> test_edges{
+        {0, 1},
+        {0, 2},
+        {1, 3},
+        {2, 3},
+        {3, 4}
+    };
+};
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "Graph representation model conversion tests", GraphParams, graph_params_template
+) {
+    using DT = std::tuple_element_t<0, GraphParams>;
+    using VP = std::tuple_element_t<1, GraphParams>;
+    using EP = std::tuple_element_t<2, GraphParams>;
+
+    using list_graph = gl::graph<gl::list_graph_traits<DT, VP, EP>>;
+    using flat_list_graph = gl::graph<gl::flat_list_graph_traits<DT, VP, EP>>;
+    using matrix_graph = gl::graph<gl::matrix_graph_traits<DT, VP, EP>>;
+
+    test_conversion fixture;
+
+    SUBCASE("source graph model: list") {
+        auto source_graph = fixture.create_test_graph<list_graph>();
+
+        SUBCASE("identity conversion") {
+            const auto converted_graph = gl::to<gl::impl::list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("flat-list conversion") {
+            const auto converted_graph = gl::to<gl::impl::flat_list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("matrix conversion") {
+            const auto converted_graph = gl::to<gl::impl::matrix_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+    }
+
+    SUBCASE("source graph model: flat list") {
+        auto source_graph = fixture.create_test_graph<flat_list_graph>();
+
+        SUBCASE("identity conversion") {
+            const auto converted_graph = gl::to<gl::impl::flat_list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("list conversion") {
+            const auto converted_graph = gl::to<gl::impl::list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("matrix conversion") {
+            const auto converted_graph = gl::to<gl::impl::matrix_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+    }
+
+    SUBCASE("source graph model: matrix") {
+        auto source_graph = fixture.create_test_graph<matrix_graph>();
+
+        SUBCASE("identity conversion") {
+            const auto converted_graph = gl::to<gl::impl::matrix_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("list conversion") {
+            const auto converted_graph = gl::to<gl::impl::list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+
+        SUBCASE("flat-list conversion") {
+            const auto converted_graph = gl::to<gl::impl::flat_list_t>(std::move(source_graph));
+            fixture.validate_graph(converted_graph);
+        }
+    }
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(graph_params_template, std::tuple<gl::directed_t, gl::types::empty_properties, gl::types::empty_properties>, std::tuple<gl::undirected_t, gl::types::empty_properties, gl::types::empty_properties>, std::tuple<gl::directed_t, gl::types::name_property, gl::types::empty_properties>, std::tuple<gl::undirected_t, gl::types::name_property, gl::types::empty_properties>, std::tuple<gl::directed_t, gl::types::empty_properties, gl::types::name_property>, std::tuple<gl::undirected_t, gl::types::empty_properties, gl::types::name_property>, std::tuple<gl::directed_t, gl::types::name_property, gl::types::name_property>, std::tuple<gl::undirected_t, gl::types::name_property, gl::types::name_property>);
+
+TEST_SUITE_END(); // test_conversion
+
+} // namespace hgl_testing

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -15,6 +15,24 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_graph");
 
+template <
+    gl::type_traits::c_instantiation_of<gl::graph_traits> TraitsType,
+    gl::type_traits::c_properties VertexProperties>
+using add_vertex_property = gl::graph_traits<
+    typename TraitsType::edge_directional_tag,
+    VertexProperties,
+    typename TraitsType::edge_properties_type,
+    typename TraitsType::implementation_tag>;
+
+template <
+    gl::type_traits::c_instantiation_of<gl::graph_traits> TraitsType,
+    gl::type_traits::c_properties EdgeProperties>
+using add_edge_property = gl::graph_traits<
+    typename TraitsType::edge_directional_tag,
+    typename TraitsType::vertex_properties_type,
+    EdgeProperties,
+    typename TraitsType::implementation_tag>;
+
 template <typename TraitsType>
 struct test_graph {
     using traits_type = TraitsType;
@@ -57,7 +75,7 @@ struct test_graph {
     void validate_full_graph_edges(const GraphType& graph) {
         REQUIRE(std::ranges::all_of(
             graph.vertex_ids(),
-            [this, &graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
+            [&graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
                 const gl::types::id_type vertex_id
             ) { return gl::util::range_size(graph.adjacent_edges(vertex_id)) == expected_n_edges; }
         ));
@@ -71,24 +89,6 @@ struct test_graph {
     const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
     const vertex_type invalid_vertex{constants::invalid_id}; // remove?
 };
-
-template <
-    gl::type_traits::c_instantiation_of<gl::graph_traits> TraitsType,
-    gl::type_traits::c_properties VertexProperties>
-using add_vertex_property = gl::graph_traits<
-    typename TraitsType::edge_directional_tag,
-    VertexProperties,
-    typename TraitsType::edge_properties_type,
-    typename TraitsType::implementation_tag>;
-
-template <
-    gl::type_traits::c_instantiation_of<gl::graph_traits> TraitsType,
-    gl::type_traits::c_properties EdgeProperties>
-using add_edge_property = gl::graph_traits<
-    typename TraitsType::edge_directional_tag,
-    typename TraitsType::vertex_properties_type,
-    EdgeProperties,
-    typename TraitsType::implementation_tag>;
 
 using vertex_id_list = std::vector<gl::types::id_type>;
 
@@ -222,7 +222,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         ));
     }
 
-    SUBCASE("vertex_ids should return the correct vertex list iterator range") {
+    SUBCASE("vertex_ids should return a correct view") {
         sut_type sut{constants::n_elements};
         CHECK(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
     }


### PR DESCRIPTION
- Defined a helper type trait that swaps out an implementation tag  of the graph (traits) type
- Implemented a `gl::to<ImplTag>(GraphType&&)` function that converts the source graph representation model to the one defined with the `ImplTag` template parameter
- Added topology generator function overloads for the flat-list representation model that generate the graph topology using the `impl::list_t` model and then convert them to `impl::flat_list_t` model
- Added an `edge_ids` method to the graph class