### PR TITLE
T-CPPGL-58: Cleanup the file structure, namespaces, and utility elements (part 2)

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -34,7 +34,7 @@ This section covers the specific types and type traits used for the algorithm im
 
 ### Constants
 
-- `no_root_vertex: types::id_type = constants::invalid_id` - A constant representing the absence of a root vertex in graph traversal algorithms. When this value is used as the `root_vertex_id` parameter in traversal algorithms, it indicates that the search should be performed on all vertices of the graph rather than starting from a specific root vertex.
+- `no_root_vertex: id_type = constants::invalid_id` - A constant representing the absence of a root vertex in graph traversal algorithms. When this value is used as the `root_vertex_id` parameter in traversal algorithms, it indicates that the search should be performed on all vertices of the graph rather than starting from a specific root vertex.
 
 ### Types
 
@@ -44,16 +44,16 @@ This section covers the specific types and type traits used for the algorithm im
     - `noret` - Indicates that the algorithm does not return a value.
   - The `gl::algorithm` namespace [uses](https://en.cppreference.com/w/cpp/language/enum.html#using_enum_declaration) the `result_discriminator` enum, which allows for the usage of it's members directly from the `gl::algorithm` namespace, e.g. `gl::algorithm::noret`.
 
-- `predecessors_map = std::vector<types::id_type>` - A type alias for a vector of vertex IDs representing the predecessors of vertices in a graph. The predecessor of a vertex is the vertex from which it was reached during a graph traversal.
+- `predecessors_map = std::vector<id_type>` - A type alias for a vector of vertex IDs representing the predecessors of vertices in a graph. The predecessor of a vertex is the vertex from which it was reached during a graph traversal.
 
 - `vertex_info`
   - *Description*: Holds information about a vertex. If `id == source_id`, the `id` represents the starting vertex.
   - *Constructors*:
-    - `vertex_info(types::id_type id)` - initializes the object with the same value for `id` and `source_id` representing a starting vertex
-    - `vertex_info(types::id_type id, types::id_type source_id)`
+    - `vertex_info(id_type id)` - initializes the object with the same value for `id` and `source_id` representing a starting vertex
+    - `vertex_info(id_type id, id_type source_id)`
   - *Member variables*:
-    - `id: types::id_type` - the ID of the vertex.
-    - `source_id: types::id_type` - the ID of the source vertex, typically used during algorithms.
+    - `id: id_type` - the ID of the vertex.
+    - `source_id: id_type` - the ID of the source vertex, typically used during algorithms.
 
 - `predicate_result`
   - *Description*: Represents the result of a predicate evaluation.
@@ -97,7 +97,7 @@ This section covers the specific types and type traits used for the algorithm im
   - *Template parameters*:
     - `ResultDiscriminator: result_discriminator` - The discriminator that determines the initialization value of the predecessor map.
   - *Parameters*:
-    - `n_vertices: types::size_type` - The number of vertices in the graph, which determines the size of the predecessor map.
+    - `n_vertices: size_type` - The number of vertices in the graph, which determines the size of the predecessor map.
   - *Return type*: `non_void_return_type<ResultDiscriminator, predecessors_map>` - The initialized predecessor map.
 
 - `is_reachable(predecessor_map, vertex_id)`
@@ -105,8 +105,8 @@ This section covers the specific types and type traits used for the algorithm im
   - *Parameters*:
     - `predecessor_map: const <id-range> auto&` - The predecessor map.
       - *Constraints*:
-        - `id-range` - `traits::c_random_access_range_of<types::id_type>` - The predecessor map must be a random access range of `types::id_type`.
-    - `vertex_id: const types::size_type` - The ID of the vertex to check for reachability.
+        - `id-range` - `traits::c_random_access_range_of<id_type>` - The predecessor map must be a random access range of `id_type`.
+    - `vertex_id: const size_type` - The ID of the vertex to check for reachability.
   - *Return type*: `bool`
   - *Equivalent to*: `predecessor_map[vertex_id] != constants::invalid_id`
 
@@ -114,7 +114,7 @@ This section covers the specific types and type traits used for the algorithm im
   - *Description*: Returns a default vertex visiting predicate function that returns the visited status of a vertex.
    - *Parameters*:
     - `visited: const std::vector<bool>&` - A reference to a vector of boolean values representing the visited status of vertices. The predicate function uses this vector to determine if a vertex has been visited.
-  - *Return type*: A predicate lambda object with the signature `bool(const types::id_type)`.
+  - *Return type*: A predicate lambda object with the signature `bool(const id_type)`.
 
 - `default_visit_callback<ResultDiscriminator>(visited, pred_map)`
   - *Description*: Returns a default visit callback function that always returns `true`.
@@ -123,7 +123,7 @@ This section covers the specific types and type traits used for the algorithm im
   - *Parameters*:
     - `visited: std::vector<bool>&` - A reference to a vector of boolean values representing the visited status of vertices. The callback function can modify this vector to mark vertices as visited.
     - `pred_map: non_void_return_type<ResultDiscriminator, predecessors_map>&` - A reference to the predecessor map, which can be modified by the callback function to set the predecessor of a vertex.
-  - *Return type*: A callback lambda object with the signature `bool(const types::id_type vertex_id, const types::id_type pred_id)`.
+  - *Return type*: A callback lambda object with the signature `bool(const id_type vertex_id, const id_type pred_id)`.
 
 - `default_enqueue_vertex_predicate<GraphType, AsResult>(visited)`
   - *Description*: Returns a default vertex enqueue predicate function that checks if a vertex has not been visited yet.
@@ -132,7 +132,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `AsResult: result_discriminator` - The discriminator that determines the return type of the predicate function.
   - *Parameters*:
     - `visited: const std::vector<bool>&` - A reference to a vector of boolean values representing the visited status of vertices. The predicate function uses this vector to determine if a vertex has been visited.
-  - *Return type*: A predicate lambda object with the signature `<ret-type>(const types::id_type vertex_id, const typename GraphType::edge_type& in_edge)`, where `<ret-type>` is determined by the `AsResult` template parameter (`predicate_result` if `AsResult == true`, otherwise `bool`).
+  - *Return type*: A predicate lambda object with the signature `<ret-type>(const id_type vertex_id, const typename GraphType::edge_type& in_edge)`, where `<ret-type>` is determined by the `AsResult` template parameter (`predicate_result` if `AsResult == true`, otherwise `bool`).
 
 ### Concepts
 
@@ -159,7 +159,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `F` - the function type to check.
     - `ReturnType` - the return type of the callback.
     - `Args...` - variadic template representing additional arguments of the callback type.
-  - *Equivalent to*: `std::is_invocable_r_v<ReturnType, F, const types::id_type, Args...>`
+  - *Equivalent to*: `std::is_invocable_r_v<ReturnType, F, const id_type, Args...>`
 
 - `c_optional_id_callback`
   - *Description*: Checks if a function is a valid (optional) ID callback.
@@ -167,7 +167,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `F` - the function type to check.
     - `ReturnType` - the return type of the callback.
     - `Args...` - variadic template representing additional arguments of the callback type.
-  - *Equivalent to*: `c_optional_callback<F, ReturnType, const types::id_type, Args...>`
+  - *Equivalent to*: `c_optional_callback<F, ReturnType, const id_type, Args...>`
 
 - `c_edge_callback`
   - *Description*: Checks if a function is a valid edge callback.
@@ -205,7 +205,7 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
-    - `root_vertex_id: const types::id_type` (default = `no_root_vertex`) - The ID of the root vertex to start the search from. If the value is `no_root_vertex` (`constants::invalid_id`), the search will be performed on all vertices of the graph.
+    - `root_vertex_id: const id_type` (default = `no_root_vertex`) - The ID of the root vertex to start the search from. If the value is `no_root_vertex` (`constants::invalid_id`), the search will be performed on all vertices of the graph.
     - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
@@ -234,7 +234,7 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform BFS on.
-    - `root_vertex_id: const types::id_type` (default = `no_root_vertex`) - The ID of the root vertex to start the search from. If the value is `no_root_vertex` (`constants::invalid_id`), the search will be performed on all vertices of the graph.
+    - `root_vertex_id: const id_type` (default = `no_root_vertex`) - The ID of the root vertex to start the search from. If the value is `no_root_vertex` (`constants::invalid_id`), the search will be performed on all vertices of the graph.
     - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
@@ -246,7 +246,7 @@ This section covers the specific types and type traits used for the algorithm im
 ### Graph coloring
 
 > [!NOTE]
-> The `bicoloring_type` used by the binary coloring algorithms is defined as `std::vector<types::binary_color>`.
+> The `bicoloring_type` used by the binary coloring algorithms is defined as `std::vector<binary_color>`.
 
 - `bipartite_coloring(graph, pre_visit, post_visit)`
   - *Description*: Performs a BFS-based graph bipartite coloring on the specified graph.
@@ -262,7 +262,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `std::optional<bicoloring_type>` - The binary coloring of the graph: `std::nullopt` if the given graph is *not bipartite* or a list of `types::binary_color` values where the color at index $i$ corresponds to the vertex $v$ such that $v_{id} = i$
+    - `std::optional<bicoloring_type>` - The binary coloring of the graph: `std::nullopt` if the given graph is *not bipartite* or a list of `binary_color` values where the color at index $i$ corresponds to the vertex $v$ such that $v_{id} = i$
 
   - *Defined in*: [gl/algorithm/topology/coloring.hpp](/include/gl/algorithm/topology/coloring.hpp)
 
@@ -280,7 +280,7 @@ This section covers the specific types and type traits used for the algorithm im
   - *Description*: Applies the given coloring to the graph by setting the color poperty of $v$ to `color_range(v.id())`. If the coloring cannot be applied to the given graph due to a size mismatch, `false` is returned. Otherwise `true` will be returned.
   - *Template parameters*:
     - `GraphType: traits::c_graph` - The type of the graph on which the operation is performed.
-    - `ColorRange: c_sized_range_of<types::binary_color>` - The color range type.
+    - `ColorRange: c_sized_range_of<binary_color>` - The color range type.
   - *Constraints*:
     - `traits::c_binary_color_properties_type<typename GraphType::vertex_properties_type>` - vertices must have a binary color property
   - *Parameters*:
@@ -305,7 +305,7 @@ This section covers the specific types and type traits used for the algorithm im
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `std::optional<std::vector<types::id_type>>` - The [topological ordering](https://en.wikipedia.org/wiki/Topological_sorting) of the graph's vertices: `std::nullopt` if the given graph is *not acyclic* or a list of vertex IDs representing the proper ordering of the vertices.
+    - `std::optional<std::vector<id_type>>` - The [topological ordering](https://en.wikipedia.org/wiki/Topological_sorting) of the graph's vertices: `std::nullopt` if the given graph is *not acyclic* or a list of vertex IDs representing the proper ordering of the vertices.
 
   - *Defined in*: [gl/algorithm/topology/topological_sort.hpp](/include/gl/algorithm/topology/topological_sort.hpp)
 
@@ -321,12 +321,12 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
-    - `source_id: types::id_type` - The ID of the source vertex to start the search from.
+    - `source_id: id_type` - The ID of the source vertex to start the search from.
     - `pre_visit: const PreVisitCallback&` (default = `{}`) - The callback function to be called before visiting a vertex.
     - `post_visit: const PostVisitCallback&` (default = `{}`) - The callback function to be called after visiting a vertex.
 
   - *Return type*:
-    - `algorithm::paths_descriptor<types::vertex_distance_type<GraphType>>` - A shortest paths descriptor structure (detailed information can be found in the note below)
+    - `algorithm::paths_descriptor<vertex_distance_type<GraphType>>` - A shortest paths descriptor structure (detailed information can be found in the note below)
 
   - *Throws*: `std::invalid_argument` if an edge with a negative weight is found during the graph search.
 
@@ -340,26 +340,26 @@ This section covers the specific types and type traits used for the algorithm im
 > - *Type definitions*:
 >   - `distance_type` - An alias for `VertexDistanceType`.
 > - *Constructors*:
->   - `paths_descriptor(types::size_type n_vertices)` - Initializes both `predecessors` and `distances` lists with default values and of size `n_vertices`
+>   - `paths_descriptor(size_type n_vertices)` - Initializes both `predecessors` and `distances` lists with default values and of size `n_vertices`
 > - *Member variables*:
->   - `predecessors: std::vector<std::optional<types::id_type>>` - A list of vertex predecessors in the graph's search.
+>   - `predecessors: std::vector<std::optional<id_type>>` - A list of vertex predecessors in the graph's search.
 >     **NOTE:** If a predecessor at index $i$ is null, then the vertex $v$ in the graph such that $v_{id} = i$ is unreachable.
 >   - `distances: std::vector<distance_type>` - A list of vertex distances from a source vertex.
 > - *Member functions*:
->   - `is_reachable(types::id_type vertex_id) const -> bool` - checks if a vertex is reachable by verifying if its predecessor exists (i.e., if the optional value is set).
->   - `operator[](types::size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`.
->   - `operator[](types::size_type i)` - returns a pair of references to the predecessor and distance at index `i`.
->   - `at(types::size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`, with bounds checking.
->   - `at(types::size_type i)` - returns a pair of references to the predecessor and distance at index `i`, with bounds checking.
+>   - `is_reachable(id_type vertex_id) const -> bool` - checks if a vertex is reachable by verifying if its predecessor exists (i.e., if the optional value is set).
+>   - `operator[](size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`.
+>   - `operator[](size_type i)` - returns a pair of references to the predecessor and distance at index `i`.
+>   - `at(size_type i) const` - returns a pair of constant references to the predecessor and distance at index `i`, with bounds checking.
+>   - `at(size_type i)` - returns a pair of references to the predecessor and distance at index `i`, with bounds checking.
 
 - `reconstruct_path(predecessor_map, vetex_id)`
   - *Description*: Reconstructs a path to the search vertex $v$ such that $v_{id} = \text{vertex-id}$ from the given predecessor map
   - *Template parameters*:
-    - `IdRange: traits::c_random_access_range_of<std::optional<types::id_type>>` - The predecessor map type.
+    - `IdRange: traits::c_random_access_range_of<std::optional<id_type>>` - The predecessor map type.
   - *Parameters*:
     - `predecessor_map: const IdRange&` - The predecessor map.
-    - `vertex_id: const types::size_type` - The ID of the vertex the path to which will be reconstructed.
-  - *Return type*: `std::deque<types::id_type>`
+    - `vertex_id: const size_type` - The ID of the vertex the path to which will be reconstructed.
+  - *Return type*: `std::deque<id_type>`
   - *Throws:* `std::invalid_argument` if the vertex with the given ID is unreachable.
 
 ### Spanning tree
@@ -374,7 +374,7 @@ This section covers the specific types and type traits used for the algorithm im
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform the search on.
-    - `root_id_opt: const std::optional<types::id_type>` - An optional root vertex ID. If set, the search will begin with edges adjacent to the vertex $v$ such that $v_{id} = \text{root-id-opt.value()}$. Otherwise the first vertex of the graph will be used as root.
+    - `root_id_opt: const std::optional<id_type>` - An optional root vertex ID. If set, the search will begin with edges adjacent to the vertex $v$ such that $v_{id} = \text{root-id-opt.value()}$. Otherwise the first vertex of the graph will be used as root.
 
   - *Return type*:
     - `algorithm::mst_descriptor<GraphType>` - An [MST](https://en.wikipedia.org/wiki/Minimum_spanning_tree) desciptor object (detailed information can be found in the note below).
@@ -398,9 +398,9 @@ This section covers the specific types and type traits used for the algorithm im
 > - *Type definitions*:
 >   - `graph_type` - An alias for `GraphType`.
 >   - `edge_typpe` - An alias for `typename graph_type::edge_type`.
->   - `weight_type` - An alias for `types::vertex_distance_type<graph_type>`.
+>   - `weight_type` - An alias for `vertex_distance_type<graph_type>`.
 > - *Constructors*:
->   - `mst_descriptor(types::size_type n_vertices)` - Initializes an empty `edges` list with the capacity of $\text{n-vertices} - 1$ and the total weight is set to $0$.
+>   - `mst_descriptor(size_type n_vertices)` - Initializes an empty `edges` list with the capacity of $\text{n-vertices} - 1$ and the total weight is set to $0$.
 > - *Member variables*:
 >   - `edges: std::vector<edge_type>` - A list of edges of the spanning tree.
 >   - `weight: weight_type` - The total weight of all edges of the spanning tree.
@@ -425,14 +425,14 @@ Moreover, you can use one of the provided search algorithm templates (DFS, BFS o
   - *Template parameters*:
     - `GraphType: traits::c_graph` - The type of the graph on which the search is performed.
     - `VisitVertexPredicate: traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `VisitCallback: traits::c_optional_id_callback<bool, id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
     - `EnqueueVertexPred: traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
     - `PreVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
-    - `root_id: const types::id_type` - The ID of a vertex from which the search will be started.
+    - `root_id: const id_type` - The ID of a vertex from which the search will be started.
     - `visit_vertex_pred: const VisitVertexPredicate&` - A predicate used to determine whether a vertex should be visited based on the vertex itself and its source/parent vertex's ID.
     - `visit: const VisitCallback&` - The vertex visiting function.
     - `enque_vertex_pred: const EnqueueVertexPred&` - A predicate used to determine whether a vertex should be pushed to the search stack based on the vertex itself and its source edge.
@@ -447,15 +447,15 @@ Moreover, you can use one of the provided search algorithm templates (DFS, BFS o
   - *Template parameters*:
     - `GraphType: traits::c_graph` - The type of the graph on which the search is performed.
     - `VisitVertexPredicate: traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `VisitCallback: traits::c_optional_id_callback<bool, id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
     - `EnqueueVertexPred: traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
     - `PreVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
 
   - *Parameters*:
     - `graph: const GraphType&` - The graph to perform DFS on.
-    - `vertex_id: const types::id_type&` - The ID of a vertex to search in the current recursive call.
-    - `pred_id: const types::id_type` - The ID of the predecessor vertex vertex of the currently searched vertex.
+    - `vertex_id: const id_type&` - The ID of a vertex to search in the current recursive call.
+    - `pred_id: const id_type` - The ID of the predecessor vertex vertex of the currently searched vertex.
     - `visit_vertex_pred: const VisitVertexPredicate&` - A predicate used to determine whether a vertex should be visited based on the vertex itself and its source/parent vertex's ID.
     - `visit: const VisitCallback&` - The vertex visiting function.
     - `enque_vertex_pred: const EnqueueVertexPred&` - A predicate used to determine whether a vertex should be pushed to the search stack based on the vertex itself and its source edge.
@@ -476,7 +476,7 @@ Moreover, you can use one of the provided search algorithm templates (DFS, BFS o
     - `GraphType: traits::c_graph` - The type of the graph on which the search is performed.
     - `InitQueueRangeType: traits::c_forward_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
     - `VisitVertexPredicate: traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
+    - `VisitCallback: traits::c_optional_id_callback<bool, id_type>` - The vertex visting callback type (arguments: `vertex_id, pred_id`).
     - `EnqueueVertexPred: traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex_id, in_edge`)
     - `PreVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.
@@ -507,7 +507,7 @@ Moreover, you can use one of the provided search algorithm templates (DFS, BFS o
     - `PQCompare: std::predicate<algorithm::vertex_info, algorithm::vertex_info>` - The type of the vertex priority queue comparator.
     - `InitQueueRangeType: traits::c_forward_range_of<algorithm::vertex_info>` (default = `std::vector<algorithm::vertex_info>`) - The type of the `vertex_info` range which will be inserted into the queue at the beginning of the algorithm.
     - `VisitVertexPredicate: traits::c_optional_id_callback<bool>` - The vertex visiting unary predicate type.
-    - `VisitCallback: traits::c_optional_id_callback<bool, types::id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
+    - `VisitCallback: traits::c_optional_id_callback<bool, id_type>` - The vertex visting callback type (arguments: `vertex, source_id`).
     - `EnqueueVertexPred: traits::c_id_callback<algorithm::predicate_result, const typename GraphType::edge_type&>` - The vertex enqueue predicate type (arguments: `vertex, in_edge`)
     - `PreVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called before visiting a vertex.
     - `PostVisitCallback: traits::c_optional_id_callback<void>` (default = `algorithm::empty_callback`) - The type of the callback function called after visiting a vertex.

--- a/docs/core_util_types.md
+++ b/docs/core_util_types.md
@@ -34,7 +34,7 @@ The table below contains the basic type aliases defined in the library.
 | `homogeneous_pair<T>` | `std::pair<T, T>` |
 
 > [!NOTE]
-> All types in the table above are defined in the `gl::types` namespace and in the [gl/types/core.hpp](/include/gl/types/core.hpp) header file.
+> All types in the table above are defined in the [gl/types/core.hpp](/include/gl/types/core.hpp) header file.
 
 <br />
 <br />
@@ -42,41 +42,32 @@ The table below contains the basic type aliases defined in the library.
 ## Graph element property types
 
 > [!NOTE]
-> All types listed in this section are defined in the `gl::types` namespace and in the [gl/types/properties.hpp](/include/gl/types/properties.hpp) header file.
+> All types listed in this section are defined in the [gl/types/properties.hpp](/include/gl/types/properties.hpp) header file.
 
 ### Basic property types
 
 - `empty_properties` - An alias for `std::monostate` representing the default properties type which holds no data.
 
-### `class name_property`
+### `struct name_property`
 
 - *Description*:
-  The `name_property` class is a simple wrapper around a `std::string`, designed to store and manage an element's name.
+  The `name_property` struct is a simple wrapper around a `std::string`, designed to store and manage an element's name.
 
 - *Type definitions*:
   - `value_type` - An alias for `std::string`, representing the type of the name stored in the property.
 
-- *Constructors*:
-  - `name_property()` - Default constructor (*default*).
-  - `name_property(std::string_view name)` - Initializes the name property with the provided `name`.
-  - `name_property(const name_property&)` - Copy constructor (*default*).
-  - `name_property(name_property&&)` - Move constructor (*default*).
-
 - *Assignment operators*:
-  - `operator=(const name_property&) -> name_property&` - Copy assignment operator (*default*).
-  - `operator=(name_property&&) -> name_property&` - Move assignment operator (*default*).
-
-- *Destructor*:
-  - `~name_property()` - (*default*).
+  - `operator=(std::string_view name) -> name_property&` - Assigns a new name to the property, allowing for efficient assignment from string literals and `std::string_view`.
 
 - *Member functions*:
-  - `name() const -> const std::string&` - Returns the stored name as a constant reference.
   - `operator==(const name_property&) const -> bool` - Equality operator (*default*).
   - `operator<=>(const name_property&) const -> auto` - Three-way comparison operator (*default*).
+  - `operator==(std::string_view name) const -> bool` - Compares the property name with a string view for equality.
+  - `operator<=>(std::string_view name) const -> auto` - Compares the property name with a string view for ordering.
 
 - *Friend functions*:
-  - `operator<<(std::ostream&, const name_property&) -> std::ostream&` - Outputs the `name_property`'s name to an output stream, enclosed in quotes.
-  - `operator>>(std::istream&, name_property&) -> std::istream&` - Inputs a `name_property`'s name from an input stream, expecting a quoted string.
+  - `operator<<(std::ostream&, const name_property&) -> std::ostream&` - Outputs the `name_property`'s name to an output stream, **enclosed in quotes**.
+  - `operator>>(std::istream&, name_property&) -> std::istream&` - Inputs a `name_property`'s name from an input stream, **expecting a quoted string**.
 
 ### `class dynamic_properties`
 
@@ -156,7 +147,7 @@ The table below contains the basic type aliases defined in the library.
   - `operator==(const binary_color&) const -> bool` - Equality operator (*default*).
 
 - *Associated type definitions*:
-  - `gl::bin_color_value = typename types::binary_color::value`
+  - `gl::bin_color_value = typename binary_color::value`
 
 ### `struct binary_color_property`
 
@@ -209,11 +200,11 @@ This section describes the type traits that are associated with the property typ
   ```
 
 - `c_empty_properties<T>`
-  - *Description*: A concept that checks if a given type `T` is an empty properties type - `types::empty_properties = std::monostate`.
+  - *Description*: A concept that checks if a given type `T` is an empty properties type - `empty_properties = std::monostate`.
 
   ```cpp
   template <typename T>
-  concept c_empty_properties = c_properties<T> and std::same_as<T, gl::types::empty_properties>;
+  concept c_empty_properties = c_properties<T> and std::same_as<T, gl::empty_properties>;
   ```
 
 - `c_non_empty_properties<T>`
@@ -251,8 +242,8 @@ This section describes the type traits that are associated with the property typ
   concept c_binary_color_properties_type = c_properties<Properties> and requires(Properties p) {
       typename Properties::color_type;
       { p.color } -> std::same_as<typename Properties::color_type&>;
-      { p.color == types::binary_color{} } -> std::convertible_to<bool>;
-      requires std::constructible_from<typename Properties::color_type, types::binary_color>;
+      { p.color == binary_color{} } -> std::convertible_to<bool>;
+      requires std::constructible_from<typename Properties::color_type, binary_color>;
   };
   ```
 

--- a/docs/core_util_types.md
+++ b/docs/core_util_types.md
@@ -147,7 +147,7 @@ The table below contains the basic type aliases defined in the library.
   - `operator==(const binary_color&) const -> bool` - Equality operator (*default*).
 
 - *Associated type definitions*:
-  - `gl::bin_color_value = typename binary_color::value`
+  - `bin_color_value = typename binary_color::value`
 
 ### `struct binary_color_property`
 
@@ -204,7 +204,7 @@ This section describes the type traits that are associated with the property typ
 
   ```cpp
   template <typename T>
-  concept c_empty_properties = c_properties<T> and std::same_as<T, gl::empty_properties>;
+  concept c_empty_properties = c_properties<T> and std::same_as<T, empty_properties>;
   ```
 
 - `c_non_empty_properties<T>`

--- a/docs/core_util_types.md
+++ b/docs/core_util_types.md
@@ -192,17 +192,6 @@ The table below contains the basic type aliases defined in the library.
     - Reads the weight property from an input stream.
     - *Constraints*: `weight_type` must be readable (`traits::c_readable<weight_type>`).
 
-### Deriving from the property types
-
-> [!IMPORTANT]
-> The `name_property`, `dynamic_properties` and `binary_color` classes are marked `final` by default. To be able to use them as base classes you have to add:
->
-> ```cpp
-> #define GL_CONFIG_PROPERTY_TYPES_NOT_FINAL
-> ```
->
-> in your program or add a `-DGL_CONFIG_PROPERTY_TYPES_NOT_FINAL` flag when compiling.
-
 ### Associated type traits
 
 This section describes the type traits that are associated with the property types defined in the library. These traits help ensure that properties meet specific requirements and can be used correctly within the library.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -51,8 +51,8 @@ The table below demostrates what parameters of the graph can be modified:
 | **Trait** | **Purpose** | **Constraints** | **Default value** |
 | :- | :- | :- | :- |
 | DirectionalTag | Specifies whether the graph should store directed or undirected edges | Either `directed_t` or `undirected_t`<br/>**Concept:** `traits::c_graph_directional_tag` | `directed_t` |
-| VertexProperties | The properties type associated with each vertex in the graph | Must be default, copy and move constructible and define copy and move assignment operators<br/>**Concept:** `traits::c_properties` | `types::empty_properties` |
-| EdgeProperties | The properties type associated with each edge in the graph | Must be default, copy and move constructible and define copy and move assignment operators<br/>**Concept:** `traits::c_properties` | `types::empty_properties` |
+| VertexProperties | The properties type associated with each vertex in the graph | Must be default, copy and move constructible and define copy and move assignment operators<br/>**Concept:** `traits::c_properties` | `empty_properties` |
+| EdgeProperties | The properties type associated with each edge in the graph | Must be default, copy and move constructible and define copy and move assignment operators<br/>**Concept:** `traits::c_properties` | `empty_properties` |
 | ImplTag  | Specifies the underlying graph representation structure (adjacency list or matrix) | One of:<br/>&bull; `impl::list_t`<br/>&bull; `impl::flat_list_t`<br/>&bull; `impl::matrix_t`<br/>**Concept:** `traits::c_graph_impl_tag` | `impl::list_t` |
 
 An example on how to define an undirected graph with a *weight* edge properties type and represented as an adjacency matrix:
@@ -62,8 +62,8 @@ An example on how to define an undirected graph with a *weight* edge properties 
 
 using traits = gl::graph_traits<
     gl::undirected_t,                // DirectionalTag
-    gl::types::empty_properties,     // VertexProperties
-    gl::types::weight_property<int>, // EdgeProperties
+    gl::empty_properties,     // VertexProperties
+    gl::weight_property<int>, // EdgeProperties
     gl::impl::matrix_t>;             // ImplTag
 
 int main() {
@@ -141,12 +141,12 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.order() const noexcept`**:
   - *Description*: Returns the total number of vertices in the graph.
   - *Returned value*: $|V|$ where $V$ is the vertex set of the graph
-  - *Return type*: `types::size_type`
+  - *Return type*: `size_type`
 
 - **`graph.size() const noexcept`**:
   - *Description*: Returns the number of edges in the graph.
   - *Returned value*: $|E|$ where $E$ is the edge set of the graph
-  - *Return type*: `types::size_type`
+  - *Return type*: `size_type`
 
 <br />
 
@@ -160,20 +160,20 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.vertex_ids() const`**:
   - *Description*: Returns a view of vertex IDs, starting from the initial vertex ID to the number of vertices in the grap.
   - *Returned value*: $(v_{id} : v \in V)$
-  - *Return type*: A *random access view* with values of type `types::id_type` : `std::ranges::iota_view`.
+  - *Return type*: A *random access view* with values of type `id_type` : `std::ranges::iota_view`.
 
 - **`graph.get_vertex(vertex_id) const`**:
   - *Description*: Retrieves the vertex object associated with the given vertex ID.
   - *Returned value*: $v \in V : v_{id} = \text{vertex-id}$
   - *Parameters*:
-    - `vertex_id: const types::id_type`
+    - `vertex_id: const id_type`
   - *Return type*: `vertex_type`
 
 - **`graph.has_vertex(vertex_id) const`**:
   - *Description*: Checks if a vertex exists for the given vertex ID.
   - *Returned value*: $\exists!(v \in V : v_{id} = \text{vertex-id})$
   - *Parameters*:
-    - `vertex_id: const types::id_type`
+    - `vertex_id: const id_type`
   - *Return type*: `bool`
 
 - **`graph.has_vertex(vertex) const`**:
@@ -197,7 +197,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.add_vertices(n)`**:
   - *Description*: Adds `n` new vertices to the graph, each with default properties.
   - *Parameters*:
-    - `n: types::size_type` – The number of vertices to add.
+    - `n: size_type` – The number of vertices to add.
   - *Return type*: `void`
 
 - **`graph.add_vertices_with(properties_rng)`**:
@@ -216,7 +216,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.remove_vertex(vertex_id)`**:
   - *Description*: Removes the vertex with the given ID from the graph.
   - *Parameters*:
-    - `vertex_id: types::size_type` – The ID of the vertex to be removed.
+    - `vertex_id: size_type` – The ID of the vertex to be removed.
   - *Return type*: `void`
 
 - **`graph.remove_vertex(vertex)`**:
@@ -228,7 +228,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.remove_vertices_from(vertex_id_rng)`**:
   - *Description*: Removes multiple vertices from the graph based on a range of vertex IDs. The IDs are sorted in descending order and duplicate IDs are removed before deletion.
   - *Template parameters*:
-    - `IdRange: traits::c_forward_range_of<types::id_type>` – A range of vertex IDs, which must satisfy the size and type constraints.
+    - `IdRange: traits::c_forward_range_of<id_type>` – A range of vertex IDs, which must satisfy the size and type constraints.
   - *Parameters*:
     - `vertex_id_rng: const IdRange&` – A range of vertex IDs to be removed.
   - *Return type*: `void`
@@ -236,7 +236,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.remove_vertices_from(vertex_rng)`**:
   - *Description*: Removes multiple vertices from the graph based on a range of vertex references. The references are sorted in descending order and duplicates are removed before deletion.
   - *Parameters*:
-    - `vertex_rng: const traits::c_forward_range_of<types::id_type> auto&` – A range of vertex references to be removed.
+    - `vertex_rng: const traits::c_forward_range_of<id_type> auto&` – A range of vertex references to be removed.
   - *Return type*: `void`
 
 - **`graph.in_degree(vertex) const`**:
@@ -246,7 +246,7 @@ Based on the specified traits, the `graph` class defines the following types:
     - For unidirected graphs: $deg(vertex)$
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which to calculate the in-degree.
-  - *Return type*: `types::size_type`
+  - *Return type*: `size_type`
 
 - **`graph.in_degree(vertex_id) const`**:
   - *Description*: Returns the in-degree (number of incoming edges) of the vertex with the specified ID.
@@ -254,12 +254,12 @@ Based on the specified traits, the `graph` class defines the following types:
     - For directed graphs: $|\{(u, v) \in E : \text{vertex-id} = v_{id}\}|$
     - For unidirected graphs: $deg(\text{vertex-id})$
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the in-degree.
-  - *Return type*: `types::size_type`
+    - `vertex_id: id_type` – the ID of the vertex for which to calculate the in-degree.
+  - *Return type*: `size_type`
 
 - **`graph.in_degree_map() const`**:
   - *Description*: Returns a vector containing the in-degrees of the corresponding vertices (in-degree at index `i` corresponds to the vertex with an ID equal `i`).
-  - *Return type*: `std::vector<types::size_type>`
+  - *Return type*: `std::vector<size_type>`
 
 - **`graph.out_degree(vertex) const`**:
   - *Description*: Returns the out-degree (number of outgoing edges) of the specified vertex.
@@ -268,7 +268,7 @@ Based on the specified traits, the `graph` class defines the following types:
     - For unidirected graphs: $deg(vertex)$
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which to calculate the out-degree.
-  - *Return type*: `types::size_type`
+  - *Return type*: `size_type`
 
 - **`graph.out_degree(vertex_id) const`**:
   - *Description*: Returns the out-degree (number of outgoing edges) of the vertex with the specified ID.
@@ -276,12 +276,12 @@ Based on the specified traits, the `graph` class defines the following types:
     - For directed graphs: $|\{(u, v) \in E : \text{vertex-id} = u_{id}\}|$
     - For unidirected graphs: $deg(\text{vertex-id})$
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the out-degree.
-  - *Return type*: `types::size_type`
+    - `vertex_id: id_type` – the ID of the vertex for which to calculate the out-degree.
+  - *Return type*: `size_type`
 
 - **`graph.out_degree_map() const`**:
   - *Description*: Returns a vector containing the out-degrees of the corresponding vertices (out-degree at index `i` corresponds to the vertex with an ID equal `i`).
-  - *Return type*: `std::vector<types::size_type>`
+  - *Return type*: `std::vector<size_type>`
 
 - **`graph.degree(vertex) const`**:
   - *Description*: Returns the degree (number of incoming and outgoing edges) of the specified vertex.
@@ -293,7 +293,7 @@ Based on the specified traits, the `graph` class defines the following types:
 
   - *Parameters*:
     - `vertex: const vertex_type&` – the vertex for which to calculate the degree.
-  - *Return type*: `types::size_type`
+  - *Return type*: `size_type`
 
 - **`graph.degree(vertex_id) const`**:
   - *Description*: Returns the degree (number of incoming and outgoing edges) of the vertex with the specified ID.
@@ -303,19 +303,19 @@ Based on the specified traits, the `graph` class defines the following types:
 
       $2 \times |\{(u, v) \in E : u = v \land (\text{vertex-id} \in \{u_{id}, v_{id}\})\}| + |\{(u, v) \in E : u \ne v \land (\text{vertex-id} \in \{u_{id}, v_{id}\})\}|$
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to calculate the degree.
-  - *Return type*: `types::size_type`
+    - `vertex_id: id_type` – the ID of the vertex for which to calculate the degree.
+  - *Return type*: `size_type`
 
 - **`graph.degree_map() const`**:
   - *Description*: Returns a vector containing the degrees of the corresponding vertices (degree at index `i` corresponds to the vertex with an ID equal `i`).
-  - *Return type*: `std::vector<types::size_type>`
+  - *Return type*: `std::vector<size_type>`
 
 - **`graph.at(vertex_id) const`**:
   - *Description*: Returns a *random access view* over the adjacency storage entry for the given vertex ID.
     - For an adjacency list representation, it returns a view over a list of edges adjacent to the vertex.
     - For an adjacency matrix representation, it returns a view over a row of size $|V|$ corresponding to the vertex. **NOTE:** If the $i$-th entry of the row contains an *invalid edge descriptor*, it means there is no edge between the vertex with ID `vertex_id` and the vertex with ID `i`.
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to find adjacent edges.
+    - `vertex_id: id_type` – the ID of the vertex for which to find adjacent edges.
   - *Return type*: A *random access view* with values of type `edge_type`.
 
 - **`graph.at(vertex) const`**:
@@ -330,7 +330,7 @@ Based on the specified traits, the `graph` class defines the following types:
     - For an adjacency list representation, it returns a view over a list of edges adjacent to the vertex.
     - For an adjacency matrix representation, it returns a *filtered view* over a row of size $|V|$ corresponding to the vertex, containing only the valid edges (i.e., edges that exist between the vertex with ID `vertex_id` and other vertices).
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to find adjacent edges.
+    - `vertex_id: id_type` – the ID of the vertex for which to find adjacent edges.
   - *Return type*: A *forward view* with values of type `edge_type`.
 
 - **`graph.adjacent_edges(vertex) const`**:
@@ -345,7 +345,7 @@ Based on the specified traits, the `graph` class defines the following types:
     - For directed graphs: edges where the vertex is the target.
     - For undirected graphs: same as `adjacent_edges(vertex_id)`.
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to find incoming edges.
+    - `vertex_id: id_type` – the ID of the vertex for which to find incoming edges.
   - *Return type*: A *forward view* with values of type `edge_type`.
 
 - **`graph.in_edges(vertex) const`**:
@@ -360,7 +360,7 @@ Based on the specified traits, the `graph` class defines the following types:
     - For directed graphs: edges where the vertex is the source.
     - For undirected graphs: same as `adjacent_edges(vertex_id)`.
   - *Parameters*:
-    - `vertex_id: types::id_type` – the ID of the vertex for which to find outgoing edges.
+    - `vertex_id: id_type` – the ID of the vertex for which to find outgoing edges.
   - *Return type*: A *forward view* with values of type `edge_type`.
 
 - **`graph.out_edges(vertex) const`**:
@@ -377,20 +377,20 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.edge_ids() const`**:
   - *Description*: Returns a view of edge IDs, starting from the initial edge ID to the number of edges in the grap.
   - *Returned value*: $(e_{id} : e \in E)$
-  - *Return type*: A *random access view* with values of type `types::id_type` : `std::ranges::iota_view`.
+  - *Return type*: A *random access view* with values of type `id_type` : `std::ranges::iota_view`.
 
 - **`graph.add_edge(source_id, target_id)`**:
   - *Description*: Adds a new edge between the vertices with the specified IDs and returns a reference to the newly added edge.
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
   - *Return type*: `edge_type`
 
 - **`graph.add_edge_with(source_id, target_id, properties)`**:
   - *Description*: Adds a new edge between the vertices with the specified IDs and returns a reference to the newly added edge. This overload is available when the edge properties type is not the default.
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
     - `properties: const edge_properties_type&` – properties to assign to the new edge.
   - *Return type*: `const edge_type`
   - *Requires*: non-default `edge_properties_type`
@@ -414,8 +414,8 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.add_edges_from(source_id, target_id_rng)`**:
   - *Description*: Adds multiple edges from a source vertex (specified by ID) to a range of target vertices (also specified by IDs).
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id_rng: const traits::c_sized_range_of<types::id_type> auto&` – a range of target vertex IDs to connect to the source vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id_rng: const traits::c_sized_range_of<id_type> auto&` – a range of target vertex IDs to connect to the source vertex.
   - *Return type*: `void`
   - *NOTE:* For an adjacency matrix representation passing a range with duplicate IDs will result in an error.
 
@@ -439,8 +439,8 @@ Based on the specified traits, the `graph` class defines the following types:
     - For directed graphs: $\exists((u, v) \in E : \text{source-id} = u_{id} \land \text{target-id} = v_{id})$
     - For unidirected graphs: $\exists((u, v) \in E : (\text{source-id}, \text{target-id}) \in \{(u_{id}, v_{id}), (v_{id}, u_{id})\})$
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
   - *Return type*: `bool`
 
 - **`graph.has_edge(source, target) const`**:
@@ -462,8 +462,8 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.get_edge(source_id, target_id) const`**:
   - *Description*: Returns an optional edge between the vertices with the specified IDs. If no edge exists, `std::nullopt` is returned (**NOTE:** for the `adjacency_list` implementation the source matchin edge is returned).
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
   - *Return type*: `std::optional<edge_type>`
 
 - **`graph.get_edge(source, target) const`**:
@@ -476,8 +476,8 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.get_edges(source_id, target_id) const`**:
   - *Description*: Returns a vector of edges between the vertices with the specified IDs. If no edges exist, returns an empty vector.
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
   - *Return type*: `std::vector<edge_type>`
 
 - **`graph.get_edges(source, target) const`**:
@@ -510,8 +510,8 @@ Based on the specified traits, the `graph` class defines the following types:
   - *Description*: Returns true if the vertices with the specified IDs are incident to each other or the IDs are the same.
   - *Returned value*: $\exists(e_1, e_2 \in E : \text{source-id} \in ids(e_1) \land \text{target-id} \in ids(e_2) \land vertices(e_1) \cap vertices(e_2) \ne \emptyset)$
   - *Parameters*:
-    - `source_id: types::id_type` – the ID of the source vertex.
-    - `target_id: types::id_type` – the ID of the target vertex.
+    - `source_id: id_type` – the ID of the source vertex.
+    - `target_id: id_type` – the ID of the target vertex.
   - *Return type*: `bool`
 
 - **`graph.are_incident(source, target) const`**:
@@ -558,7 +558,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.get_vertex_properties(vertex_id) const`**:
   - *Description*: Returns a reference to the properties of the vertex with the specified ID.
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the ID of the vertex whose properties are to be retrieved.
+    - `vertex_id: const id_type` – the ID of the vertex whose properties are to be retrieved.
   - *Return type*: `vertex_properties_type&`
   - *Requires*: non-default `vertex_properties_type`
 
@@ -570,7 +570,7 @@ Based on the specified traits, the `graph` class defines the following types:
 - **`graph.get_edge_properties(edge_id) const`**:
   - *Description*: Returns a reference to the properties of the edge with the specified ID.
   - *Parameters*:
-    - `edge_id: const types::id_type` – the ID of the edge whose properties are to be retrieved.
+    - `edge_id: const id_type` – the ID of the edge whose properties are to be retrieved.
   - *Return type*: `edge_properties_type&`
   - *Requires*: non-default `edge_properties_type`
 
@@ -606,7 +606,7 @@ To write safe and more expressive graph utility of your own, you can use the def
 #### Types
 
 > [!NOTE]
-> All of the utility types listed below are defined in the `gl::types` namespace
+> All of the utility types listed below are defined in the [gl/graph.hpp](/include/gl/graph.hpp) header file.
 
 - `default_vertex_distance_type = std::int64_t` : Defines the default type for distance between vertices. This is used in the absence of a weight type definition in the `edge_properties_type` of a graph.
 - `vertex_distance`
@@ -629,8 +629,8 @@ To write safe and more expressive graph utility of your own, you can use the def
     - `edge: const typename GraphType::edge_type&` - the edge to get weight from
   - *Returned value*:
     - `edge.properties.weight` if the `edge_properties_type` satisfies the `traits::c_weight_properties_type` concept
-    - `static_cast<types::default_vertex_distance_type>(1ll)` otherwise
-  - *Return type*: `types::vertex_distance_type<GraphType>`
+    - `static_cast<default_vertex_distance_type>(1ll)` otherwise
+  - *Return type*: `vertex_distance_type<GraphType>`
 
 <br />
 <br />

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -61,10 +61,10 @@ An example on how to define an undirected graph with a *weight* edge properties 
 #include <gl/graph.hpp>
 
 using traits = gl::graph_traits<
-    gl::undirected_t,                // DirectionalTag
+    gl::undirected_t,         // DirectionalTag
     gl::empty_properties,     // VertexProperties
     gl::weight_property<int>, // EdgeProperties
-    gl::impl::matrix_t>;             // ImplTag
+    gl::impl::matrix_t>;      // ImplTag
 
 int main() {
     gl::graph<traits> graph;

--- a/docs/graph_elements.md
+++ b/docs/graph_elements.md
@@ -13,8 +13,8 @@ This section provides an overview of the `vertex_descriptor` and `edge_descripto
 <br />
 
 > [!IMPORTANT]
-> - Both vertices and edges are identified using unique ID values of type [`types::id_type`](/docs/core_util_types.md#general-type-aliases).
-> - `std::numeric_limits<types::id_type>::max()` is reserved as an **invalid ID value** and vertex or edge class instances created with this ID value will be treated as invalid.
+> - Both vertices and edges are identified using unique ID values of type [`id_type`](/docs/core_util_types.md#general-type-aliases).
+> - `std::numeric_limits<id_type>::max()` is reserved as an **invalid ID value** and vertex or edge class instances created with this ID value will be treated as invalid.
 
 <br />
 
@@ -27,7 +27,7 @@ By default, the `vertex_descriptor` class does not carry any properties. However
 ### Template Parameters
 
 - **`Properties`**: A type that defines the properties associated with each vertex.
-  - *Default value*:  `types::empty_properties`
+  - *Default value*:  `empty_properties`
   - *Constraints*: must satisfy the **`traits::c_properties`** concept
 
 ### Member Types
@@ -35,16 +35,16 @@ By default, the `vertex_descriptor` class does not carry any properties. However
 - **`type`**: Alias for the `vertex_descriptor` itself.
 - **`properties_type`**: Type of the vertex properties as defined by the `Properties` template parameter.
 - **`properties_ref_type`**: Reference type to the vertex properties.
-  - If the `Properties` type is `types::empty_properties`, this type is also `types::empty_properties`.
+  - If the `Properties` type is `empty_properties`, this type is also `empty_properties`.
   - Otherwise, it is `properties_type&`.
 
 ### Constructors
 
 - **`vertex_descriptor()`**:
   - Construct an *invalid* `vertex_descriptor` object.
-- **`vertex_descriptor(const types::id_type id)`**:
+- **`vertex_descriptor(const id_type id)`**:
   - Constructs a `vertex_descriptor` with a unique vertex ID.
-- **`vertex_descriptor(const types::id_type id, const properties_type& properties)`**:
+- **`vertex_descriptor(const id_type id, const properties_type& properties)`**:
   - Constructs a `vertex_descriptor` with a unique ID and specified properties.
   - *Constraints*: the `properties_type` must be non-default.
 - **Move constructor and assignment operator**: *default*
@@ -68,7 +68,7 @@ The destructor is *defaulted*, allowing proper cleanup of the `vertex_descriptor
 
 - **`id() const noexcept`**:
   - *Description*: Returns the unique identifier of the vertex.
-  - *Return type*: `types::id_type`
+  - *Return type*: `id_type`
 
 - **`properties() const`**:
   - *Description*: Returns a reference to the properties associated with the vertex.
@@ -103,7 +103,7 @@ The destructor is *defaulted*, allowing proper cleanup of the `vertex_descriptor
 - **`vertex`**: A convenient alias for `vertex_descriptor` with customizable properties.
 
   ```cpp
-  template <traits::c_properties Properties = types::empty_properties>
+  template <traits::c_properties Properties = empty_properties>
   using vertex = vertex_descriptor<Properties>;
   ```
 
@@ -121,7 +121,7 @@ By default, the `edge_descriptor` class does not carry any properties and assume
   - *Default value*: `directed_t`
   - *Constraints*: must satisfy the **`traits::c_graph_directional_tag`** concept (either `directed_t` or `undirected_t`)
 - **`Properties`**: A type that defines the properties associated with each edge.
-  - *Default value*: `types::empty_properties`
+  - *Default value*: `empty_properties`
   - *Constraints*: must satisfy the **`traits::c_properties`** concept
 
 ### Member types
@@ -130,16 +130,16 @@ By default, the `edge_descriptor` class does not carry any properties and assume
 - **`directional_tag`**: The tag indicating whether the edge is directed or undirected.
 - **`properties_type`**: Type of the edge properties as defined by the `Properties` template parameter.
 - **`properties_ref_type`**: Reference type to the edge properties.
-  - If the `Properties` type is `types::empty_properties`, this type is also `types::empty_properties`.
+  - If the `Properties` type is `empty_properties`, this type is also `empty_properties`.
   - Otherwise, it is `properties_type&`.
 
 ### Constructors
 
 - **`edge_descriptor()`**:
   - Construct an *invalid* `edge_descriptor` object.
-- **`edge_descriptor(const types::id_type source, const types::id_type target)`**:
+- **`edge_descriptor(const id_type source, const id_type target)`**:
   - Constructs an edge between two vertices.
-- **`edge_descriptor(const types::id_type source, const types::id_type target, const properties_type& properties)`**:
+- **`edge_descriptor(const id_type source, const id_type target, const properties_type& properties)`**:
   - Constructs an edge between two vertices with specified properties.
   - *Constraints*: the `properties_type` must be non-default.
 - **Move constructor and assignment operator**: *default*
@@ -171,27 +171,27 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
 
 - **`id() const noexcept`**:
   - *Description*: Returns the unique identifier of the edge.
-  - *Return type*: `types::id_type`
+  - *Return type*: `id_type`
 
 - **`incident_vertices() const noexcept`**:
   - *Description*: Returns a pair of references to the two vertices connected by the edge.
   - *Returned value*: $(u, v)$
-  - *Return type*: `types::homogeneous_pair<types::id_type>`
+  - *Return type*: `homogeneous_pair<id_type>`
 
 - **`incident_vertices_r() const noexcept`**:
   - *Description*: Returns a pair of references to the two vertices connected by the edge in reverse order.
   - *Returned value*: $(v, u)$
-  - *Return type*: `types::homogeneous_pair<types::id_type>`
+  - *Return type*: `homogeneous_pair<id_type>`
 
 - **`source() const noexcept`**:
   - *Description*: Returns an ID of the source vertex of the edge.
   - *Returned value*: $u$
-  - *Return type*: `types::id_type`
+  - *Return type*: `id_type`
 
 - **`target() const noexcept`**:
   - *Description*: Returns an ID of the target vertex of the edge.
   - *Returned value*: $v$
-  - *Return type*: `const types::id_type`
+  - *Return type*: `const id_type`
 
 - **`incident_vertex(vertex_id) const noexcept`**:
   - *Description*: Returns the vertex on the other end of the edge relative to the provided vertex. Throws an error if the provided vertex is not incident with the edge.
@@ -200,14 +200,14 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
     - $u$ if $\text{vertex-id} = v$
     - error otherwise
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the vertex for which the opposite vertex is requested.
-  - *Return type*: `const types::id_type`
+    - `vertex_id: const id_type` – the vertex for which the opposite vertex is requested.
+  - *Return type*: `const id_type`
 
 - **`is_incident_with(vertex_id) const noexcept`**:
   - *Description*: Returns `true` if a vertex with the given ID is connected to the edge.
   - *Returned value*: $\text{vertex-id} \in {u, v}$
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the vertex ID to check for incidence with the edge.
+    - `vertex_id: const id_type` – the vertex ID to check for incidence with the edge.
   - *Return type*: `bool`
 
 - **`is_incident_from(vertex_id) const noexcept`**:
@@ -216,7 +216,7 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
     - For directed edges: $\text{vertex-id} = u$
     - For undirected edges: `is_incident_with(vertex_id)`
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the vertex ID to check if it is the source.
+    - `vertex_id: const id_type` – the vertex ID to check if it is the source.
   - *Return type*: `bool`
 
 - **`is_incident_to(vertex_id) const noexcept`**:
@@ -225,7 +225,7 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
     - For directed edges: $\text{vertex-id} = v$
     - For undirected edges: `is_incident_with(vertex)`
   - *Parameters*:
-    - `vertex_id: const types::id_type` – the vertex ID to check if it is the target.
+    - `vertex_id: const id_type` – the vertex ID to check if it is the target.
   - *Return type*: `bool`
 
 - **`is_loop() const noexcept`**:
@@ -245,21 +245,21 @@ The destructor is *defaulted*, allowing proper cleanup of the `edge_descriptor` 
   ```cpp
   template <
       traits::c_graph_directional_tag DirectionalTag = directed_t,
-      traits::c_properties Properties = types::empty_properties>
+      traits::c_properties Properties = empty_properties>
   using edge = edge_descriptor<DirectionalTag, Properties>;
   ```
 
 - `directed_edge`: An alias for `edge_descriptor` specifically for directed edges.
 
   ```cpp
-  template <traits::c_properties Properties = types::empty_properties>
+  template <traits::c_properties Properties = empty_properties>
   using directed_edge = edge_descriptor<directed_t, Properties>;
   ```
 
 - `undirected_edge`: An alias for `edge_descriptor` specifically for undirected edges.
 
   ```cpp
-  template <traits::c_properties Properties = types::empty_properties>
+  template <traits::c_properties Properties = empty_properties>
   using undirected_edge = edge_descriptor<undirected_t, Properties>;
   ```
 

--- a/docs/io.md
+++ b/docs/io.md
@@ -85,7 +85,7 @@ Below you can find an example program showing how to use the I/O option setters:
 
 int main() {
     // declare the graph traits
-    using graph_traits = gl::graph_traits<gl::directed_t, gl::types::name_property, gl::types::name_property>;
+    using graph_traits = gl::graph_traits<gl::directed_t, gl::name_property, gl::name_property>;
     using graph_type = gl::graph<graph_traits>;
 
     // initialize a biclique where |A| = 2 and |B| = 3
@@ -214,7 +214,7 @@ Below you can find an example showing how to use the `save` and `load` functions
 
 int main() {
     // declare the graph type
-    using graph_traits = gl::graph_traits<gl::directed_t, gl::types::name_property, gl::types::name_property>;
+    using graph_traits = gl::graph_traits<gl::directed_t, gl::name_property, gl::name_property>;
     using graph_type = gl::graph<graph_traits>;
 
     // initialize a clique of size 3

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -25,7 +25,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: traits::c_graph` - the type of the generated graph
   - *Parameters*:
-    - `n_vertices: types::size_type` - the number of vertices the graph will be initialized with
+    - `n_vertices: size_type` - the number of vertices the graph will be initialized with
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/clique.hpp](/include/gl/topology/clique.hpp)
 
@@ -34,8 +34,8 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: traits::c_graph` - the type of the generated graph
   - *Parameters*:
-    - `n_vertices_a: types::size_type` - the number of vertices of the first vertex set of the graph
-    - `n_vertices_b: types::size_type` - the number of vertices of the second vertex set of the graph
+    - `n_vertices_a: size_type` - the number of vertices of the first vertex set of the graph
+    - `n_vertices_b: size_type` - the number of vertices of the second vertex set of the graph
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/bipartite.hpp](/include/gl/topology/bipartite.hpp)
 
@@ -44,7 +44,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: traits::c_graph` - the type of the generated graph
   - *Parameters*:
-    - `n_vertices: types::size_type` - the number of vertices the graph will be initialized with
+    - `n_vertices: size_type` - the number of vertices the graph will be initialized with
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/path.hpp](/include/gl/topology/path.hpp)
 
@@ -55,7 +55,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
     - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* path graph, an additional edge is added - $(v_j, v_i)$
     - For undirected edges: equivalent to `path(n_vertices)`
   - *Parameters*:
-    - `n_vertices: types::size_type` - the number of vertices the graph will be initialized with
+    - `n_vertices: size_type` - the number of vertices the graph will be initialized with
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/path.hpp](/include/gl/topology/path.hpp)
 
@@ -64,7 +64,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: traits::c_graph` - the type of the generated graph
   - *Parameters*:
-    - `n_vertices: types::size_type` - the number of vertices the graph will be initialized with
+    - `n_vertices: size_type` - the number of vertices the graph will be initialized with
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/path.hpp](/include/gl/topology/path.hpp)
 
@@ -75,7 +75,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
     - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* cycle graph, an additional edge is added - $(v_j, v_i)$
     - For undirected edges: equivalent to `cycle(n_vertices)`
   - *Parameters*:
-    - `n_vertices: types::size_type` - the number of vertices the graph will be initialized with
+    - `n_vertices: size_type` - the number of vertices the graph will be initialized with
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/cycle.hpp](/include/gl/topology/cycle.hpp)
 
@@ -84,7 +84,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
   - *Template parameters*:
     - `GraphType: traits::c_graph` - the type of the generated graph
   - *Parameters*:
-    - `depth: types::size_type` - the leaf depth of the generated binary tree graph
+    - `depth: size_type` - the leaf depth of the generated binary tree graph
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/binary_tree.hpp](/include/gl/topology/binary_tree.hpp)
 
@@ -95,7 +95,7 @@ The `CPP-GL` library provides a set of graph topology generator functions, which
     - For directed graphs: for each edge $(v_i, v_j)$ of a *normal* regular binary tree, an additional edge is added - $(v_j, v_i)$
     - For undirected edges: equivalent to `regular_binary_tree(n_vertices)`
   - *Parameters*:
-    - `depth: types::size_type` - the leaf depth of the generated binary tree graph
+    - `depth: size_type` - the leaf depth of the generated binary tree graph
   - *Return type*: `GraphType`
   - *Defined in*: [gl/topology/binary_tree.hpp](/include/gl/topology/binary_tree.hpp)
 
@@ -121,7 +121,7 @@ void print_graph(const GraphType& graph, const std::string& name) {
 
 int main() {
     // define the graph type
-    using graph_traits = gl::graph_traits<gl::directed_t, gl::types::name_property, gl::types::name_property>;
+    using graph_traits = gl::graph_traits<gl::directed_t, gl::name_property, gl::name_property>;
     using graph_type = gl::graph<graph_traits>;
 
     // clique of size 3

--- a/include/gl/algorithm/core.hpp
+++ b/include/gl/algorithm/core.hpp
@@ -17,17 +17,16 @@ namespace gl::algorithm {
 enum class result_discriminator : bool { ret = true, noret = false };
 using enum result_discriminator;
 
-using predecessors_map = std::vector<types::id_type>;
+using predecessors_map = std::vector<id_type>;
 
 struct vertex_info {
-    vertex_info(types::id_type id) : id(id), pred_id(id) {}
+    vertex_info(id_type id) : id(id), pred_id(id) {}
 
-    vertex_info(types::id_type id, types::id_type pred_id) : id(id), pred_id(pred_id) {}
+    vertex_info(id_type id, id_type pred_id) : id(id), pred_id(pred_id) {}
 
     // if id == pred_id then vertex_id is the id of the starting vertex
-    // TODO: add has_pred/is_root method?
-    types::id_type id;
-    types::id_type pred_id;
+    id_type id;
+    id_type pred_id;
 };
 
 struct predicate_result {
@@ -65,6 +64,6 @@ using non_void_return_type =
 
 // --- constants ---
 
-inline constexpr types::id_type no_root_vertex = constants::invalid_id;
+inline constexpr id_type no_root_vertex = constants::invalid_id;
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -14,7 +14,7 @@ namespace gl::algorithm {
 
 template <traits::c_arithmetic VertexDistanceType>
 struct paths_descriptor {
-    paths_descriptor(const types::size_type n_vertices)
+    paths_descriptor(const size_type n_vertices)
     : predecessors(n_vertices, constants::invalid_id), distances(n_vertices) {}
 
     predecessors_map predecessors;
@@ -37,7 +37,7 @@ template <
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 [[nodiscard]] paths_descriptor_type<GraphType> dijkstra_shortest_paths(
     const GraphType& graph,
-    const types::id_type source_id,
+    const id_type source_id,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
@@ -59,7 +59,7 @@ template <
         init_range(source_id),
         algorithm::empty_callback{}, // visit predicate
         algorithm::empty_callback{}, // visit callback
-        [&paths, &negative_edge](const types::id_type vertex_id, const edge_type& in_edge)
+        [&paths, &negative_edge](const id_type vertex_id, const edge_type& in_edge)
             -> predicate_result { // enqueue predicate
             const auto pred_id = in_edge.incident_vertex(vertex_id);
 
@@ -96,21 +96,21 @@ template <
     return paths;
 }
 
-template <traits::c_random_access_range_of<std::optional<types::id_type>> IdRange>
-[[nodiscard]] std::deque<types::id_type> reconstruct_path(
-    const IdRange& predecessor_map, const types::id_type vertex_id
+template <traits::c_random_access_range_of<std::optional<id_type>> IdRange>
+[[nodiscard]] std::deque<id_type> reconstruct_path(
+    const IdRange& predecessor_map, const id_type vertex_id
 ) {
     if (not std::ranges::next(predecessor_map.begin(), vertex_id)->has_value())
         throw std::invalid_argument(
             std::format("[alg::reconstruct_path] The given vertex is unreachable: {}", vertex_id)
         );
 
-    std::deque<types::id_type> path;
-    types::id_type current_vertex = vertex_id;
+    std::deque<id_type> path;
+    id_type current_vertex = vertex_id;
 
     while (true) {
         path.push_front(current_vertex);
-        types::id_type predecessor = (predecessor_map.begin() + current_vertex)->value();
+        id_type predecessor = (predecessor_map.begin() + current_vertex)->value();
 
         if (predecessor == current_vertex)
             break;

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -22,7 +22,7 @@ struct paths_descriptor {
 };
 
 template <traits::c_graph GraphType>
-using paths_descriptor_type = paths_descriptor<types::vertex_distance_type<GraphType>>;
+using paths_descriptor_type = paths_descriptor<vertex_distance_type<GraphType>>;
 
 template <traits::c_graph GraphType>
 [[nodiscard]] gl_attr_force_inline paths_descriptor_type<GraphType> make_paths_descriptor(
@@ -42,7 +42,7 @@ template <
     const PostVisitCallback& post_visit = {}
 ) {
     using edge_type = typename GraphType::edge_type;
-    using distance_type = types::vertex_distance_type<GraphType>;
+    using distance_type = vertex_distance_type<GraphType>;
 
     auto paths = make_paths_descriptor<GraphType>(graph);
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -18,7 +18,7 @@ struct mst_descriptor {
     using edge_type = typename graph_type::edge_type;
     using weight_type = types::vertex_distance_type<graph_type>;
 
-    mst_descriptor(const types::size_type n_vertices) {
+    mst_descriptor(const size_type n_vertices) {
         edges.reserve(n_vertices - 1uz);
     }
 
@@ -28,7 +28,7 @@ struct mst_descriptor {
 
 template <traits::c_undirected_graph GraphType>
 [[nodiscard]] mst_descriptor<GraphType> edge_heap_prim_mst(
-    const GraphType& graph, const std::optional<types::id_type> root_id_opt
+    const GraphType& graph, const std::optional<id_type> root_id_opt
 ) {
     // type definitions
     using edge_type = typename GraphType::edge_type;
@@ -50,14 +50,14 @@ template <traits::c_undirected_graph GraphType>
     queue_type edge_queue;
 
     // insert the edges adjacent to the root vertex to the queue
-    const types::id_type root_id = root_id_opt.value_or(constants::initial_id);
+    const id_type root_id = root_id_opt.value_or(constants::initial_id);
 
     for (const auto& edge : graph.adjacent_edges(root_id))
         edge_queue.emplace(edge);
 
     // mark the root vertex as visited
     visited[root_id] = true;
-    types::size_type n_vertices_in_mst = 1uz;
+    size_type n_vertices_in_mst = 1uz;
 
     // find the mst
     while (n_vertices_in_mst < n_vertices) {
@@ -86,7 +86,7 @@ template <traits::c_undirected_graph GraphType>
 template <traits::c_undirected_graph GraphType>
 requires traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
 [[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
-    const GraphType& graph, const std::optional<types::id_type> root_id_opt
+    const GraphType& graph, const std::optional<id_type> root_id_opt
 ) {
     // type definitions
     using edge_type = typename GraphType::edge_type;
@@ -103,12 +103,12 @@ requires traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>
     // set the distance to the root vertex to 0
     min_cost.at(root_id_opt.value_or(constants::initial_id)) = static_cast<distance_type>(0);
 
-    auto heap_comparator = [&min_cost](const types::id_type lhs, const types::id_type rhs) {
+    auto heap_comparator = [&min_cost](const id_type lhs, const id_type rhs) {
         return min_cost[lhs] > min_cost[rhs]; // min-heap based on min_cost
     };
 
     // Initialize the vertex info and the heap
-    std::vector<types::id_type> heap(n_vertices);
+    std::vector<id_type> heap(n_vertices);
     std::iota(heap.begin(), heap.end(), constants::initial_id);
     std::make_heap(heap.begin(), heap.end(), heap_comparator);
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -16,7 +16,7 @@ template <traits::c_undirected_graph GraphType>
 struct mst_descriptor {
     using graph_type = GraphType;
     using edge_type = typename graph_type::edge_type;
-    using weight_type = types::vertex_distance_type<graph_type>;
+    using weight_type = vertex_distance_type<graph_type>;
 
     mst_descriptor(const size_type n_vertices) {
         edges.reserve(n_vertices - 1uz);
@@ -84,13 +84,13 @@ template <traits::c_undirected_graph GraphType>
 }
 
 template <traits::c_undirected_graph GraphType>
-requires traits::c_has_numeric_limits_max<types::vertex_distance_type<GraphType>>
+requires traits::c_has_numeric_limits_max<vertex_distance_type<GraphType>>
 [[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
     const GraphType& graph, const std::optional<id_type> root_id_opt
 ) {
     // type definitions
     using edge_type = typename GraphType::edge_type;
-    using distance_type = types::vertex_distance_type<GraphType>;
+    using distance_type = vertex_distance_type<GraphType>;
 
     // Prepare the necessary utility
     const auto n_vertices = graph.order();

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -16,7 +16,7 @@ template <
     traits::c_forward_range_of<algorithm::vertex_info> InitQueueRangeType =
         std::vector<algorithm::vertex_info>,
     traits::c_optional_id_callback<bool> VisitVertexPredicate,
-    traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    traits::c_optional_id_callback<bool, id_type> VisitCallback,
     traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
     traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -14,13 +14,13 @@ namespace gl::algorithm {
 template <
     traits::c_graph GraphType,
     traits::c_optional_id_callback<bool> VisitVertexPredicate,
-    traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    traits::c_optional_id_callback<bool, id_type> VisitCallback,
     traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
     traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void dfs(
     const GraphType& graph,
-    const types::id_type root_id,
+    const id_type root_id,
     const VisitVertexPredicate& visit_vertex_pred,
     const VisitCallback& visit,
     const EnqueueVertexPred& enqueue_vertex_pred,
@@ -65,14 +65,14 @@ void dfs(
 template <
     traits::c_graph GraphType,
     traits::c_optional_id_callback<bool> VisitVertexPredicate,
-    traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    traits::c_optional_id_callback<bool, id_type> VisitCallback,
     traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
     traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 void r_dfs(
     const GraphType& graph,
-    const types::id_type vertex_id,
-    const types::id_type pred_id,
+    const id_type vertex_id,
+    const id_type pred_id,
     const VisitVertexPredicate& visit_vertex_pred,
     const VisitCallback& visit,
     const EnqueueVertexPred& enqueue_vertex_pred,

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -17,7 +17,7 @@ template <
     traits::c_forward_range_of<algorithm::vertex_info> InitQueueRangeType =
         std::vector<algorithm::vertex_info>,
     traits::c_optional_id_callback<GraphType, bool> VisitVertexPredicate,
-    traits::c_optional_id_callback<bool, types::id_type> VisitCallback,
+    traits::c_optional_id_callback<bool, id_type> VisitCallback,
     traits::c_id_callback<predicate_result, const typename GraphType::edge_type&> EnqueueVertexPred,
     traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -37,7 +37,7 @@ template <
             init_range(root_id),
             algorithm::empty_callback{}, // visit predicate
             algorithm::empty_callback{}, // visit callback
-            [&coloring](const types::id_type vertex_id, const edge_type& in_edge)
+            [&coloring](const id_type vertex_id, const edge_type& in_edge)
                 -> predicate_result { // enqueue predicate
                 if (in_edge.is_loop())
                     return false;

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -8,7 +8,7 @@
 
 namespace gl::algorithm {
 
-using bicoloring_type = std::vector<types::binary_color>;
+using bicoloring_type = std::vector<binary_color>;
 
 template <
     traits::c_graph GraphType,
@@ -69,7 +69,7 @@ template <
     return bipartite_coloring(graph).has_value();
 }
 
-template <traits::c_graph GraphType, traits::c_sized_range_of<types::binary_color> ColorRange>
+template <traits::c_graph GraphType, traits::c_sized_range_of<binary_color> ColorRange>
 requires(traits::c_binary_color_properties_type<typename GraphType::vertex_properties_type>)
 bool apply_coloring(GraphType& graph, const ColorRange& color_range) {
     if (std::ranges::size(color_range) != graph.order())

--- a/include/gl/algorithm/topology/topological_sort.hpp
+++ b/include/gl/algorithm/topology/topological_sort.hpp
@@ -12,7 +12,7 @@ template <
     traits::c_directed_graph GraphType,
     traits::c_optional_id_callback<void> PreVisitCallback = algorithm::empty_callback,
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
-[[nodiscard]] std::optional<std::vector<types::id_type>> topological_sort(
+[[nodiscard]] std::optional<std::vector<id_type>> topological_sort(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
@@ -20,7 +20,7 @@ template <
     using edge_type = typename GraphType::edge_type;
 
     // prepare the vertex in degree map
-    std::vector<types::size_type> in_degree_map = graph.in_degree_map();
+    std::vector<size_type> in_degree_map = graph.in_degree_map();
 
     // prepare the initial queue content (source vertices)
     std::vector<algorithm::vertex_info> source_vertex_list;
@@ -29,8 +29,7 @@ template <
         if (in_degree_map[id] == 0uz)
             source_vertex_list.emplace_back(id);
 
-    std::optional<std::vector<types::id_type>> topological_order_opt =
-        std::vector<types::id_type>{};
+    std::optional<std::vector<id_type>> topological_order_opt = std::vector<id_type>{};
     auto& topological_order = topological_order_opt.value();
     topological_order.reserve(graph.order());
 
@@ -39,12 +38,12 @@ template <
         source_vertex_list,
         algorithm::empty_callback{}, // visit predicate
         [&topological_order](
-            const types::id_type vertex_id, [[maybe_unused]] const types::id_type source_id
+            const id_type vertex_id, [[maybe_unused]] const id_type source_id
         ) { // visit callback
             topological_order.push_back(vertex_id);
             return true;
         },
-        [&in_degree_map](const types::id_type vertex_id, const edge_type& in_edge)
+        [&in_degree_map](const id_type vertex_id, const edge_type& in_edge)
             -> predicate_result { // enqueue predicate
             if (in_edge.is_loop())
                 return false;

--- a/include/gl/algorithm/traits.hpp
+++ b/include/gl/algorithm/traits.hpp
@@ -17,10 +17,10 @@ template <typename F, typename ReturnType, typename... Args>
 concept c_optional_callback = c_empty_callback<F> or std::is_invocable_r_v<ReturnType, F, Args...>;
 
 template <typename F, typename ReturnType, typename... Args>
-concept c_id_callback = std::is_invocable_r_v<ReturnType, F, const types::id_type, Args...>;
+concept c_id_callback = std::is_invocable_r_v<ReturnType, F, const id_type, Args...>;
 
 template <typename F, typename ReturnType, typename... Args>
-concept c_optional_id_callback = c_optional_callback<F, ReturnType, const types::id_type, Args...>;
+concept c_optional_id_callback = c_optional_callback<F, ReturnType, const id_type, Args...>;
 
 template <typename F, typename GraphType, typename ReturnType, typename... Args>
 concept c_edge_callback =

--- a/include/gl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/gl/algorithm/traversal/breadth_first_search.hpp
@@ -18,12 +18,12 @@ template <
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 return_type<ResultDiscriminator, predecessors_map> breadth_first_search(
     const GraphType& graph,
-    const types::id_type root_vertex_id = no_root_vertex,
+    const id_type root_vertex_id = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<types::id_type> sources(graph.order());
+    std::vector<id_type> sources(graph.order());
 
     auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
 

--- a/include/gl/algorithm/traversal/depth_first_search.hpp
+++ b/include/gl/algorithm/traversal/depth_first_search.hpp
@@ -17,12 +17,12 @@ template <
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 return_type<ResultDiscriminator, predecessors_map> depth_first_search(
     const GraphType& graph,
-    const types::id_type root_vertex_id = no_root_vertex,
+    const id_type root_vertex_id = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<types::id_type> sources(graph.order());
+    std::vector<id_type> sources(graph.order());
 
     auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
 
@@ -65,12 +65,12 @@ template <
     traits::c_optional_id_callback<void> PostVisitCallback = algorithm::empty_callback>
 return_type<ResultDiscriminator, predecessors_map> recursive_depth_first_search(
     const GraphType& graph,
-    const types::id_type root_vertex_id = no_root_vertex,
+    const id_type root_vertex_id = no_root_vertex,
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<types::id_type> sources(graph.order());
+    std::vector<id_type> sources(graph.order());
 
     auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
 

--- a/include/gl/algorithm/util.hpp
+++ b/include/gl/algorithm/util.hpp
@@ -22,8 +22,7 @@ init_predecessors_map(const traits::c_graph auto& graph) {
 }
 
 [[nodiscard]] gl_attr_force_inline bool is_reachable(
-    const traits::c_random_access_range_of<types::id_type> auto& pred_map,
-    const types::id_type vertex_id
+    const traits::c_random_access_range_of<id_type> auto& pred_map, const id_type vertex_id
 ) noexcept {
     return pred_map[vertex_id] != constants::invalid_id;
 }
@@ -31,12 +30,12 @@ init_predecessors_map(const traits::c_graph auto& graph) {
 template <
     traits::c_forward_range_of<algorithm::vertex_info> InitRangeType =
         std::vector<algorithm::vertex_info>>
-[[nodiscard]] gl_attr_force_inline InitRangeType init_range(types::id_type root_vertex_id) {
+[[nodiscard]] gl_attr_force_inline InitRangeType init_range(id_type root_vertex_id) {
     return InitRangeType{algorithm::vertex_info{root_vertex_id}};
 }
 
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited) {
-    return [&](const types::id_type vertex_id) -> bool { return not visited[vertex_id]; };
+    return [&](const id_type vertex_id) -> bool { return not visited[vertex_id]; };
 }
 
 template <result_discriminator ResultDiscriminator>
@@ -44,7 +43,7 @@ template <result_discriminator ResultDiscriminator>
     std::vector<bool>& visited,
     non_void_return_type<ResultDiscriminator, predecessors_map>& pred_map
 ) {
-    return [&](const types::id_type vertex_id, const types::id_type pred_id) {
+    return [&](const id_type vertex_id, const id_type pred_id) {
         visited[vertex_id] = true;
         if constexpr (ResultDiscriminator == algorithm::ret)
             pred_map[vertex_id] = pred_id;
@@ -57,10 +56,9 @@ template <traits::c_graph GraphType, bool AsResult = false>
 ) {
     using return_type = std::conditional_t<AsResult, predicate_result, bool>;
 
-    return [&](const types::id_type vertex_id,
-               [[maybe_unused]] const typename GraphType::edge_type& in_edge) -> return_type {
-        return not visited[vertex_id];
-    };
+    return
+        [&](const id_type vertex_id, [[maybe_unused]] const typename GraphType::edge_type& in_edge
+        ) -> return_type { return not visited[vertex_id]; };
 }
 
 } // namespace gl::algorithm

--- a/include/gl/constants.hpp
+++ b/include/gl/constants.hpp
@@ -10,7 +10,7 @@
 
 namespace gl::constants {
 
-inline constexpr types::id_type initial_id{std::numeric_limits<types::id_type>::min()};
-inline constexpr types::id_type invalid_id{std::numeric_limits<types::id_type>::max()};
+inline constexpr id_type initial_id{std::numeric_limits<id_type>::min()};
+inline constexpr id_type invalid_id{std::numeric_limits<id_type>::max()};
 
 } // namespace gl::constants

--- a/include/gl/directional_tags.hpp
+++ b/include/gl/directional_tags.hpp
@@ -44,7 +44,7 @@ struct directed_t {
     template <traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(traits::c_directed_edge<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
-        const EdgeType& edge, const types::id_type vertex_id
+        const EdgeType& edge, const id_type vertex_id
     ) {
         return vertex_id == edge._vertices.first;
     }
@@ -52,7 +52,7 @@ struct directed_t {
     template <traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(traits::c_directed_edge<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
-        const EdgeType& edge, const types::id_type vertex_id
+        const EdgeType& edge, const id_type vertex_id
     ) {
         return vertex_id == edge._vertices.second;
     }
@@ -64,7 +64,7 @@ struct undirected_t {
     template <traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(traits::c_undirected_edge<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static bool is_incident_from(
-        const EdgeType& edge, const types::id_type vertex_id
+        const EdgeType& edge, const id_type vertex_id
     ) {
         return edge.is_incident_with(vertex_id);
     }
@@ -72,7 +72,7 @@ struct undirected_t {
     template <traits::c_instantiation_of<edge_descriptor> EdgeType>
     requires(traits::c_undirected_edge<EdgeType>)
     [[nodiscard]] gl_attr_force_inline static bool is_incident_to(
-        const EdgeType& edge, const types::id_type vertex_id
+        const EdgeType& edge, const id_type vertex_id
     ) {
         return edge.is_incident_with(vertex_id);
     }

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -30,17 +30,12 @@ public:
         *this = edge_descriptor::invalid();
     }
 
-    explicit edge_descriptor(
-        const types::id_type id, const types::id_type source, const types::id_type target
-    )
+    explicit edge_descriptor(const id_type id, const id_type source, const id_type target)
     requires(traits::c_empty_properties<properties_type>)
     : _id(id), _vertices(source, target) {}
 
     explicit edge_descriptor(
-        const types::id_type id,
-        const types::id_type source,
-        const types::id_type target,
-        properties_type& properties
+        const id_type id, const id_type source, const id_type target, properties_type& properties
     )
     requires(traits::c_non_empty_properties<properties_type>)
     : _id(id), _vertices(source, target), _properties(properties) {}
@@ -99,16 +94,16 @@ public:
            and this->_vertices.second != constants::invalid_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::id_type id() const noexcept {
+    [[nodiscard]] gl_attr_force_inline id_type id() const noexcept {
         return this->_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::homogeneous_pair<types::id_type> incident_vertices(
+    [[nodiscard]] gl_attr_force_inline homogeneous_pair<id_type> incident_vertices(
     ) const noexcept {
         return this->_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::homogeneous_pair<types::id_type> incident_vertices_r(
+    [[nodiscard]] gl_attr_force_inline homogeneous_pair<id_type> incident_vertices_r(
     ) const noexcept {
         return std::make_pair(this->_vertices.second, this->_vertices.first);
     }
@@ -116,18 +111,18 @@ public:
     // clang-format off
     // gl_attr_force_inline misplacement
 
-    [[nodiscard]] gl_attr_force_inline const types::id_type source() const noexcept {
+    [[nodiscard]] gl_attr_force_inline const id_type source() const noexcept {
         return this->_vertices.first;
     }
 
-    [[nodiscard]] gl_attr_force_inline const types::id_type target() const noexcept {
+    [[nodiscard]] gl_attr_force_inline const id_type target() const noexcept {
         return this->_vertices.second;
     }
 
     // clang-format on
 
     // returns the `other` vertex or throws error if the given vertex is not incident with the edge
-    [[nodiscard]] const types::id_type incident_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] const id_type incident_vertex(const id_type vertex_id) const {
         if (vertex_id == this->_vertices.first)
             return this->_vertices.second;
 
@@ -137,20 +132,19 @@ public:
         throw std::invalid_argument(std::format("Got invalid vertex id: {}", vertex_id));
     }
 
-    [[nodiscard]] gl_attr_force_inline bool is_incident_with(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline bool is_incident_with(const id_type vertex_id
     ) const noexcept {
         return vertex_id == this->_vertices.first or vertex_id == this->_vertices.second;
     }
 
     // true if the given vertex is the `source` of the edge
-    [[nodiscard]] gl_attr_force_inline bool is_incident_from(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline bool is_incident_from(const id_type vertex_id
     ) const noexcept {
         return directional_tag::is_incident_from(*this, vertex_id);
     }
 
     // true if the given vertex is the `target` vertex of the edge
-    [[nodiscard]] gl_attr_force_inline bool is_incident_to(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline bool is_incident_to(const id_type vertex_id) const noexcept {
         return directional_tag::is_incident_to(*this, vertex_id);
     }
 
@@ -201,8 +195,8 @@ private:
             os << "[" << this->_vertices.first << ", " << this->_vertices.second << "]";
     }
 
-    types::id_type _id;
-    types::homogeneous_pair<types::id_type> _vertices;
+    id_type _id;
+    homogeneous_pair<id_type> _vertices;
     [[no_unique_address]] std::conditional_t<
         traits::c_empty_properties<properties_type>,
         types::empty_properties,

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -13,7 +13,7 @@ namespace gl {
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties Properties = types::empty_properties>
+    traits::c_properties Properties = empty_properties>
 class edge_descriptor final {
 public:
     using type = edge_descriptor<DirectionalTag, Properties>;
@@ -21,7 +21,7 @@ public:
     using properties_type = Properties;
     using properties_ref_type = std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         properties_type&>;
 
     friend directional_tag;
@@ -199,19 +199,19 @@ private:
     homogeneous_pair<id_type> _vertices;
     [[no_unique_address]] std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         std::reference_wrapper<properties_type>> _properties;
 };
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties Properties = types::empty_properties>
+    traits::c_properties Properties = empty_properties>
 using edge = edge_descriptor<DirectionalTag, Properties>;
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 using directed_edge = edge_descriptor<directed_t, Properties>;
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 using undirected_edge = edge_descriptor<undirected_t, Properties>;
 
 } // namespace gl

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -76,7 +76,7 @@ public:
     using vertex_properties_type = typename traits_type::vertex_properties_type;
     using vertex_properties_map_type = std::conditional_t<
         traits::c_empty_properties<vertex_properties_type>,
-        types::empty_properties_map,
+        empty_properties_map,
         std::vector<std::unique_ptr<vertex_properties_type>>>;
 
     using edge_type = typename traits_type::edge_type;
@@ -84,7 +84,7 @@ public:
 
     using edge_properties_map_type = std::conditional_t<
         traits::c_empty_properties<edge_properties_type>,
-        types::empty_properties_map,
+        empty_properties_map,
         std::vector<std::unique_ptr<edge_properties_type>>>;
 
     graph& operator=(const graph&) = delete;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -185,7 +185,7 @@ public:
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
             const auto old_size = this->_vertex_properties.size();
             this->_vertex_properties.reserve(this->_n_vertices);
-            for (size_type i = old_size; i < this->_n_vertices; ++i)
+            for (auto i = old_size; i < this->_n_vertices; ++i)
                 this->_vertex_properties.push_back(std::make_unique<vertex_properties_type>());
         }
     }
@@ -783,7 +783,7 @@ private:
             else {
                 // read vertex properties and use them to initialze the vertices
                 std::vector<vertex_properties_type> vertex_properties(n_vertices);
-                for (id_type i = 0uz; i < n_vertices; ++i)
+                for (auto i = 0uz; i < n_vertices; ++i)
                     is >> vertex_properties[i];
                 this->add_vertices_with(vertex_properties);
             }
@@ -805,7 +805,7 @@ private:
                 id_type source_id, target_id;
                 edge_properties_type properties;
 
-                for (size_type _ = 0uz; _ < n_edges; ++_) {
+                for (auto _ = 0uz; _ < n_edges; ++_) {
                     is >> source_id >> target_id >> properties;
                     this->add_edge_with(source_id, target_id, properties);
                 }
@@ -815,7 +815,7 @@ private:
             // read the edges
             id_type source_id, target_id;
 
-            for (size_type _ = 0uz; _ < n_edges; ++_) {
+            for (auto _ = 0uz; _ < n_edges; ++_) {
                 is >> source_id >> target_id;
                 this->add_edge(source_id, target_id);
             }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -838,8 +838,6 @@ template <traits::c_graph Graph>
     return Graph(source);
 }
 
-namespace types {
-
 using default_vertex_distance_type = std::int64_t;
 
 template <traits::c_graph GraphType>
@@ -856,16 +854,14 @@ struct vertex_distance<GraphType> {
 template <traits::c_graph GraphType>
 using vertex_distance_type = typename vertex_distance<GraphType>::type;
 
-} // namespace types
-
 template <traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline types::vertex_distance_type<GraphType> get_weight(
+[[nodiscard]] gl_attr_force_inline vertex_distance_type<GraphType> get_weight(
     const typename GraphType::edge_type& edge
 ) {
     if constexpr (traits::c_weight_properties_type<typename GraphType::edge_properties_type>)
         return edge.properties().weight;
     else
-        return static_cast<types::default_vertex_distance_type>(1ll);
+        return static_cast<default_vertex_distance_type>(1ll);
 }
 
 } // namespace gl

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -91,7 +91,7 @@ public:
 
     graph() = default;
 
-    explicit graph(const types::size_type n_vertices) : _n_vertices(n_vertices), _impl(n_vertices) {
+    explicit graph(const size_type n_vertices) : _n_vertices(n_vertices), _impl(n_vertices) {
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
             this->_vertex_properties.reserve(n_vertices);
             for (const auto _ : this->vertex_ids())
@@ -106,11 +106,11 @@ public:
 
     // --- general methods ---
 
-    [[nodiscard]] gl_attr_force_inline types::size_type order() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type order() const noexcept {
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type size() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type size() const noexcept {
         return this->_n_edges;
     }
 
@@ -120,7 +120,7 @@ public:
     requires(traits::c_empty_properties<vertex_properties_type>)
     {
         return this->vertex_ids()
-             | std::views::transform([](const types::id_type id) { return vertex_descriptor{id}; });
+             | std::views::transform([](const id_type id) { return vertex_descriptor{id}; });
     }
 
     [[nodiscard]] gl_attr_force_inline auto vertices() const
@@ -129,7 +129,7 @@ public:
         return this->_vertex_properties | std::views::enumerate
              | std::views::transform([](const auto& x) {
                    const auto& [id, ptr] = x;
-                   return vertex_descriptor{static_cast<types::id_type>(id), *ptr};
+                   return vertex_descriptor{static_cast<id_type>(id), *ptr};
                });
     }
 
@@ -137,7 +137,7 @@ public:
         return std::views::iota(constants::initial_id, this->_n_vertices);
     }
 
-    [[nodiscard]] vertex_type get_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] vertex_type get_vertex(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_descriptor{vertex_id, *this->_vertex_properties[vertex_id]};
@@ -145,7 +145,7 @@ public:
             return vertex_descriptor{vertex_id};
     }
 
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
         return vertex_id < this->_n_vertices;
     }
 
@@ -178,14 +178,14 @@ public:
         };
     }
 
-    void add_vertices(const types::size_type n) {
+    void add_vertices(const size_type n) {
         this->_impl.add_vertices(n);
         this->_n_vertices += n;
 
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
             const auto old_size = this->_vertex_properties.size();
             this->_vertex_properties.reserve(this->_n_vertices);
-            for (types::size_type i = old_size; i < this->_n_vertices; ++i)
+            for (size_type i = old_size; i < this->_n_vertices; ++i)
                 this->_vertex_properties.push_back(std::make_unique<vertex_properties_type>());
         }
     }
@@ -209,7 +209,7 @@ public:
         }
     }
 
-    gl_attr_force_inline void remove_vertex(const types::size_type vertex_id) {
+    gl_attr_force_inline void remove_vertex(const size_type vertex_id) {
         this->_verify_vertex_id(vertex_id);
         this->_remove_vertex_impl(vertex_id);
     }
@@ -218,10 +218,9 @@ public:
         this->remove_vertex(vertex.id());
     }
 
-    void remove_vertices_from(const traits::c_forward_range_of<types::id_type> auto& vertex_id_rng
-    ) {
+    void remove_vertices_from(const traits::c_forward_range_of<id_type> auto& vertex_id_rng) {
         // sorts the ids in a descending order and removes duplicate ids
-        std::set<types::id_type, std::greater<>> vertex_id_set(
+        std::set<id_type, std::greater<>> vertex_id_set(
             std::ranges::begin(vertex_id_rng), std::ranges::end(vertex_id_rng)
         );
 
@@ -240,50 +239,46 @@ public:
             this->_remove_vertex_impl(vertex.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type in_degree(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.in_degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline size_type in_degree(const vertex_type& vertex) const {
         return this->in_degree(vertex.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> in_degree_map() const {
         return this->_impl.in_degree_map();
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type out_degree(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.out_degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type out_degree(const vertex_type& vertex) const {
         return this->out_degree(vertex.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> out_degree_map() const {
         return this->_impl.out_degree_map();
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const vertex_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const vertex_type& vertex) const {
         return this->degree(vertex.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map() const {
         return this->_impl.degree_map();
     }
 
-    [[nodiscard]] inline auto at(const types::id_type vertex_id) const {
+    [[nodiscard]] inline auto at(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
             return this->_impl.at(vertex_id, this->_edge_properties);
@@ -295,7 +290,7 @@ public:
         return this->at(vertex.id());
     }
 
-    [[nodiscard]] inline auto adjacent_edges(const types::id_type vertex_id) const {
+    [[nodiscard]] inline auto adjacent_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
             return this->_impl.adjacent_edges(vertex_id, this->_edge_properties);
@@ -307,7 +302,7 @@ public:
         return this->adjacent_edges(vertex.id());
     }
 
-    [[nodiscard]] inline auto in_edges(const types::id_type vertex_id) const {
+    [[nodiscard]] inline auto in_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
             return this->_impl.in_edges(vertex_id, this->_edge_properties);
@@ -319,7 +314,7 @@ public:
         return this->in_edges(vertex.id());
     }
 
-    [[nodiscard]] inline auto out_edges(const types::id_type vertex_id) const {
+    [[nodiscard]] inline auto out_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
             return this->_impl.out_edges(vertex_id, this->_edge_properties);
@@ -337,7 +332,7 @@ public:
         return std::views::iota(constants::initial_id, this->_n_edges);
     }
 
-    const edge_type add_edge(const types::id_type source_id, const types::id_type target_id) {
+    const edge_type add_edge(const id_type source_id, const id_type target_id) {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
 
@@ -355,9 +350,7 @@ public:
     }
 
     const edge_type add_edge_with(
-        const types::id_type source_id,
-        const types::id_type target_id,
-        const edge_properties_type& properties
+        const id_type source_id, const id_type target_id, const edge_properties_type& properties
     )
     requires(traits::c_non_empty_properties<edge_properties_type>)
     {
@@ -391,8 +384,7 @@ public:
     // clang-format on
 
     void add_edges_from(
-        const types::id_type source_id,
-        const traits::c_sized_range_of<types::id_type> auto& target_id_rng
+        const id_type source_id, const traits::c_sized_range_of<id_type> auto& target_id_rng
     ) {
         this->_verify_vertex_id(source_id);
 
@@ -430,7 +422,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
@@ -448,7 +440,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline std::optional<edge_type> get_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
@@ -466,7 +458,7 @@ public:
     }
 
     [[nodiscard]] inline std::vector<edge_type> get_edges(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
@@ -504,8 +496,7 @@ public:
 
     // --- incidence methods ---
 
-    [[nodiscard]] bool are_incident(const types::id_type source_id, const types::id_type target_id)
-        const {
+    [[nodiscard]] bool are_incident(const id_type source_id, const id_type target_id) const {
         this->_verify_vertex_id(source_id);
         if (source_id == target_id)
             return true;
@@ -551,7 +542,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline vertex_properties_type& get_vertex_properties(
-        const types::id_type id
+        const id_type id
     ) const
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
@@ -565,7 +556,7 @@ public:
         return util::deref_view(this->_edge_properties);
     }
 
-    [[nodiscard]] edge_properties_type& get_edge_properties(const types::id_type id) const
+    [[nodiscard]] edge_properties_type& get_edge_properties(const id_type id) const
     requires(traits::c_non_empty_properties<edge_properties_type>)
     {
         if (id >= this->_n_edges)
@@ -653,7 +644,7 @@ private:
 
     // --- graph element verification methods ---
 
-    gl_attr_force_inline void _verify_vertex_id(const types::id_type vertex_id) const {
+    gl_attr_force_inline void _verify_vertex_id(const id_type vertex_id) const {
         if (not this->has_vertex(vertex_id))
             throw std::out_of_range(std::format("Got invalid vertex id [{}]", vertex_id));
     }
@@ -671,7 +662,7 @@ private:
 
     // --- vertex methods ---
 
-    void _remove_vertex_impl(const types::id_type vertex_id) {
+    void _remove_vertex_impl(const id_type vertex_id) {
         const auto removed_edge_ids = this->_impl.remove_vertex(vertex_id);
         this->_n_vertices--;
         this->_n_edges -= removed_edge_ids.size();
@@ -737,7 +728,7 @@ private:
 
         if constexpr (traits::c_writable<typename edge_type::properties_type>) {
             if (with_edge_properties) {
-                const auto print_incident_edges = [this, &os](const types::id_type vertex_id) {
+                const auto print_incident_edges = [this, &os](const id_type vertex_id) {
                     for (const auto& edge : this->adjacent_edges(vertex_id)) {
                         if (edge.source() != vertex_id)
                             continue; // vertex is not the source
@@ -753,7 +744,7 @@ private:
             }
         }
 
-        const auto print_incident_edges = [this, &os](const types::id_type vertex_id) {
+        const auto print_incident_edges = [this, &os](const id_type vertex_id) {
             for (const auto& edge : this->adjacent_edges(vertex_id)) {
                 if (edge.source() != vertex_id)
                     continue; // vertex is not the source
@@ -776,7 +767,7 @@ private:
             ));
 
         // read initial graph parameters
-        types::id_type n_vertices, n_edges;
+        id_type n_vertices, n_edges;
         is >> n_vertices >> n_edges;
 
         bool with_vertex_properties, with_edge_properties;
@@ -792,7 +783,7 @@ private:
             else {
                 // read vertex properties and use them to initialze the vertices
                 std::vector<vertex_properties_type> vertex_properties(n_vertices);
-                for (types::id_type i = 0uz; i < n_vertices; ++i)
+                for (id_type i = 0uz; i < n_vertices; ++i)
                     is >> vertex_properties[i];
                 this->add_vertices_with(vertex_properties);
             }
@@ -811,10 +802,10 @@ private:
             }
             else {
                 // read edges with their properties
-                types::id_type source_id, target_id;
+                id_type source_id, target_id;
                 edge_properties_type properties;
 
-                for (types::size_type _ = 0uz; _ < n_edges; ++_) {
+                for (size_type _ = 0uz; _ < n_edges; ++_) {
                     is >> source_id >> target_id >> properties;
                     this->add_edge_with(source_id, target_id, properties);
                 }
@@ -822,17 +813,17 @@ private:
         }
         else {
             // read the edges
-            types::id_type source_id, target_id;
+            id_type source_id, target_id;
 
-            for (types::size_type _ = 0uz; _ < n_edges; ++_) {
+            for (size_type _ = 0uz; _ < n_edges; ++_) {
                 is >> source_id >> target_id;
                 this->add_edge(source_id, target_id);
             }
         }
     }
 
-    types::size_type _n_vertices = 0uz;
-    types::size_type _n_edges = 0uz;
+    size_type _n_vertices = 0uz;
+    size_type _n_edges = 0uz;
 
     [[no_unique_address]] vertex_properties_map_type _vertex_properties{};
     [[no_unique_address]] edge_properties_map_type _edge_properties{};

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -12,8 +12,8 @@ namespace gl {
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
     traits::c_graph_impl_tag ImplTag = impl::list_t>
 struct graph_traits {
     using directional_tag = DirectionalTag;
@@ -28,34 +28,34 @@ struct graph_traits {
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties>
 using list_graph_traits =
     graph_traits<DirectionalTag, VertexProperties, EdgeProperties, impl::list_t>;
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties>
 using flat_list_graph_traits =
     graph_traits<DirectionalTag, VertexProperties, EdgeProperties, impl::flat_list_t>;
 
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties>
 using matrix_graph_traits =
     graph_traits<DirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t>;
 
 template <
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
     traits::c_graph_impl_tag ImplTag = impl::list_t>
 using directed_graph_traits = graph_traits<directed_t, VertexProperties, EdgeProperties, ImplTag>;
 
 template <
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties EdgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
     traits::c_graph_impl_tag ImplTag = impl::list_t>
 using undirected_graph_traits =
     graph_traits<undirected_t, VertexProperties, EdgeProperties, ImplTag>;

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -39,7 +39,7 @@ public:
 
     adjacency_list() = default;
 
-    explicit adjacency_list(const types::size_type n_vertices) : _list(n_vertices) {}
+    explicit adjacency_list(const size_type n_vertices) : _list(n_vertices) {}
 
     adjacency_list(const adjacency_list&) = default;
     adjacency_list& operator=(const adjacency_list&) = default;
@@ -55,38 +55,35 @@ public:
         this->_list.resize(this->_list.size() + 1uz);
     }
 
-    inline void add_vertices(const types::size_type n) {
+    inline void add_vertices(const size_type n) {
         this->_list.resize(this->_list.size() + n);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const {
         return specialized_impl::degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type in_degree(const id_type vertex_id) const {
         return specialized_impl::in_degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type out_degree(const id_type vertex_id) const {
         return specialized_impl::out_degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map() const {
         return specialized_impl::degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> in_degree_map() const {
         return specialized_impl::in_degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> out_degree_map() const {
         return specialized_impl::out_degree_map(*this);
     }
 
-    std::vector<types::id_type> remove_vertex(const types::id_type vertex_id) {
+    std::vector<id_type> remove_vertex(const id_type vertex_id) {
         auto removed_edge_ids = specialized_impl::remove_vertex(*this, vertex_id);
         this->_remap_element_ids(vertex_id, removed_edge_ids);
         return removed_edge_ids;
@@ -94,22 +91,20 @@ public:
 
     // --- edge methods ---
 
-    gl_attr_force_inline void add_edge(
-        types::id_type id, types::id_type source_id, types::id_type target_id
-    ) {
+    gl_attr_force_inline void add_edge(id_type id, id_type source_id, id_type target_id) {
         specialized_impl::add_edge(*this, id, source_id, target_id);
     }
 
     gl_attr_force_inline void add_edges_from(
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         specialized_impl::add_edges_from(*this, edge_ids, source_id, target_ids);
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const {
         return std::ranges::contains(
             this->_list[source_id], target_id, &specialized::adjacency_list_item::vertex_id
@@ -123,7 +118,7 @@ public:
     }
 
     [[nodiscard]] std::optional<edge_type> get_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
@@ -137,9 +132,7 @@ public:
     }
 
     [[nodiscard]] std::optional<edge_type> get_edge(
-        const types::id_type source_id,
-        const types::id_type target_id,
-        const auto& edge_properties_map
+        const id_type source_id, const id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -154,9 +147,8 @@ public:
         );
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(
-        const types::id_type source_id, const types::id_type target_id
-    ) const
+    [[nodiscard]] std::vector<edge_type> get_edges(const id_type source_id, const id_type target_id)
+        const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[source_id] | std::views::filter([&target_id](const auto& item) {
@@ -169,9 +161,7 @@ public:
     }
 
     [[nodiscard]] std::vector<edge_type> get_edges(
-        const types::id_type source_id,
-        const types::id_type target_id,
-        const auto& edge_properties_map
+        const id_type source_id, const id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -190,10 +180,10 @@ public:
         specialized_impl::remove_edge(*this, edge);
         for (auto&& adj : this->_list)
             for (auto& item : adj)
-                item.edge_id -= static_cast<types::id_type>(item.edge_id > edge.id());
+                item.edge_id -= static_cast<id_type>(item.edge_id > edge.id());
     }
 
-    std::vector<types::id_type> remove_edges(const traits::c_range_of<edge_type> auto& edges) {
+    std::vector<id_type> remove_edges(const traits::c_range_of<edge_type> auto& edges) {
         for (const auto& edge : edges)
             specialized_impl::remove_edge(*this, edge);
         auto removed_edge_ids =
@@ -203,21 +193,21 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id, edge_properties_map);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return specialized_impl::in_edges(*this, vertex_id)
@@ -227,7 +217,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -239,7 +229,7 @@ public:
                });
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[vertex_id] | std::views::transform([vertex_id](const auto& item) {
@@ -248,7 +238,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -262,14 +252,14 @@ public:
 
     // --- access operators ---
 
-    [[nodiscard]] gl_attr_force_inline auto at(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto at(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->adjacent_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto at(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -294,7 +284,7 @@ private:
     friend specialized_impl;
 
     void _remap_element_ids(
-        const types::id_type removed_vertex_id, std::vector<types::id_type>& removed_edge_ids
+        const id_type removed_vertex_id, std::vector<id_type>& removed_edge_ids
     ) {
         std::ranges::sort(removed_edge_ids);
         removed_edge_ids.erase(

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -30,12 +30,12 @@ class adjacency_matrix final {
 public:
     using vertex_type = typename GraphTraits::vertex_type;
     using edge_type = typename GraphTraits::edge_type;
-    using row_type = std::vector<types::id_type>;
+    using row_type = std::vector<id_type>;
     using matrix_type = std::vector<row_type>;
 
     adjacency_matrix() = default;
 
-    explicit adjacency_matrix(const types::size_type n_vertices) : _matrix(n_vertices) {
+    explicit adjacency_matrix(const size_type n_vertices) : _matrix(n_vertices) {
         // initialize a full n x n matrix with null elements
         for (auto& row : this->_matrix)
             row.resize(n_vertices, constants::invalid_id);
@@ -57,44 +57,41 @@ public:
         this->_matrix.emplace_back(this->_matrix.size() + 1uz, constants::invalid_id);
     }
 
-    void add_vertices(const types::size_type n) {
+    void add_vertices(const size_type n) {
         const auto new_n_vertices = this->_matrix.size() + n;
 
         for (auto& row : this->_matrix)
             row.resize(new_n_vertices, constants::invalid_id);
 
-        for (types::size_type _ = 0uz; _ < n; ++_)
+        for (size_type _ = 0uz; _ < n; ++_)
             this->_matrix.emplace_back(new_n_vertices, constants::invalid_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type in_degree(const id_type vertex_id) const {
         return specialized_impl::in_degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type out_degree(const id_type vertex_id) const {
         return specialized_impl::out_degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const {
         return specialized_impl::degree(*this, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> in_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> in_degree_map() const {
         return specialized_impl::in_degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> out_degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> out_degree_map() const {
         return specialized_impl::out_degree_map(*this);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map() const {
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map() const {
         return specialized_impl::degree_map(*this);
     }
 
-    std::vector<types::id_type> remove_vertex(const types::id_type vertex_id) {
+    std::vector<id_type> remove_vertex(const id_type vertex_id) {
         auto removed_edge_ids = specialized_impl::remove_vertex(*this, vertex_id);
         this->_remap_element_ids(removed_edge_ids);
         return removed_edge_ids;
@@ -102,22 +99,20 @@ public:
 
     // --- edge methods ---
 
-    gl_attr_force_inline void add_edge(
-        types::id_type id, types::id_type source_id, types::id_type target_id
-    ) {
+    gl_attr_force_inline void add_edge(id_type id, id_type source_id, id_type target_id) {
         specialized_impl::add_edge(*this, id, source_id, target_id);
     }
 
     gl_attr_force_inline void add_edges_from(
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         specialized_impl::add_edges_from(*this, edge_ids, source_id, target_ids);
     }
 
     [[nodiscard]] gl_attr_force_inline bool has_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const {
         return this->_matrix[source_id][target_id] != constants::invalid_id;
     }
@@ -127,7 +122,7 @@ public:
     }
 
     [[nodiscard]] std::optional<edge_type> get_edge(
-        const types::id_type source_id, const types::id_type target_id
+        const id_type source_id, const id_type target_id
     ) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
@@ -138,9 +133,7 @@ public:
     }
 
     [[nodiscard]] std::optional<edge_type> get_edge(
-        const types::id_type source_id,
-        const types::id_type target_id,
-        const auto& edge_properties_map
+        const id_type source_id, const id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -152,9 +145,8 @@ public:
         );
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(
-        const types::id_type source_id, const types::id_type target_id
-    ) const
+    [[nodiscard]] std::vector<edge_type> get_edges(const id_type source_id, const id_type target_id)
+        const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         const auto edge_id = this->_matrix[source_id][target_id];
@@ -166,9 +158,7 @@ public:
     }
 
     [[nodiscard]] std::vector<edge_type> get_edges(
-        const types::id_type source_id,
-        const types::id_type target_id,
-        const auto& edge_properties_map
+        const id_type source_id, const id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -188,7 +178,7 @@ public:
                     edge_id--;
     }
 
-    std::vector<types::id_type> remove_edges(const traits::c_range_of<edge_type> auto& edges) {
+    std::vector<id_type> remove_edges(const traits::c_range_of<edge_type> auto& edges) {
         for (const auto& edge : edges)
             specialized_impl::remove_edge(*this, edge);
         auto removed_edge_ids =
@@ -198,21 +188,21 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id, edge_properties_map);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return std::views::iota(0uz, this->_matrix.size())
@@ -226,7 +216,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -240,7 +230,7 @@ public:
                });
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_edges(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->_matrix[vertex_id] | std::views::enumerate
@@ -250,12 +240,12 @@ public:
                })
              | std::views::transform([vertex_id](const auto& edge_info) {
                    const auto& [target_id, edge_id] = edge_info;
-                   return edge_type{edge_id, vertex_id, static_cast<types::id_type>(target_id)};
+                   return edge_type{edge_id, vertex_id, static_cast<id_type>(target_id)};
                });
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_edges(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -269,7 +259,7 @@ public:
                    return edge_type{
                        edge_id,
                        vertex_id,
-                       static_cast<types::id_type>(target_id),
+                       static_cast<id_type>(target_id),
                        *edge_properties_map[edge_id]
                    };
                });
@@ -277,7 +267,7 @@ public:
 
     // --- access operators ---
 
-    [[nodiscard]] gl_attr_force_inline auto at(const types::id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto at(const id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->_matrix[vertex_id] | std::views::enumerate
@@ -285,12 +275,12 @@ public:
                    const auto& [target_id, edge_id] = edge_info;
                    return edge_id == constants::invalid_id
                             ? edge_type::invalid()
-                            : edge_type{edge_id, vertex_id, static_cast<types::id_type>(target_id)};
+                            : edge_type{edge_id, vertex_id, static_cast<id_type>(target_id)};
                });
     }
 
     [[nodiscard]] gl_attr_force_inline auto at(
-        const types::id_type vertex_id, const auto& edge_properties_map
+        const id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
@@ -302,7 +292,7 @@ public:
                             : edge_type{
                                   edge_id,
                                   vertex_id,
-                                  static_cast<types::id_type>(target_id),
+                                  static_cast<id_type>(target_id),
                                   *edge_properties_map[edge_id]
                               };
                });
@@ -327,7 +317,7 @@ private:
         typename specialized::adjacency_matrix_impl_traits<adjacency_matrix>::type;
     friend specialized_impl;
 
-    void _remap_element_ids(std::vector<types::id_type>& removed_edge_ids) {
+    void _remap_element_ids(std::vector<id_type>& removed_edge_ids) {
         std::ranges::sort(removed_edge_ids);
         removed_edge_ids.erase(
             std::ranges::unique(removed_edge_ids).begin(), removed_edge_ids.end()

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -22,8 +22,8 @@ class adjacency_list;
 namespace specialized {
 
 struct adjacency_list_item {
-    types::id_type vertex_id;
-    types::id_type edge_id;
+    id_type vertex_id;
+    id_type edge_id;
 
     [[nodiscard]] bool operator==(const adjacency_list_item&) const = default;
 };
@@ -53,9 +53,9 @@ struct directed_adjacency_list {
     using impl_type = AdjacencyList;
     using edge_type = typename impl_type::edge_type;
 
-    [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
+    [[nodiscard]] static auto in_edges(const impl_type& self, const id_type vertex_id) {
         std::vector<adjacency_list_item> in_edges;
-        for (types::id_type src_id = constants::initial_id; src_id < self._list.size(); ++src_id) {
+        for (id_type src_id = constants::initial_id; src_id < self._list.size(); ++src_id) {
             auto in_edges_view =
                 self._list[src_id] | std::views::filter([tgt_id = vertex_id](const auto& item) {
                     return item.vertex_id == tgt_id;
@@ -68,10 +68,8 @@ struct directed_adjacency_list {
         return in_edges;
     }
 
-    [[nodiscard]] static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
-        types::size_type in_deg = 0uz;
+    [[nodiscard]] static size_type in_degree(const impl_type& self, const id_type vertex_id) {
+        size_type in_deg = 0uz;
         for (const auto& adjacent_edges : self._list)
             in_deg +=
                 std::ranges::count(adjacent_edges, vertex_id, &adjacency_list_item::vertex_id);
@@ -79,22 +77,22 @@ struct directed_adjacency_list {
         return in_deg;
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return self._list[vertex_id].size();
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return in_degree(self, vertex_id) + out_degree(self, vertex_id);
     }
 
-    [[nodiscard]] static std::vector<types::size_type> in_degree_map(const impl_type& self) {
-        std::vector<types::size_type> in_degree_map(self._list.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
+        std::vector<size_type> in_degree_map(self._list.size(), 0uz);
 
-        for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
+        for (id_type id = constants::initial_id; id < self._list.size(); ++id) {
             std::ranges::for_each(self._list[id], [&in_degree_map](const auto& item) {
                 ++in_degree_map[item.vertex_id];
             });
@@ -103,18 +101,18 @@ struct directed_adjacency_list {
         return in_degree_map;
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> out_degree_map(
         const impl_type& self
     ) {
         return self._list
              | std::views::transform([](const auto& adj_edges) { return adj_edges.size(); })
-             | std::ranges::to<std::vector<types::size_type>>();
+             | std::ranges::to<std::vector<size_type>>();
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map(self._list.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map(self._list.size(), 0uz);
 
-        for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
+        for (id_type id = constants::initial_id; id < self._list.size(); ++id) {
             degree_map[id] += self._list[id].size();
             std::ranges::for_each(self._list[id], [&degree_map](const auto& item) {
                 ++degree_map[item.vertex_id];
@@ -124,15 +122,13 @@ struct directed_adjacency_list {
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
         auto removed_edges =
             self._list[vertex_id] | std::views::transform(&adjacency_list_item::edge_id)
             | std::ranges::to<std::vector>();
 
         // remove all edges incident to the vertex
-        for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
+        for (id_type id = constants::initial_id; id < self._list.size(); ++id) {
             auto& adj_edges = self._list[id];
             if (id == vertex_id or adj_edges.empty())
                 continue;
@@ -154,16 +150,16 @@ struct directed_adjacency_list {
     }
 
     gl_attr_force_inline static void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
+        impl_type& self, id_type edge_id, id_type source_id, id_type target_id
     ) {
         self._list[source_id].emplace_back(target_id, edge_id);
     }
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());
@@ -185,55 +181,51 @@ struct undirected_adjacency_list {
     using edge_type = typename impl_type::edge_type;
 
     [[nodiscard]] gl_attr_force_inline static auto in_edges(
-        const impl_type& self, const types::id_type vertex_id
+        const impl_type& self, const id_type vertex_id
     ) {
         return std::views::all(self._list[vertex_id]);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type in_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
-        types::size_type degree = 0uz;
+    [[nodiscard]] static size_type degree(const impl_type& self, const id_type vertex_id) {
+        size_type degree = 0uz;
         for (const auto& item : self._list[vertex_id])
-            degree += 1uz + static_cast<types::size_type>(item.vertex_id == vertex_id);
+            degree += 1uz + static_cast<size_type>(item.vertex_id == vertex_id);
         return degree;
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> in_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> in_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> out_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map;
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map;
         degree_map.reserve(self._list.size());
-        for (types::id_type id = constants::initial_id; id < self._list.size(); ++id)
+        for (id_type id = constants::initial_id; id < self._list.size(); ++id)
             degree_map.push_back(degree(self, id));
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
         // remove all edges incident with the vertex (scan only the selected vertices)
         for (const auto& item : self._list[vertex_id]) {
             if (item.vertex_id == vertex_id)
@@ -254,9 +246,7 @@ struct undirected_adjacency_list {
         return removed_edges;
     }
 
-    static void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
-    ) {
+    static void add_edge(impl_type& self, id_type edge_id, id_type source_id, id_type target_id) {
         self._list[source_id].emplace_back(target_id, edge_id);
         if (target_id != source_id)
             self._list[target_id].emplace_back(source_id, edge_id);
@@ -264,9 +254,9 @@ struct undirected_adjacency_list {
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         auto& adjacent_edges_source = self._list[source_id];
         adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -114,12 +114,10 @@ struct directed_adjacency_matrix {
     }
 
     static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
-        auto removed_edges_view =
+        auto removed_edges =
             self._matrix[vertex_id]
-            | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; });
-
-        // TODO: use std::ranges::to (requires newer compiler)
-        std::vector<id_type> removed_edges(removed_edges_view.begin(), removed_edges_view.end());
+            | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; })
+            | std::ranges::to<std::vector>();
 
         self._matrix.erase(std::next(std::begin(self._matrix), vertex_id));
 
@@ -214,11 +212,10 @@ struct undirected_adjacency_matrix {
     }
 
     static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
-        auto removed_edges_view =
+        const auto removed_edges =
             self._matrix[vertex_id]
-            | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; });
-        // TODO: use std::ranges::to (requires newer compiler)
-        std::vector<id_type> removed_edges(removed_edges_view.begin(), removed_edges_view.end());
+            | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; })
+            | std::ranges::to<std::vector>();
 
         self._matrix.erase(std::next(std::begin(self._matrix), vertex_id));
         for (auto& row : self._matrix)

--- a/include/gl/impl/specialized/adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/adjacency_matrix.hpp
@@ -20,7 +20,7 @@ namespace specialized {
 
 namespace detail {
 
-[[nodiscard]] types::id_type& strict_get(auto& id_matrix, const auto& edge) {
+[[nodiscard]] id_type& strict_get(auto& id_matrix, const auto& edge) {
     // get the edge and validate the address
     const auto [source_id, target_id] = edge.incident_vertices();
     auto& edge_id = id_matrix[source_id][target_id];
@@ -33,7 +33,7 @@ namespace detail {
 }
 
 inline void check_edge_override(
-    const auto& id_matrix, const types::id_type source_id, const types::id_type target_id
+    const auto& id_matrix, const id_type source_id, const id_type target_id
 ) {
     if (const auto edge_id = id_matrix[source_id][target_id]; edge_id != constants::invalid_id)
         throw std::logic_error(std::format(
@@ -53,59 +53,55 @@ struct directed_adjacency_matrix {
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type in_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return std::ranges::count_if(self._matrix, [vertex_id](const auto& row) {
             return row[vertex_id] != constants::invalid_id;
         });
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return self._matrix[vertex_id].size()
              - std::ranges::count(self._matrix[vertex_id], constants::invalid_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type degree(
+        const impl_type& self, const id_type vertex_id
     ) {
-        types::size_type deg = 0uz;
-        for (types::id_type v_id = constants::initial_id; v_id < self._matrix.size(); ++v_id)
-            deg += static_cast<types::size_type>(
-                       self._matrix[vertex_id][v_id] != constants::invalid_id
-                   )
-                 + static_cast<types::size_type>(
-                       self._matrix[v_id][vertex_id] != constants::invalid_id
-                 );
+        size_type deg = 0uz;
+        for (id_type v_id = constants::initial_id; v_id < self._matrix.size(); ++v_id)
+            deg += static_cast<size_type>(self._matrix[vertex_id][v_id] != constants::invalid_id)
+                 + static_cast<size_type>(self._matrix[v_id][vertex_id] != constants::invalid_id);
 
         return deg;
     }
 
-    [[nodiscard]] static std::vector<types::size_type> in_degree_map(const impl_type& self) {
-        std::vector<types::size_type> in_degree_map(self._matrix.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
+        std::vector<size_type> in_degree_map(self._matrix.size(), 0uz);
 
         for (const auto& row : self._matrix)
             for (auto [target_id, edge_id] : std::views::enumerate(row))
                 in_degree_map[target_id] +=
-                    static_cast<types::size_type>(edge_id != constants::invalid_id);
+                    static_cast<size_type>(edge_id != constants::invalid_id);
 
         return in_degree_map;
     }
 
-    [[nodiscard]] static std::vector<types::size_type> out_degree_map(const impl_type& self) {
+    [[nodiscard]] static std::vector<size_type> out_degree_map(const impl_type& self) {
         return std::views::iota(constants::initial_id, self._matrix.size())
-             | std::views::transform([&](types::id_type id) { return out_degree(self, id); })
+             | std::views::transform([&](id_type id) { return out_degree(self, id); })
              | std::ranges::to<std::vector>();
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map(self._matrix.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map(self._matrix.size(), 0uz);
 
-        for (types::id_type source_id = constants::initial_id; source_id < self._matrix.size();
+        for (id_type source_id = constants::initial_id; source_id < self._matrix.size();
              ++source_id) {
-            for (types::id_type target_id = constants::initial_id; target_id < self._matrix.size();
+            for (id_type target_id = constants::initial_id; target_id < self._matrix.size();
                  ++target_id) {
                 if (self._matrix[source_id][target_id] != constants::invalid_id) {
                     ++degree_map[source_id];
@@ -117,17 +113,13 @@ struct directed_adjacency_matrix {
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
         auto removed_edges_view =
             self._matrix[vertex_id]
             | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; });
 
         // TODO: use std::ranges::to (requires newer compiler)
-        std::vector<types::id_type> removed_edges(
-            removed_edges_view.begin(), removed_edges_view.end()
-        );
+        std::vector<id_type> removed_edges(removed_edges_view.begin(), removed_edges_view.end());
 
         self._matrix.erase(std::next(std::begin(self._matrix), vertex_id));
 
@@ -141,7 +133,7 @@ struct directed_adjacency_matrix {
     }
 
     static inline void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
+        impl_type& self, id_type edge_id, id_type source_id, id_type target_id
     ) {
         detail::check_edge_override(self._matrix, source_id, target_id);
         self._matrix[source_id][target_id] = edge_id;
@@ -149,9 +141,9 @@ struct directed_adjacency_matrix {
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         for (const auto target_id : target_ids)
             detail::check_edge_override(self._matrix, source_id, target_id);
@@ -173,47 +165,44 @@ struct undirected_adjacency_matrix {
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type in_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return self._matrix.size()
              - std::ranges::count(self._matrix[vertex_id], constants::invalid_id)
-             + static_cast<types::size_type>(
-                   self._matrix[vertex_id][vertex_id] != constants::invalid_id
-             );
+             + static_cast<size_type>(self._matrix[vertex_id][vertex_id] != constants::invalid_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> in_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> in_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> out_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map(self._matrix.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map(self._matrix.size(), 0uz);
 
-        for (types::id_type source_id = constants::initial_id; source_id < self._matrix.size();
+        for (id_type source_id = constants::initial_id; source_id < self._matrix.size();
              ++source_id) {
-            for (types::id_type target_id = constants::initial_id; target_id <= source_id;
-                 ++target_id) {
+            for (id_type target_id = constants::initial_id; target_id <= source_id; ++target_id) {
                 if (self._matrix[source_id][target_id] != constants::invalid_id) {
                     ++degree_map[source_id];
                     ++degree_map[target_id];
@@ -224,16 +213,12 @@ struct undirected_adjacency_matrix {
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
         auto removed_edges_view =
             self._matrix[vertex_id]
             | std::views::filter([](auto edge_id) { return edge_id != constants::invalid_id; });
         // TODO: use std::ranges::to (requires newer compiler)
-        std::vector<types::id_type> removed_edges(
-            removed_edges_view.begin(), removed_edges_view.end()
-        );
+        std::vector<id_type> removed_edges(removed_edges_view.begin(), removed_edges_view.end());
 
         self._matrix.erase(std::next(std::begin(self._matrix), vertex_id));
         for (auto& row : self._matrix)
@@ -242,9 +227,7 @@ struct undirected_adjacency_matrix {
         return removed_edges;
     }
 
-    static void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
-    ) {
+    static void add_edge(impl_type& self, id_type edge_id, id_type source_id, id_type target_id) {
         detail::check_edge_override(self._matrix, source_id, target_id);
 
         self._matrix[source_id][target_id] = edge_id;
@@ -254,9 +237,9 @@ struct undirected_adjacency_matrix {
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         for (const auto target_id : target_ids)
             detail::check_edge_override(self._matrix, source_id, target_id);

--- a/include/gl/impl/specialized/flat_adjacency_list.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_list.hpp
@@ -268,7 +268,7 @@ struct adjacency_list_impl_traits<AdjacencyList> {
     using type = directed_flat_adjacency_list<AdjacencyList>;
 
     template <typename ItemType>
-    using storage_type = types::flat_jagged_vector<ItemType>;
+    using storage_type = flat_jagged_vector<ItemType>;
 };
 
 template <traits::c_instantiation_of<adjacency_list> AdjacencyList>
@@ -278,7 +278,7 @@ struct adjacency_list_impl_traits<AdjacencyList> {
     using type = undirected_flat_adjacency_list<AdjacencyList>;
 
     template <typename ItemType>
-    using storage_type = types::flat_jagged_vector<ItemType>;
+    using storage_type = flat_jagged_vector<ItemType>;
 };
 
 } // namespace gl::impl::specialized

--- a/include/gl/impl/specialized/flat_adjacency_list.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_list.hpp
@@ -23,7 +23,7 @@ struct directed_flat_adjacency_list {
     using impl_type = AdjacencyList;
     using edge_type = typename impl_type::edge_type;
 
-    [[nodiscard]] static auto in_edges(const impl_type& self, const types::id_type vertex_id) {
+    [[nodiscard]] static auto in_edges(const impl_type& self, const id_type vertex_id) {
         std::vector<adjacency_list_item> in_edges;
         for (auto src_id = constants::initial_id; src_id < self._list.size(); ++src_id) {
             auto in_edges_view =
@@ -38,45 +38,43 @@ struct directed_flat_adjacency_list {
         return in_edges;
     }
 
-    [[nodiscard]] static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
+    [[nodiscard]] static size_type in_degree(const impl_type& self, const id_type vertex_id) {
         return std::ranges::count(
             self._list.data_view(), vertex_id, &adjacency_list_item::vertex_id
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return self._list[vertex_id].size();
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return in_degree(self, vertex_id) + out_degree(self, vertex_id);
     }
 
-    [[nodiscard]] static std::vector<types::size_type> in_degree_map(const impl_type& self) {
-        std::vector<types::size_type> in_degree_map(self._list.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
+        std::vector<size_type> in_degree_map(self._list.size(), 0uz);
         for (const auto& item : self._list.data_view())
             ++in_degree_map[item.vertex_id];
         return in_degree_map;
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> out_degree_map(
         const impl_type& self
     ) {
-        std::vector<types::size_type> out_degree;
+        std::vector<size_type> out_degree;
         out_degree.reserve(self._list.size());
         for (auto id = constants::initial_id; id < self._list.size(); ++id)
             out_degree.push_back(self._list.segment_size(id));
         return out_degree;
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map(self._list.size(), 0uz);
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map(self._list.size(), 0uz);
 
         for (auto id = constants::initial_id; id < self._list.size(); ++id) {
             degree_map[id] += self._list.segment_size(id);
@@ -87,10 +85,8 @@ struct directed_flat_adjacency_list {
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
-        std::vector<types::id_type> removed_edges;
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
+        std::vector<id_type> removed_edges;
 
         // extract out-edges
         for (const auto& item : self._list[vertex_id])
@@ -121,16 +117,16 @@ struct directed_flat_adjacency_list {
     }
 
     gl_attr_force_inline static void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
+        impl_type& self, id_type edge_id, id_type source_id, id_type target_id
     ) {
         self._list.push_back(source_id, {target_id, edge_id});
     }
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids))
             self._list.push_back(source_id, {target_id, edge_id});
@@ -151,55 +147,51 @@ struct undirected_flat_adjacency_list {
     using edge_type = typename impl_type::edge_type;
 
     [[nodiscard]] gl_attr_force_inline static auto in_edges(
-        const impl_type& self, const types::id_type vertex_id
+        const impl_type& self, const id_type vertex_id
     ) {
         return self._list[vertex_id];
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type in_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type in_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline static types::size_type out_degree(
-        const impl_type& self, const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline static size_type out_degree(
+        const impl_type& self, const id_type vertex_id
     ) {
         return degree(self, vertex_id);
     }
 
-    [[nodiscard]] static types::size_type degree(
-        const impl_type& self, const types::id_type vertex_id
-    ) {
-        types::size_type degree = 0uz;
+    [[nodiscard]] static size_type degree(const impl_type& self, const id_type vertex_id) {
+        size_type degree = 0uz;
         for (const auto& item : self._list[vertex_id])
-            degree += 1uz + static_cast<types::size_type>(item.vertex_id == vertex_id);
+            degree += 1uz + static_cast<size_type>(item.vertex_id == vertex_id);
         return degree;
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> in_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> in_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] gl_attr_force_inline static std::vector<types::size_type> out_degree_map(
+    [[nodiscard]] gl_attr_force_inline static std::vector<size_type> out_degree_map(
         const impl_type& self
     ) {
         return degree_map(self);
     }
 
-    [[nodiscard]] static std::vector<types::size_type> degree_map(const impl_type& self) {
-        std::vector<types::size_type> degree_map;
+    [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
+        std::vector<size_type> degree_map;
         degree_map.reserve(self._list.size());
         for (auto id = constants::initial_id; id < self._list.size(); ++id)
             degree_map.push_back(degree(self, id));
         return degree_map;
     }
 
-    static std::vector<types::id_type> remove_vertex(
-        impl_type& self, const types::id_type vertex_id
-    ) {
+    static std::vector<id_type> remove_vertex(impl_type& self, const id_type vertex_id) {
         // all removed edges are stored in the vertex's list segment
         auto removed_edges =
             self._list[vertex_id] | std::views::transform(&adjacency_list_item::edge_id)
@@ -213,7 +205,7 @@ struct undirected_flat_adjacency_list {
         new_list.reserve_data(estimated_new_size);
 
         std::vector<adjacency_list_item> buffer;
-        for (types::id_type id = constants::initial_id; id < self._list.size(); ++id) {
+        for (id_type id = constants::initial_id; id < self._list.size(); ++id) {
             if (id == vertex_id)
                 continue;
 
@@ -229,9 +221,7 @@ struct undirected_flat_adjacency_list {
         return removed_edges;
     }
 
-    static void add_edge(
-        impl_type& self, types::id_type edge_id, types::id_type source_id, types::id_type target_id
-    ) {
+    static void add_edge(impl_type& self, id_type edge_id, id_type source_id, id_type target_id) {
         self._list.push_back(source_id, {target_id, edge_id});
         if (target_id != source_id)
             self._list.push_back(target_id, {source_id, edge_id});
@@ -239,9 +229,9 @@ struct undirected_flat_adjacency_list {
 
     static void add_edges_from(
         impl_type& self,
-        const traits::c_forward_range_of<types::id_type> auto& edge_ids,
-        const types::id_type source_id,
-        const traits::c_forward_range_of<types::id_type> auto& target_ids
+        const traits::c_forward_range_of<id_type> auto& edge_ids,
+        const id_type source_id,
+        const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids)) {
             self._list.push_back(source_id, {target_id, edge_id});
@@ -254,20 +244,18 @@ struct undirected_flat_adjacency_list {
         if (edge.is_loop()) {
             auto adj_edges = self._list[edge.source()];
             const auto it = detail::strict_find(adj_edges, edge);
-            const auto pos = static_cast<types::size_type>(std::distance(adj_edges.begin(), it));
+            const auto pos = static_cast<size_type>(std::distance(adj_edges.begin(), it));
             self._list.erase(edge.source(), pos);
         }
         else {
             auto adj_edges_source = self._list[edge.source()];
             const auto it1 = detail::strict_find(adj_edges_source, edge);
-            const auto pos1 =
-                static_cast<types::size_type>(std::distance(adj_edges_source.begin(), it1));
+            const auto pos1 = static_cast<size_type>(std::distance(adj_edges_source.begin(), it1));
             self._list.erase(edge.source(), pos1);
 
             auto adj_edges_target = self._list[edge.target()];
             const auto it2 = detail::strict_find(adj_edges_target, edge);
-            const auto pos2 =
-                static_cast<types::size_type>(std::distance(adj_edges_target.begin(), it2));
+            const auto pos2 = static_cast<size_type>(std::distance(adj_edges_target.begin(), it2));
             self._list.erase(edge.target(), pos2);
         }
     }

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -13,63 +13,61 @@ namespace gl::topology {
 
 namespace detail {
 
-[[nodiscard]] gl_attr_force_inline auto get_binary_target_ids(const types::size_type source_id) {
+[[nodiscard]] gl_attr_force_inline auto get_binary_target_ids(const size_type source_id) {
     return std::make_pair(2uz * source_id + 1uz, 2uz * source_id + 2uz);
 }
 
-constexpr types::size_type min_non_trivial_bin_tree_depth = 2uz;
+constexpr size_type min_non_trivial_bin_tree_depth = 2uz;
 
 } // namespace detail
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType regular_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType regular_binary_tree(const size_type depth) {
     if (depth < detail::min_non_trivial_bin_tree_depth)
         return GraphType{depth};
 
-    constexpr types::size_type base = 2uz;
-    constexpr types::size_type i_begin = 0uz;
-    const types::size_type i_end = depth - 1uz;
+    constexpr size_type base = 2uz;
+    constexpr size_type i_begin = 0uz;
+    const size_type i_end = depth - 1uz;
 
     const auto n_vertices = util::upow_sum(base, i_begin, i_end);
     GraphType graph{n_vertices};
 
     const auto n_source_vertices = n_vertices - util::upow(base, i_end);
 
-    for (types::id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
+    for (id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
         const auto target_ids = detail::get_binary_target_ids(source_id);
-        graph.add_edges_from(
-            source_id, std::vector<types::id_type>{target_ids.first, target_ids.second}
-        );
+        graph.add_edges_from(source_id, std::vector<id_type>{target_ids.first, target_ids.second});
     }
 
     return graph;
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType regular_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType regular_binary_tree(const size_type depth) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(regular_binary_tree<base_graph_type>(depth));
 }
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType bidirectional_regular_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType bidirectional_regular_binary_tree(const size_type depth) {
     if constexpr (traits::c_directed_graph<GraphType>) {
         if (depth < detail::min_non_trivial_bin_tree_depth)
             return GraphType{depth};
 
-        constexpr types::size_type base = 2uz;
-        constexpr types::size_type i_begin = 0uz;
-        const types::size_type i_end = depth - 1uz;
+        constexpr size_type base = 2uz;
+        constexpr size_type i_begin = 0uz;
+        const size_type i_end = depth - 1uz;
 
         const auto n_vertices = util::upow_sum(base, i_begin, i_end);
         GraphType graph{n_vertices};
 
         const auto n_source_vertices = n_vertices - util::upow(base, i_end);
 
-        for (types::id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
+        for (id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
             const auto target_ids = detail::get_binary_target_ids(source_id);
             graph.add_edges_from(
-                source_id, std::vector<types::id_type>{target_ids.first, target_ids.second}
+                source_id, std::vector<id_type>{target_ids.first, target_ids.second}
             );
             graph.add_edge(target_ids.first, source_id);
             graph.add_edge(target_ids.second, source_id);
@@ -83,7 +81,7 @@ template <traits::c_graph GraphType>
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType bidirectional_regular_binary_tree(const types::size_type depth) {
+[[nodiscard]] GraphType bidirectional_regular_binary_tree(const size_type depth) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(bidirectional_regular_binary_tree<base_graph_type>(depth));
 }

--- a/include/gl/topology/binary_tree.hpp
+++ b/include/gl/topology/binary_tree.hpp
@@ -9,6 +9,8 @@
 #include "gl/graph.hpp"
 #include "gl/util/pow.hpp"
 
+#include <initializer_list>
+
 namespace gl::topology {
 
 namespace detail {
@@ -35,9 +37,11 @@ template <traits::c_graph GraphType>
 
     const auto n_source_vertices = n_vertices - util::upow(base, i_end);
 
-    for (id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
+    for (auto source_id = 0uz; source_id < n_source_vertices; ++source_id) {
         const auto target_ids = detail::get_binary_target_ids(source_id);
-        graph.add_edges_from(source_id, std::vector<id_type>{target_ids.first, target_ids.second});
+        graph.add_edges_from(
+            source_id, std::initializer_list<id_type>{target_ids.first, target_ids.second}
+        );
     }
 
     return graph;
@@ -64,10 +68,10 @@ template <traits::c_graph GraphType>
 
         const auto n_source_vertices = n_vertices - util::upow(base, i_end);
 
-        for (id_type source_id = 0uz; source_id < n_source_vertices; ++source_id) {
+        for (auto source_id = 0uz; source_id < n_source_vertices; ++source_id) {
             const auto target_ids = detail::get_binary_target_ids(source_id);
             graph.add_edges_from(
-                source_id, std::vector<id_type>{target_ids.first, target_ids.second}
+                source_id, std::initializer_list<id_type>{target_ids.first, target_ids.second}
             );
             graph.add_edge(target_ids.first, source_id);
             graph.add_edge(target_ids.second, source_id);

--- a/include/gl/topology/bipartite.hpp
+++ b/include/gl/topology/bipartite.hpp
@@ -16,8 +16,8 @@ template <traits::c_graph GraphType>
     const auto n_vertices = n_vertices_a + n_vertices_b;
     GraphType graph{n_vertices};
 
-    for (id_type source_id = constants::initial_id; source_id < n_vertices_a; ++source_id) {
-        for (id_type target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
+    for (auto source_id = constants::initial_id; source_id < n_vertices_a; ++source_id) {
+        for (auto target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
             graph.add_edge(source_id, target_id);
             if constexpr (traits::c_directed_graph<GraphType>)
                 graph.add_edge(target_id, source_id);

--- a/include/gl/topology/bipartite.hpp
+++ b/include/gl/topology/bipartite.hpp
@@ -12,14 +12,12 @@
 namespace gl::topology {
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType biclique(
-    const types::size_type n_vertices_a, const types::size_type n_vertices_b
-) {
+[[nodiscard]] GraphType biclique(const size_type n_vertices_a, const size_type n_vertices_b) {
     const auto n_vertices = n_vertices_a + n_vertices_b;
     GraphType graph{n_vertices};
 
-    for (types::id_type source_id = constants::initial_id; source_id < n_vertices_a; ++source_id) {
-        for (types::id_type target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
+    for (id_type source_id = constants::initial_id; source_id < n_vertices_a; ++source_id) {
+        for (id_type target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
             graph.add_edge(source_id, target_id);
             if constexpr (traits::c_directed_graph<GraphType>)
                 graph.add_edge(target_id, source_id);
@@ -30,9 +28,7 @@ template <traits::c_graph GraphType>
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType biclique(
-    const types::size_type n_vertices_a, const types::size_type n_vertices_b
-) {
+[[nodiscard]] GraphType biclique(const size_type n_vertices_a, const size_type n_vertices_b) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(biclique<base_graph_type>(n_vertices_a, n_vertices_b));
 }

--- a/include/gl/topology/clique.hpp
+++ b/include/gl/topology/clique.hpp
@@ -11,11 +11,11 @@
 namespace gl::topology {
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType clique(const types::size_type n_vertices) {
+[[nodiscard]] GraphType clique(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (types::id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
-        for (types::id_type target_id = constants::initial_id; target_id < source_id; ++target_id) {
+    for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
+        for (id_type target_id = constants::initial_id; target_id < source_id; ++target_id) {
             graph.add_edge(source_id, target_id);
             if constexpr (traits::c_directed_graph<GraphType>)
                 graph.add_edge(target_id, source_id);
@@ -26,7 +26,7 @@ template <traits::c_graph GraphType>
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType clique(const types::size_type n_vertices) {
+[[nodiscard]] GraphType clique(const size_type n_vertices) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(clique<base_graph_type>(n_vertices));
 }

--- a/include/gl/topology/clique.hpp
+++ b/include/gl/topology/clique.hpp
@@ -14,8 +14,8 @@ template <traits::c_graph GraphType>
 [[nodiscard]] GraphType clique(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
-        for (id_type target_id = constants::initial_id; target_id < source_id; ++target_id) {
+    for (auto source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
+        for (auto target_id = constants::initial_id; target_id < source_id; ++target_id) {
             graph.add_edge(source_id, target_id);
             if constexpr (traits::c_directed_graph<GraphType>)
                 graph.add_edge(target_id, source_id);

--- a/include/gl/topology/cycle.hpp
+++ b/include/gl/topology/cycle.hpp
@@ -14,7 +14,7 @@ template <traits::c_graph GraphType>
 [[nodiscard]] GraphType cycle(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id)
+    for (auto source_id = constants::initial_id; source_id < n_vertices; ++source_id)
         graph.add_edge(source_id, (source_id + 1uz) % n_vertices);
 
     return graph;
@@ -31,7 +31,7 @@ template <traits::c_graph GraphType>
     if constexpr (traits::c_directed_graph<GraphType>) {
         GraphType graph{n_vertices};
 
-        for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
+        for (auto source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
             const auto target_id = (source_id + 1uz) % n_vertices;
             graph.add_edge(source_id, target_id);
             graph.add_edge(target_id, source_id);

--- a/include/gl/topology/cycle.hpp
+++ b/include/gl/topology/cycle.hpp
@@ -11,28 +11,27 @@
 namespace gl::topology {
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType cycle(const types::size_type n_vertices) {
+[[nodiscard]] GraphType cycle(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (types::id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id)
+    for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id)
         graph.add_edge(source_id, (source_id + 1uz) % n_vertices);
 
     return graph;
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType cycle(const types::size_type n_vertices) {
+[[nodiscard]] GraphType cycle(const size_type n_vertices) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(cycle<base_graph_type>(n_vertices));
 }
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType bidirectional_cycle(const types::size_type n_vertices) {
+[[nodiscard]] GraphType bidirectional_cycle(const size_type n_vertices) {
     if constexpr (traits::c_directed_graph<GraphType>) {
         GraphType graph{n_vertices};
 
-        for (types::id_type source_id = constants::initial_id; source_id < n_vertices;
-             ++source_id) {
+        for (id_type source_id = constants::initial_id; source_id < n_vertices; ++source_id) {
             const auto target_id = (source_id + 1uz) % n_vertices;
             graph.add_edge(source_id, target_id);
             graph.add_edge(target_id, source_id);
@@ -46,7 +45,7 @@ template <traits::c_graph GraphType>
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType bidirectional_cycle(const types::size_type n_vertices) {
+[[nodiscard]] GraphType bidirectional_cycle(const size_type n_vertices) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(bidirectional_cycle<base_graph_type>(n_vertices));
 }

--- a/include/gl/topology/path.hpp
+++ b/include/gl/topology/path.hpp
@@ -14,7 +14,7 @@ template <traits::c_graph GraphType>
 [[nodiscard]] GraphType path(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id)
+    for (auto source_id = 0uz; source_id < n_vertices - 1uz; ++source_id)
         graph.add_edge(source_id, source_id + 1uz);
 
     return graph;
@@ -31,7 +31,7 @@ template <traits::c_graph GraphType>
     if constexpr (traits::c_directed_graph<GraphType>) {
         GraphType graph{n_vertices};
 
-        for (id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id) {
+        for (auto source_id = 0uz; source_id < n_vertices - 1uz; ++source_id) {
             const auto target_id = source_id + 1uz;
             graph.add_edge(source_id, target_id);
             graph.add_edge(target_id, source_id);

--- a/include/gl/topology/path.hpp
+++ b/include/gl/topology/path.hpp
@@ -11,27 +11,27 @@
 namespace gl::topology {
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType path(const types::size_type n_vertices) {
+[[nodiscard]] GraphType path(const size_type n_vertices) {
     GraphType graph{n_vertices};
 
-    for (types::id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id)
+    for (id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id)
         graph.add_edge(source_id, source_id + 1uz);
 
     return graph;
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType path(const types::size_type n_vertices) {
+[[nodiscard]] GraphType path(const size_type n_vertices) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(path<base_graph_type>(n_vertices));
 }
 
 template <traits::c_graph GraphType>
-[[nodiscard]] GraphType bidirectional_path(const types::size_type n_vertices) {
+[[nodiscard]] GraphType bidirectional_path(const size_type n_vertices) {
     if constexpr (traits::c_directed_graph<GraphType>) {
         GraphType graph{n_vertices};
 
-        for (types::id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id) {
+        for (id_type source_id = 0uz; source_id < n_vertices - 1uz; ++source_id) {
             const auto target_id = source_id + 1uz;
             graph.add_edge(source_id, target_id);
             graph.add_edge(target_id, source_id);
@@ -45,7 +45,7 @@ template <traits::c_graph GraphType>
 }
 
 template <traits::c_flat_list_graph GraphType>
-[[nodiscard]] GraphType bidirectional_path(const types::size_type n_vertices) {
+[[nodiscard]] GraphType bidirectional_path(const size_type n_vertices) {
     using base_graph_type = traits::swap_impl_tag_t<GraphType, impl::list_t>;
     return to<impl::flat_list_t>(bidirectional_path<base_graph_type>(n_vertices));
 }

--- a/include/gl/types/core.hpp
+++ b/include/gl/types/core.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <utility>
 
-namespace gl::types {
+namespace gl {
 
 using size_type = std::uint64_t;
 using id_type = size_type;
@@ -16,4 +16,4 @@ using id_type = size_type;
 template <typename T>
 using homogeneous_pair = std::pair<T, T>;
 
-} // namespace gl::types
+} // namespace gl

--- a/include/gl/types/core.hpp
+++ b/include/gl/types/core.hpp
@@ -10,7 +10,7 @@
 
 namespace gl {
 
-using size_type = std::uint64_t;
+using size_type = std::size_t;
 using id_type = size_type;
 
 template <typename T>

--- a/include/gl/types/flat_jagged_vector.hpp
+++ b/include/gl/types/flat_jagged_vector.hpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
-namespace gl::types {
+namespace gl {
 
 /// @brief A flattened 2D vector (jagged array) providing efficient storage for variable-length segments.
 ///
@@ -1178,4 +1178,4 @@ private:
     std::vector<size_type> _offsets{0uz};
 };
 
-} // namespace gl::types
+} // namespace gl

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -164,6 +164,8 @@ struct binary_color_property {
     color_type color;
 };
 
+using bin_color_value = typename binary_color::value;
+
 template <traits::c_arithmetic WeightType = double>
 struct weight_property {
     using weight_type = WeightType;
@@ -183,8 +185,6 @@ struct weight_property {
         return is;
     }
 };
-
-using bin_color_value = typename binary_color::value;
 
 namespace traits {
 

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -12,12 +12,6 @@
 #include <unordered_map>
 #include <variant>
 
-#ifdef GL_CONFIG_PROPERTY_TYPES_NOT_FINAL
-#define _GL_PROPERTY_TYPES_NOT_FINAL
-#else
-#undef _GL_PROPERTY_TYPES_NOT_FINAL
-#endif
-
 namespace gl {
 
 namespace types {
@@ -27,67 +21,34 @@ namespace types {
 using empty_properties = std::monostate;
 using empty_properties_map = std::monostate;
 
-class name_property
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
-    final
-#endif
-{
-public:
-    using value_type = std::string;
-
-    name_property() = default;
-
-    name_property(const std::string_view name) : _name(name) {}
-
-    name_property(const name_property&) = default;
-    name_property(name_property&&) noexcept = default;
-
-    name_property& operator=(const name_property&) = default;
-    name_property& operator=(name_property&&) noexcept = default;
-
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
-    ~name_property() = default;
-#else
-    virtual ~name_property() = default;
-#endif
+struct name_property {
+    std::string name;
 
     name_property& operator=(const std::string_view name) {
-        this->_name = name;
+        this->name = name;
         return *this;
     }
-
-    // clang-format off
-    // gl_attr_force_inline misplacement
-
-    [[nodiscard]] gl_attr_force_inline const std::string& name() const {
-        return this->_name;
-    }
-
-    // clang-format on
 
     [[nodiscard]] bool operator==(const name_property&) const = default;
     [[nodiscard]] auto operator<=>(const name_property&) const = default;
 
     [[nodiscard]] bool operator==(const std::string_view name) const {
-        return this->_name == name;
+        return this->name == name;
     }
 
     [[nodiscard]] auto operator<=>(const std::string_view name) const {
-        return this->_name <=> name;
+        return this->name <=> name;
     }
 
     friend std::ostream& operator<<(std::ostream& os, const name_property& property) {
-        os << std::quoted(property._name);
+        os << std::quoted(property.name);
         return os;
     }
 
     friend std::istream& operator>>(std::istream& is, name_property& property) {
-        is >> std::quoted(property._name);
+        is >> std::quoted(property.name);
         return is;
     }
-
-private:
-    std::string _name;
 };
 
 class dynamic_properties

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -16,8 +16,6 @@ namespace gl {
 
 namespace types {
 
-// --- common properties ---
-
 using empty_properties = std::monostate;
 using empty_properties_map = std::monostate;
 
@@ -51,11 +49,7 @@ struct name_property {
     }
 };
 
-class dynamic_properties
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
-    final
-#endif
-{
+class dynamic_properties final {
 public:
     using key_type = std::string;
     using value_type = std::any;
@@ -69,11 +63,7 @@ public:
     dynamic_properties& operator=(const dynamic_properties&) = default;
     dynamic_properties& operator=(dynamic_properties&&) noexcept = default;
 
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
     ~dynamic_properties() = default;
-#else
-    virtual ~dynamic_properties() = default;
-#endif
 
     [[nodiscard]] gl_attr_force_inline bool is_present(const key_type& key) const {
         return this->_property_map.contains(key);
@@ -115,11 +105,7 @@ private:
 
 // --- vertex properties ---
 
-class binary_color
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
-    final
-#endif
-{
+class binary_color final {
 public:
     enum class value : std::uint16_t {
         black = static_cast<std::uint16_t>(0),
@@ -181,8 +167,6 @@ struct binary_color_property {
     using color_type = binary_color;
     color_type color;
 };
-
-// --- edge properties ---
 
 template <traits::c_arithmetic WeightType = double>
 struct weight_property {

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -18,9 +18,11 @@ using empty_properties = std::monostate;
 using empty_properties_map = std::monostate;
 
 struct name_property {
-    std::string name;
+    using value_type = std::string;
 
-    name_property& operator=(const std::string_view name) {
+    value_type name;
+
+    name_property& operator=(std::string_view name) {
         this->name = name;
         return *this;
     }

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -14,8 +14,6 @@
 
 namespace gl {
 
-namespace types {
-
 using empty_properties = std::monostate;
 using empty_properties_map = std::monostate;
 
@@ -123,11 +121,7 @@ public:
     binary_color& operator=(const binary_color&) = default;
     binary_color& operator=(binary_color&&) noexcept = default;
 
-#ifndef _GL_PROPERTY_TYPES_NOT_FINAL
     ~binary_color() = default;
-#else
-    virtual ~binary_color() = default;
-#endif
 
     binary_color& operator=(value value) {
         this->_value = this->_restrict(value);
@@ -188,9 +182,7 @@ struct weight_property {
     }
 };
 
-} // namespace types
-
-using bin_color_value = typename types::binary_color::value;
+using bin_color_value = typename binary_color::value;
 
 namespace traits {
 
@@ -199,7 +191,7 @@ concept c_properties =
     std::semiregular<T> and std::move_constructible<T> and std::assignable_from<T&, const T&>;
 
 template <typename T>
-concept c_empty_properties = c_properties<T> and std::same_as<T, gl::types::empty_properties>;
+concept c_empty_properties = c_properties<T> and std::same_as<T, gl::empty_properties>;
 
 template <typename T>
 concept c_non_empty_properties = c_properties<T> and not c_empty_properties<T>;
@@ -217,8 +209,8 @@ template <typename Properties>
 concept c_binary_color_properties_type = c_properties<Properties> and requires(Properties p) {
     typename Properties::color_type;
     { p.color } -> std::same_as<typename Properties::color_type&>;
-    { p.color == types::binary_color{} } -> std::convertible_to<bool>;
-    requires std::constructible_from<typename Properties::color_type, types::binary_color>;
+    { p.color == binary_color{} } -> std::convertible_to<bool>;
+    requires std::constructible_from<typename Properties::color_type, binary_color>;
 };
 
 template <typename Properties>

--- a/include/gl/util/pow.hpp
+++ b/include/gl/util/pow.hpp
@@ -12,8 +12,8 @@
 namespace gl::util {
 
 // exponentation function for u64 integral type
-[[nodiscard]] inline constexpr types::size_type upow(types::size_type base, types::size_type exp) {
-    types::size_type result = 1uz;
+[[nodiscard]] inline constexpr size_type upow(size_type base, size_type exp) {
+    size_type result = 1uz;
     while (exp) {
         if (exp % 2uz == 1uz)
             result *= base;
@@ -25,13 +25,11 @@ namespace gl::util {
 }
 
 // sum of exponents: base ^ i_begin + base ^ (i_begin + 1) + ... + base ^ (i_end)
-[[nodiscard]] inline types::size_type upow_sum(
-    const types::size_type base, types::size_type i_begin, types::size_type i_end
-) {
+[[nodiscard]] inline size_type upow_sum(const size_type base, size_type i_begin, size_type i_end) {
     std::tie(i_begin, i_end) = std::minmax(i_begin, i_end);
 
     if (base == 0uz)
-        return static_cast<types::size_type>(i_begin == 0uz);
+        return static_cast<size_type>(i_begin == 0uz);
 
     if (base == 1uz)
         return i_end - i_begin + 1uz;

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -16,14 +16,14 @@
 
 namespace gl {
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 class vertex_descriptor final {
 public:
     using type = std::type_identity_t<vertex_descriptor<Properties>>;
     using properties_type = Properties;
     using properties_ref_type = std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         properties_type&>;
 
     vertex_descriptor() {
@@ -127,11 +127,11 @@ private:
     id_type _id;
     [[no_unique_address]] std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         std::reference_wrapper<properties_type>> _properties;
 };
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 using vertex = vertex_descriptor<Properties>;
 
 } // namespace gl

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -30,11 +30,11 @@ public:
         *this = vertex_descriptor::invalid();
     }
 
-    explicit vertex_descriptor(const types::id_type id)
+    explicit vertex_descriptor(const id_type id)
     requires(traits::c_empty_properties<properties_type>)
     : _id(id) {}
 
-    explicit vertex_descriptor(const types::id_type id, properties_type& properties)
+    explicit vertex_descriptor(const id_type id, properties_type& properties)
     requires(traits::c_non_empty_properties<properties_type>)
     : _id(id), _properties(properties) {}
 
@@ -78,7 +78,7 @@ public:
         return this->_id != constants::invalid_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::id_type id() const noexcept {
+    [[nodiscard]] gl_attr_force_inline id_type id() const noexcept {
         return this->_id;
     }
 
@@ -124,7 +124,7 @@ private:
         }
     }
 
-    types::id_type _id;
+    id_type _id;
     [[no_unique_address]] std::conditional_t<
         traits::c_empty_properties<properties_type>,
         types::empty_properties,

--- a/include/hgl/conversion.hpp
+++ b/include/hgl/conversion.hpp
@@ -230,7 +230,7 @@ template <traits::c_hypergraph_impl_tag TargetImplTag, traits::c_hypergraph Hype
 
 template <gl::traits::c_undirected_graph G>
 [[nodiscard]] G projection(const traits::c_undirected_hypergraph auto& h) {
-    using edge_vertices = std::pair<types::id_type, types::id_type>;
+    using edge_vertices = std::pair<id_type, id_type>;
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {
@@ -262,7 +262,7 @@ requires std::same_as<typename G::traits_type::implementation_tag, gl::impl::fla
 
 template <gl::traits::c_directed_graph G>
 [[nodiscard]] G projection(const traits::c_bf_directed_hypergraph auto& h) {
-    using edge_vertices = std::pair<types::id_type, types::id_type>;
+    using edge_vertices = std::pair<id_type, id_type>;
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -85,21 +85,19 @@ public:
     using vertex_properties_type = typename traits_type::vertex_properties_type;
     using vertex_properties_map_type = std::conditional_t<
         traits::c_empty_properties<vertex_properties_type>,
-        types::empty_properties_map,
+        empty_properties_map,
         std::vector<std::unique_ptr<vertex_properties_type>>>;
 
     using hyperedge_type = typename traits_type::hyperedge_type;
     using hyperedge_properties_type = typename traits_type::hyperedge_properties_type;
     using hyperedge_properties_map_type = std::conditional_t<
         traits::c_empty_properties<hyperedge_properties_type>,
-        types::empty_properties_map,
+        empty_properties_map,
         std::vector<std::unique_ptr<hyperedge_properties_type>>>;
 
     hypergraph& operator=(const hypergraph&) = delete;
 
-    explicit hypergraph(
-        const types::size_type n_vertices = 0uz, const types::size_type n_hyperedges = 0uz
-    )
+    explicit hypergraph(const size_type n_vertices = 0uz, const size_type n_hyperedges = 0uz)
     : _n_vertices(n_vertices), _n_hyperedges(n_hyperedges), _impl(n_vertices, n_hyperedges) {
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
             this->_vertex_properties.reserve(n_vertices);
@@ -122,11 +120,11 @@ public:
 
     // --- general methods ---
 
-    [[nodiscard]] gl_attr_force_inline types::size_type order() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type order() const noexcept {
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type size() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type size() const noexcept {
         return this->_n_hyperedges;
     }
 
@@ -140,7 +138,7 @@ public:
         return std::views::iota(constants::initial_id, this->_n_vertices);
     }
 
-    [[nodiscard]] vertex_type get_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] vertex_type get_vertex(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
@@ -148,7 +146,7 @@ public:
             return vertex_type{vertex_id};
     }
 
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const types::id_type vertex_id) const {
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
         return vertex_id < this->_n_vertices;
     }
 
@@ -181,14 +179,14 @@ public:
         };
     }
 
-    void add_vertices(const types::size_type n) {
+    void add_vertices(const size_type n) {
         this->_impl.add_vertices(n);
         this->_n_vertices += n;
 
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
             const auto old_size = this->_vertex_properties.size();
             this->_vertex_properties.reserve(this->_n_vertices);
-            for (types::size_type i = old_size; i < this->_n_vertices; ++i)
+            for (size_type i = old_size; i < this->_n_vertices; ++i)
                 this->_vertex_properties.push_back(std::make_unique<vertex_properties_type>());
         }
     }
@@ -212,7 +210,7 @@ public:
         }
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) {
         this->_remove_vertex_impl(vertex_id);
     }
 
@@ -220,10 +218,9 @@ public:
         this->remove_vertex(vertex.id());
     }
 
-    void remove_vertices_from(const traits::c_forward_range_of<types::id_type> auto& vertex_id_rng
-    ) {
+    void remove_vertices_from(const traits::c_forward_range_of<id_type> auto& vertex_id_rng) {
         // sorts ids in a descending order and removes duplicate ids
-        std::set<types::id_type, std::greater<types::id_type>> vertex_id_set(
+        std::set<id_type, std::greater<id_type>> vertex_id_set(
             std::ranges::begin(vertex_id_rng), std::ranges::end(vertex_id_rng)
         );
 
@@ -250,7 +247,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline vertex_properties_type& get_vertex_properties(
-        const types::id_type vertex_id
+        const id_type vertex_id
     ) const
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
@@ -268,7 +265,7 @@ public:
         return std::views::iota(constants::initial_id, this->_n_hyperedges);
     }
 
-    [[nodiscard]] hyperedge_type get_hyperedge(const types::id_type hyperedge_id) const {
+    [[nodiscard]] hyperedge_type get_hyperedge(const id_type hyperedge_id) const {
         this->_verify_hyperedge_id(hyperedge_id);
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
             return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
@@ -276,7 +273,7 @@ public:
             return hyperedge_type{hyperedge_id};
     }
 
-    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const types::id_type hyperedge_id) const {
+    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const id_type hyperedge_id) const {
         return hyperedge_id < this->_n_hyperedges;
     }
 
@@ -311,14 +308,14 @@ public:
         };
     }
 
-    void add_hyperedges(const types::size_type n) {
+    void add_hyperedges(const size_type n) {
         this->_impl.add_hyperedges(n);
         this->_n_hyperedges += n;
 
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
             const auto old_size = this->_hyperedge_properties.size();
             this->_hyperedge_properties.reserve(this->_n_hyperedges);
-            for (types::size_type i = old_size; i < this->_n_hyperedges; ++i)
+            for (size_type i = old_size; i < this->_n_hyperedges; ++i)
                 this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
                 );
         }
@@ -343,7 +340,7 @@ public:
         }
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) {
         this->_remove_hyperedge_impl(hyperedge_id);
     }
 
@@ -351,11 +348,9 @@ public:
         this->remove_hyperedge(hyperedge.id());
     }
 
-    void remove_hyperedges_from(
-        const traits::c_forward_range_of<types::id_type> auto& hyperedge_id_rng
-    ) {
+    void remove_hyperedges_from(const traits::c_forward_range_of<id_type> auto& hyperedge_id_rng) {
         // sorts ids in a descending order and removes duplicate ids
-        std::set<types::id_type, std::greater<types::id_type>> hyperedge_id_set(
+        std::set<id_type, std::greater<id_type>> hyperedge_id_set(
             std::ranges::begin(hyperedge_id_rng), std::ranges::end(hyperedge_id_rng)
         );
 
@@ -383,7 +378,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline hyperedge_properties_type& get_hyperedge_properties(
-        const types::id_type id
+        const id_type id
     ) const
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
@@ -393,7 +388,7 @@ public:
 
     // --- incidence methods ---
 
-    void bind(const types::id_type vertex_id, const types::id_type hyperedge_id)
+    void bind(const id_type vertex_id, const id_type hyperedge_id)
     requires std::same_as<directional_tag, undirected_t>
     {
         this->_verify_vertex_id(vertex_id);
@@ -407,7 +402,7 @@ public:
         this->bind(vertex.id(), hyperedge.id());
     }
 
-    void bind_head(const types::id_type vertex_id, const types::id_type hyperedge_id)
+    void bind_head(const id_type vertex_id, const id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
@@ -421,7 +416,7 @@ public:
         this->bind_head(vertex.id(), hyperedge.id());
     }
 
-    void bind_tail(const types::id_type vertex_id, const types::id_type hyperedge_id)
+    void bind_tail(const id_type vertex_id, const id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
@@ -435,7 +430,7 @@ public:
         this->bind_tail(vertex.id(), hyperedge.id());
     }
 
-    void unbind(const types::id_type vertex_id, const types::id_type hyperedge_id) {
+    void unbind(const id_type vertex_id, const id_type hyperedge_id) {
         this->_verify_vertex_id(vertex_id);
         this->_verify_hyperedge_id(hyperedge_id);
         this->_impl.unbind(vertex_id, hyperedge_id);
@@ -445,9 +440,7 @@ public:
         this->unbind(vertex.id(), hyperedge.id());
     }
 
-    [[nodiscard]] bool are_incident(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) const {
+    [[nodiscard]] bool are_incident(const id_type vertex_id, const id_type hyperedge_id) const {
         this->_verify_vertex_id(vertex_id);
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.are_bound(vertex_id, hyperedge_id);
@@ -459,8 +452,7 @@ public:
         return this->are_incident(vertex.id(), hyperedge.id());
     }
 
-    [[nodiscard]] bool is_tail(const types::id_type vertex_id, const types::id_type hyperedge_id)
-        const
+    [[nodiscard]] bool is_tail(const id_type vertex_id, const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
@@ -476,8 +468,7 @@ public:
         return this->is_tail(vertex.id(), hyperedge.id());
     }
 
-    [[nodiscard]] bool is_head(const types::id_type vertex_id, const types::id_type hyperedge_id)
-        const
+    [[nodiscard]] bool is_head(const id_type vertex_id, const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
@@ -493,7 +484,7 @@ public:
         return this->is_head(vertex.id(), hyperedge.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id) {
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id) {
         return this->incident_hyperedge_ids(vertex_id)
              | std::views::transform(this->_create_hyperedge_descriptor());
     }
@@ -502,7 +493,7 @@ public:
         return this->incident_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto incident_hyperedge_ids(const types::id_type vertex_id) const {
+    [[nodiscard]] auto incident_hyperedge_ids(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.incident_hyperedges(vertex_id);
     }
@@ -512,20 +503,20 @@ public:
         return this->incident_hyperedge_ids(vertex.id());
     }
 
-    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const {
+    [[nodiscard]] size_type degree(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const vertex_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const vertex_type& vertex) const {
         return this->degree(vertex.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> degree_map() const {
+    [[nodiscard]] std::vector<size_type> degree_map() const {
         return this->_impl.degree_map(this->_n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id)
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->out_hyperedge_ids(vertex_id)
@@ -538,7 +529,7 @@ public:
         return this->out_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto out_hyperedge_ids(const types::id_type vertex_id) const {
+    [[nodiscard]] auto out_hyperedge_ids(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.out_hyperedges(vertex_id);
     }
@@ -547,26 +538,26 @@ public:
         return this->out_hyperedge_ids(vertex.id());
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.out_degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type out_degree(const vertex_type& vertex) const
+    [[nodiscard]] gl_attr_force_inline size_type out_degree(const vertex_type& vertex) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->out_degree(vertex.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map() const
+    [[nodiscard]] std::vector<size_type> out_degree_map() const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->_impl.out_degree_map(this->_n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id)
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->in_hyperedge_ids(vertex_id)
@@ -579,7 +570,7 @@ public:
         return this->in_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto in_hyperedge_ids(const types::id_type vertex_id) const {
+    [[nodiscard]] auto in_hyperedge_ids(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.in_hyperedges(vertex_id);
     }
@@ -588,26 +579,26 @@ public:
         return this->in_hyperedge_ids(vertex.id());
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.in_degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type in_degree(const vertex_type& vertex) const
+    [[nodiscard]] gl_attr_force_inline size_type in_degree(const vertex_type& vertex) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->in_degree(vertex.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map() const
+    [[nodiscard]] std::vector<size_type> in_degree_map() const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->_impl.in_degree_map(this->_n_vertices);
     }
 
-    [[nodiscard]] auto incident_vertices(const types::id_type hyperedge_id) {
+    [[nodiscard]] auto incident_vertices(const id_type hyperedge_id) {
         return this->incident_vertex_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
@@ -616,7 +607,7 @@ public:
         return this->incident_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto incident_vertex_ids(const types::id_type hyperedge_id) const {
+    [[nodiscard]] auto incident_vertex_ids(const id_type hyperedge_id) const {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.incident_vertices(hyperedge_id);
     }
@@ -626,22 +617,21 @@ public:
         return this->incident_vertex_ids(hyperedge.id());
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id) const {
+    [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.hyperedge_size(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
-        const hyperedge_type& hyperedge
+    [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const hyperedge_type& hyperedge
     ) const {
         return this->hyperedge_size(hyperedge.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> hyperedge_size_map() const {
+    [[nodiscard]] std::vector<size_type> hyperedge_size_map() const {
         return this->_impl.hyperedge_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id)
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->tail_vertex_ids(hyperedge_id)
@@ -654,7 +644,7 @@ public:
         return this->tail_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto tail_vertex_ids(const types::id_type hyperedge_id) const
+    [[nodiscard]] auto tail_vertex_ids(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
@@ -667,27 +657,26 @@ public:
         return this->tail_vertex_ids(hyperedge.id());
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.tail_size(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type tail_size(const hyperedge_type& hyperedge
-    ) const
+    [[nodiscard]] gl_attr_force_inline size_type tail_size(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->tail_size(hyperedge.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map() const
+    [[nodiscard]] std::vector<size_type> tail_size_map() const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->_impl.tail_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id)
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id)
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->head_vertex_ids(hyperedge_id)
@@ -700,7 +689,7 @@ public:
         return this->head_vertices(hyperedge.id());
     }
 
-    [[nodiscard]] auto head_vertex_ids(const types::id_type hyperedge_id) const
+    [[nodiscard]] auto head_vertex_ids(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
@@ -713,21 +702,20 @@ public:
         return this->head_vertex_ids(hyperedge.id());
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
         return this->_impl.head_size(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type head_size(const hyperedge_type& hyperedge
-    ) const
+    [[nodiscard]] gl_attr_force_inline size_type head_size(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->head_size(hyperedge.id());
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map() const
+    [[nodiscard]] std::vector<size_type> head_size_map() const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         return this->_impl.head_size_map(this->_n_hyperedges);
@@ -793,12 +781,12 @@ private:
 
     // --- vertex methods ---
 
-    gl_attr_force_inline void _verify_vertex_id(const types::id_type vertex_id) const {
+    gl_attr_force_inline void _verify_vertex_id(const id_type vertex_id) const {
         if (not this->has_vertex(vertex_id))
             throw std::out_of_range(std::format("Got invalid vertex id [{}]", vertex_id));
     }
 
-    void _remove_vertex_impl(const types::id_type vertex_id) {
+    void _remove_vertex_impl(const id_type vertex_id) {
         if (not this->has_vertex(vertex_id))
             return;
 
@@ -810,12 +798,12 @@ private:
 
     // --- hyperedge methods ---
 
-    gl_attr_force_inline void _verify_hyperedge_id(const types::id_type hyperedge_id) const {
+    gl_attr_force_inline void _verify_hyperedge_id(const id_type hyperedge_id) const {
         if (not this->has_hyperedge(hyperedge_id))
             throw std::out_of_range(std::format("Got invalid hyperedge id [{}]", hyperedge_id));
     }
 
-    void _remove_hyperedge_impl(const types::id_type hyperedge_id) {
+    void _remove_hyperedge_impl(const id_type hyperedge_id) {
         if (not this->has_hyperedge(hyperedge_id))
             return;
 
@@ -830,13 +818,13 @@ private:
     gl_attr_force_inline auto _create_vertex_descriptor() noexcept
     requires(traits::c_empty_properties<vertex_properties_type>)
     {
-        return [](const types::id_type id) { return vertex_type{id}; };
+        return [](const id_type id) { return vertex_type{id}; };
     }
 
     gl_attr_force_inline auto _create_vertex_descriptor() noexcept
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
-        return [&pmap = this->_vertex_properties](const types::id_type id) {
+        return [&pmap = this->_vertex_properties](const id_type id) {
             return vertex_type{id, *pmap[id]};
         };
     }
@@ -844,21 +832,21 @@ private:
     gl_attr_force_inline auto _create_hyperedge_descriptor() noexcept
     requires(traits::c_empty_properties<hyperedge_properties_type>)
     {
-        return [](const types::id_type id) { return hyperedge_type{id}; };
+        return [](const id_type id) { return hyperedge_type{id}; };
     }
 
     gl_attr_force_inline auto _create_hyperedge_descriptor() noexcept
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
-        return [&pmap = this->_hyperedge_properties](const types::id_type id) {
+        return [&pmap = this->_hyperedge_properties](const id_type id) {
             return hyperedge_type{id, *pmap[id]};
         };
     }
 
     // --- data members ---
 
-    types::size_type _n_vertices = 0uz;
-    types::size_type _n_hyperedges = 0uz;
+    size_type _n_vertices = 0uz;
+    size_type _n_hyperedges = 0uz;
 
     implementation_type _impl{};
 
@@ -875,37 +863,35 @@ template <traits::c_hypergraph Hypergraph>
 
 // --- degree bounds ---
 
-[[nodiscard]] types::size_type max_degree(const traits::c_hypergraph auto& hypergraph) noexcept {
+[[nodiscard]] size_type max_degree(const traits::c_hypergraph auto& hypergraph) noexcept {
     const auto degrees = hypergraph.degree_map();
     return degrees.empty() ? 0uz : *std::ranges::max_element(degrees);
 }
 
-[[nodiscard]] types::size_type min_degree(const traits::c_hypergraph auto& hypergraph) noexcept {
+[[nodiscard]] size_type min_degree(const traits::c_hypergraph auto& hypergraph) noexcept {
     const auto degrees = hypergraph.degree_map();
     return degrees.empty() ? 0uz : *std::ranges::min_element(degrees);
 }
 
-[[nodiscard]] types::size_type max_out_degree(
-    const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type max_out_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto degrees = hypergraph.out_degree_map();
     return degrees.empty() ? 0uz : *std::ranges::max_element(degrees);
 }
 
-[[nodiscard]] types::size_type min_out_degree(
-    const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type min_out_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto degrees = hypergraph.out_degree_map();
     return degrees.empty() ? 0uz : *std::ranges::min_element(degrees);
 }
 
-[[nodiscard]] types::size_type max_in_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type max_in_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto degrees = hypergraph.in_degree_map();
     return degrees.empty() ? 0uz : *std::ranges::max_element(degrees);
 }
 
-[[nodiscard]] types::size_type min_in_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type min_in_degree(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto degrees = hypergraph.in_degree_map();
     return degrees.empty() ? 0uz : *std::ranges::min_element(degrees);
@@ -913,35 +899,35 @@ template <traits::c_hypergraph Hypergraph>
 
 // --- hyperedge size bounds ---
 
-[[nodiscard]] types::size_type rank(const traits::c_hypergraph auto& hypergraph) noexcept {
+[[nodiscard]] size_type rank(const traits::c_hypergraph auto& hypergraph) noexcept {
     const auto sizes = hypergraph.hyperedge_size_map();
     return sizes.empty() ? 0uz : *std::ranges::max_element(sizes);
 }
 
-[[nodiscard]] types::size_type corank(const traits::c_hypergraph auto& hypergraph) noexcept {
+[[nodiscard]] size_type corank(const traits::c_hypergraph auto& hypergraph) noexcept {
     const auto sizes = hypergraph.hyperedge_size_map();
     return sizes.empty() ? 0uz : *std::ranges::min_element(sizes);
 }
 
-[[nodiscard]] types::size_type max_tail_size(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type max_tail_size(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto sizes = hypergraph.tail_size_map();
     return sizes.empty() ? 0uz : *std::ranges::max_element(sizes);
 }
 
-[[nodiscard]] types::size_type min_tail_size(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type min_tail_size(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto sizes = hypergraph.tail_size_map();
     return sizes.empty() ? 0uz : *std::ranges::min_element(sizes);
 }
 
-[[nodiscard]] types::size_type max_head_size(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type max_head_size(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto sizes = hypergraph.head_size_map();
     return sizes.empty() ? 0uz : *std::ranges::max_element(sizes);
 }
 
-[[nodiscard]] types::size_type min_head_size(const traits::c_bf_directed_hypergraph auto& hypergraph
+[[nodiscard]] size_type min_head_size(const traits::c_bf_directed_hypergraph auto& hypergraph
 ) noexcept {
     const auto sizes = hypergraph.head_size_map();
     return sizes.empty() ? 0uz : *std::ranges::min_element(sizes);
@@ -950,7 +936,7 @@ template <traits::c_hypergraph Hypergraph>
 // --- regularity ---
 
 [[nodiscard]] bool is_regular(
-    const traits::c_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.degree_map(), k);
 }
@@ -960,7 +946,7 @@ template <traits::c_hypergraph Hypergraph>
 }
 
 [[nodiscard]] bool is_out_regular(
-    const traits::c_bf_directed_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_bf_directed_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.out_degree_map(), k);
 }
@@ -971,7 +957,7 @@ template <traits::c_hypergraph Hypergraph>
 }
 
 [[nodiscard]] bool is_in_regular(
-    const traits::c_bf_directed_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_bf_directed_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.in_degree_map(), k);
 }
@@ -983,7 +969,7 @@ template <traits::c_hypergraph Hypergraph>
 // --- uniformity ---
 
 [[nodiscard]] bool is_uniform(
-    const traits::c_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.hyperedge_size_map(), k);
 }
@@ -993,7 +979,7 @@ template <traits::c_hypergraph Hypergraph>
 }
 
 [[nodiscard]] bool is_tail_uniform(
-    const traits::c_bf_directed_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_bf_directed_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.tail_size_map(), k);
 }
@@ -1004,7 +990,7 @@ template <traits::c_hypergraph Hypergraph>
 }
 
 [[nodiscard]] bool is_head_uniform(
-    const traits::c_bf_directed_hypergraph auto& hypergraph, const types::size_type k
+    const traits::c_bf_directed_hypergraph auto& hypergraph, const size_type k
 ) noexcept {
     return util::all_equal(hypergraph.head_size_map(), k);
 }

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -13,30 +13,30 @@ namespace hgl {
 
 // hypergraph vertex descriptor
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 using vertex_descriptor = gl::vertex_descriptor<Properties>;
 
 // hyperedge descriptor
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 class hyperedge_descriptor final {
 public:
     using type = hyperedge_descriptor<Properties>;
     using properties_type = Properties;
     using properties_ref_type = std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         properties_type&>;
 
     hyperedge_descriptor() {
         *this = hyperedge_descriptor::invalid();
     }
 
-    explicit hyperedge_descriptor(const types::id_type id)
+    explicit hyperedge_descriptor(const id_type id)
     requires(traits::c_empty_properties<properties_type>)
     : _id(id) {}
 
-    explicit hyperedge_descriptor(const types::id_type id, properties_type& properties)
+    explicit hyperedge_descriptor(const id_type id, properties_type& properties)
     requires(traits::c_non_empty_properties<properties_type>)
     : _id(id), _properties(properties) {}
 
@@ -79,7 +79,7 @@ public:
         return this->_id != constants::invalid_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline types::id_type id() const noexcept {
+    [[nodiscard]] gl_attr_force_inline id_type id() const noexcept {
         return this->_id;
     }
 
@@ -91,14 +91,14 @@ public:
     }
 
 private:
-    types::id_type _id;
+    id_type _id;
     [[no_unique_address]] std::conditional_t<
         traits::c_empty_properties<properties_type>,
-        types::empty_properties,
+        empty_properties,
         std::reference_wrapper<properties_type>> _properties;
 };
 
-template <traits::c_properties Properties = types::empty_properties>
+template <traits::c_properties Properties = empty_properties>
 using hyperedge = hyperedge_descriptor<Properties>;
 
 } // namespace hgl

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -13,8 +13,8 @@ namespace hgl {
 
 template <
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
     traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
 struct hypergraph_traits {
     using directional_tag = DirectionalTag;
@@ -30,16 +30,16 @@ struct hypergraph_traits {
 template <
     traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties>
 using list_hypergraph_traits =
     hypergraph_traits<DirectionalTag, VertexProperties, HyperedgeProperties, impl::list_t<LayoutTag>>;
 
 template <
     traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties>
 using flat_list_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
@@ -49,8 +49,8 @@ using flat_list_hypergraph_traits = hypergraph_traits<
 template <
     traits::c_hypergraph_asymmetric_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties>
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties>
 using matrix_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
@@ -58,15 +58,15 @@ using matrix_hypergraph_traits = hypergraph_traits<
     impl::matrix_t<LayoutTag>>;
 
 template <
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
     traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
 using undirected_hypergraph_traits =
     hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 template <
-    traits::c_properties VertexProperties = types::empty_properties,
-    traits::c_properties HyperedgeProperties = types::empty_properties,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
     traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
 using bf_directed_hypergraph_traits =
     hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag>;

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -250,7 +250,7 @@ private:
     template <impl::element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
 
             const std::size_t n_segments = this->_storage.size();
             const auto offsets = this->_storage.offsets_view();
@@ -260,7 +260,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto minor_id : this->_storage.data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             return size_map;
@@ -599,7 +599,7 @@ private:
     template <impl::element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
 
             const std::size_t n_segments = this->_tail_storage.size();
             const auto tail_offsets = this->_tail_storage.offsets_view();
@@ -611,7 +611,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto minor_id : this->_tail_storage.data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             for (const auto minor_id : this->_head_storage.data_view())
@@ -625,7 +625,7 @@ private:
         const size_type n_elements, const auto&& storage_proj
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
 
             const std::size_t n_segments = std::invoke(storage_proj, this).size();
             const auto offsets = std::invoke(storage_proj, this).offsets_view();
@@ -635,7 +635,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto minor_id : std::invoke(storage_proj, this).data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             return size_map;

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "gl/types/core.hpp"
-#include "gl/types/flat_jagged_vector.hpp"
 #include "hgl/decl/impl_tags.hpp"
 #include "hgl/directional_tags.hpp"
 #include "hgl/impl/layout_tags.hpp"
@@ -37,30 +35,27 @@ namespace impl {
 
 namespace detail {
 
-using common_storage_type = gl::types::flat_jagged_vector<gl::types::id_type>;
+using common_storage_type = types::flat_jagged_vector<types::id_type>;
 
 [[nodiscard]] inline bool contains(
-    const common_storage_type::const_segment_type& segment, const gl::types::id_type minor_id
+    const common_storage_type::const_segment_type& segment, const types::id_type minor_id
 ) noexcept {
     const auto minor_it = std::ranges::lower_bound(segment, minor_id);
     return minor_it != segment.end() and *minor_it == minor_id;
 }
 
 inline void unique_insert(
-    common_storage_type& storage,
-    const gl::types::id_type major_id,
-    const gl::types::id_type minor_id
+    common_storage_type& storage, const types::id_type major_id, const types::id_type minor_id
 ) noexcept {
     const auto segment = storage[major_id];
     const auto insert_it = std::ranges::lower_bound(segment, minor_id);
     if (insert_it == segment.end() or *insert_it != minor_id) {
-        const auto pos =
-            static_cast<gl::types::size_type>(std::distance(segment.begin(), insert_it));
+        const auto pos = static_cast<types::size_type>(std::distance(segment.begin(), insert_it));
         storage.insert(major_id, pos, minor_id);
     }
 }
 
-inline void remove_minor(common_storage_type& storage, const gl::types::id_type id) noexcept {
+inline void remove_minor(common_storage_type& storage, const types::id_type id) noexcept {
     auto& data = storage.data_storage();
     auto& offsets = storage.offsets_storage();
 

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -35,27 +35,27 @@ namespace impl {
 
 namespace detail {
 
-using common_storage_type = types::flat_jagged_vector<types::id_type>;
+using flat_list_storage_type = flat_jagged_vector<id_type>;
 
 [[nodiscard]] inline bool contains(
-    const common_storage_type::const_segment_type& segment, const types::id_type minor_id
+    const flat_list_storage_type::const_segment_type& segment, const id_type minor_id
 ) noexcept {
     const auto minor_it = std::ranges::lower_bound(segment, minor_id);
     return minor_it != segment.end() and *minor_it == minor_id;
 }
 
 inline void unique_insert(
-    common_storage_type& storage, const types::id_type major_id, const types::id_type minor_id
+    flat_list_storage_type& storage, const id_type major_id, const id_type minor_id
 ) noexcept {
     const auto segment = storage[major_id];
     const auto insert_it = std::ranges::lower_bound(segment, minor_id);
     if (insert_it == segment.end() or *insert_it != minor_id) {
-        const auto pos = static_cast<types::size_type>(std::distance(segment.begin(), insert_it));
+        const auto pos = static_cast<size_type>(std::distance(segment.begin(), insert_it));
         storage.insert(major_id, pos, minor_id);
     }
 }
 
-inline void remove_minor(common_storage_type& storage, const types::id_type id) noexcept {
+inline void remove_minor(flat_list_storage_type& storage, const id_type id) noexcept {
     auto& data = storage.data_storage();
     auto& offsets = storage.offsets_storage();
 
@@ -96,7 +96,7 @@ public:
 
     flat_incidence_list() = default;
 
-    flat_incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    flat_incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _storage{layout_tag::major(n_vertices, n_hyperedges)} {}
 
     flat_incidence_list(const flat_incidence_list&) = default;
@@ -109,82 +109,74 @@ public:
 
     // --- vertex methods ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
-        const types::size_type n_vertices
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
         return this->_size_map<impl::element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
         return this->_size<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
+        const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         detail::unique_insert(this->_storage, major_id, minor_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
 
         const auto segment = this->_storage[major_id];
         const auto minor_it = std::ranges::lower_bound(segment, minor_id);
         if (minor_it != segment.end() and *minor_it == minor_id) {
-            const auto pos =
-                static_cast<types::size_type>(std::distance(segment.begin(), minor_it));
+            const auto pos = static_cast<size_type>(std::distance(segment.begin(), minor_it));
             this->_storage.erase(major_id, pos);
         }
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         return detail::contains(
             this->_storage[layout_tag::major(vertex_id, hyperedge_id)],
@@ -209,19 +201,19 @@ public:
 #endif
 
 private:
-    using element_type = types::id_type;
-    using storage_type = types::flat_jagged_vector<element_type>;
+    using element_type = id_type;
+    using storage_type = flat_jagged_vector<element_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) // add major
             this->_storage.resize(this->_storage.size() + n);
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) // remove major
             this->_storage.erase(id);
         else // remove minor
@@ -229,25 +221,25 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline auto _incident_with(const types::id_type id) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return this->_storage[id];
         }
         else { // incident with minor
             return std::views::iota(0uz, this->_storage.size())
-                 | std::views::filter([this, minor_id = id](const types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id](const id_type major_id) {
                        return detail::contains(this->_storage[major_id], minor_id);
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] types::size_type _size(const types::id_type id) const noexcept {
+    [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_storage[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto segment : this->_storage)
                 if (detail::contains(segment, id))
                     ++size;
@@ -256,10 +248,9 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _size_map(const types::size_type n_elements
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
 
             const std::size_t n_segments = this->_storage.size();
             const auto offsets = this->_storage.offsets_view();
@@ -269,7 +260,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto minor_id : this->_storage.data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             return size_map;
@@ -287,7 +278,7 @@ public:
 
     flat_incidence_list() = default;
 
-    flat_incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    flat_incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _tail_storage{layout_tag::major(n_vertices, n_hyperedges)},
       _head_storage{layout_tag::major(n_vertices, n_hyperedges)} {}
 
@@ -301,65 +292,60 @@ public:
 
     // --- vertex methods : general ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
         return this->_get<impl::element_type::vertex>(
             vertex_id, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(
             vertex_id, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(
             n_vertices, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
         return this->_get<impl::element_type::vertex>(
             vertex_id, &flat_incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(
             vertex_id, &flat_incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(
             n_vertices, &flat_incidence_list::_head_storage
         );
@@ -367,66 +353,64 @@ public:
 
     // --- hyperedge methods : general ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(
             n_hyperedges, &flat_incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(
             n_hyperedges, &flat_incidence_list::_head_storage
@@ -436,7 +420,7 @@ public:
     // --- binding methods ---
 
     gl_attr_force_inline void bind_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_head_storage, major_id, minor_id);
@@ -444,23 +428,21 @@ public:
     }
 
     gl_attr_force_inline void bind_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_tail_storage, major_id, minor_id);
         detail::unique_insert(this->_head_storage, major_id, minor_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_tail_storage, major_id, minor_id);
         this->_remove_no_align(this->_head_storage, major_id, minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return detail::contains(this->_tail_storage[major_id], minor_id)
@@ -468,14 +450,14 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return detail::contains(this->_tail_storage[major_id], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return detail::contains(this->_head_storage[major_id], minor_id);
@@ -498,14 +480,14 @@ public:
 #endif
 
 private:
-    using element_type = types::id_type;
-    using storage_type = types::flat_jagged_vector<element_type>;
+    using element_type = id_type;
+    using storage_type = flat_jagged_vector<element_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
     template <typename Projection>
     [[nodiscard]] gl_attr_force_inline auto _storage_view(
-        const types::id_type id, const Projection storage_proj
+        const id_type id, const Projection storage_proj
     ) const noexcept {
         if constexpr (std::same_as<Projection, std::identity>) {
             // TODO: use std::views::concat (C++26)
@@ -521,7 +503,7 @@ private:
     }
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) {
             this->_tail_storage.resize(this->_tail_storage.size() + n);
             this->_head_storage.resize(this->_head_storage.size() + n);
@@ -529,7 +511,7 @@ private:
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) {
             this->_tail_storage.erase(id);
             this->_head_storage.erase(id);
@@ -541,19 +523,18 @@ private:
     }
 
     void _remove_no_align(
-        storage_type& storage, const types::id_type major_id, const types::id_type minor_id
+        storage_type& storage, const id_type major_id, const id_type minor_id
     ) noexcept {
         const auto segment = storage[major_id];
         const auto minor_it = std::ranges::lower_bound(segment, minor_id);
         if (minor_it != segment.end() and *minor_it == minor_id) {
-            const auto pos =
-                static_cast<types::size_type>(std::distance(segment.begin(), minor_it));
+            const auto pos = static_cast<size_type>(std::distance(segment.begin(), minor_it));
             storage.erase(major_id, pos);
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline auto _get(const types::id_type id) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::array<storage_const_segment_type, 2>{
                        this->_tail_storage[id], this->_head_storage[id]
@@ -562,7 +543,7 @@ private:
         }
         else { // get minor
             return std::views::iota(0uz, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id](id_type major_id) {
                        return detail::contains(this->_tail_storage[major_id], minor_id)
                            or detail::contains(this->_head_storage[major_id], minor_id);
                    });
@@ -570,27 +551,26 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline auto _get(const types::id_type id, const auto&& storage_proj)
+    [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const auto&& storage_proj)
         const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::invoke(storage_proj, this)[id];
         }
         else { // get minor
             return std::views::iota(0uz, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](types::id_type major_id) {
+                 | std::views::filter([this, storage_proj, minor_id = id](id_type major_id) {
                        return detail::contains(std::invoke(storage_proj, this)[major_id], minor_id);
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline types::size_type _size(const types::id_type id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_tail_storage[id].size() + this->_head_storage[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto [ts, hs] : std::views::zip(this->_tail_storage, this->_head_storage)) {
                 if (detail::contains(ts, id))
                     ++size;
@@ -602,14 +582,13 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline types::size_type _size(
-        const types::id_type id, const auto&& storage_proj
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type
+    _size(const id_type id, const auto&& storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return std::invoke(storage_proj, this)[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto segment : std::invoke(storage_proj, this))
                 if (detail::contains(segment, id))
                     ++size;
@@ -618,10 +597,9 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _size_map(const types::size_type n_elements
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
 
             const std::size_t n_segments = this->_tail_storage.size();
             const auto tail_offsets = this->_tail_storage.offsets_view();
@@ -633,7 +611,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto minor_id : this->_tail_storage.data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             for (const auto minor_id : this->_head_storage.data_view())
@@ -643,11 +621,11 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _size_map(
-        const types::size_type n_elements, const auto&& storage_proj
+    [[nodiscard]] std::vector<size_type> _size_map(
+        const size_type n_elements, const auto&& storage_proj
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
 
             const std::size_t n_segments = std::invoke(storage_proj, this).size();
             const auto offsets = std::invoke(storage_proj, this).offsets_view();
@@ -657,7 +635,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto minor_id : std::invoke(storage_proj, this).data_view())
                 ++size_map[static_cast<std::size_t>(minor_id)];
             return size_map;
@@ -676,7 +654,7 @@ public:
 
     flat_incidence_list() = default;
 
-    flat_incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    flat_incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _v_list{n_vertices, n_hyperedges}, _e_list{n_vertices, n_hyperedges} {}
 
     flat_incidence_list(const flat_incidence_list&) = default;
@@ -689,69 +667,63 @@ public:
 
     // --- vertex methods : general ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_v_list.add_vertices(n);
         this->_e_list.add_vertices(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_v_list.remove_vertex(vertex_id);
         this->_e_list.remove_vertex(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_v_list.incident_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
         return this->_v_list.degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
-        const types::size_type n_vertices
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
         return this->_v_list.degree_map(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_degree(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_degree_map(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_degree(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_degree_map(n_vertices);
@@ -759,70 +731,65 @@ public:
 
     // --- hyperedge methods : general ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_v_list.add_hyperedges(n);
         this->_e_list.add_hyperedges(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_v_list.remove_hyperedge(hyperedge_id);
         this->_e_list.remove_hyperedge(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_e_list.incident_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
         return this->_e_list.hyperedge_size(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
+        const size_type n_hyperedges
     ) const noexcept {
         return this->_e_list.hyperedge_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_size(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_size(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_size_map(n_hyperedges);
@@ -830,24 +797,20 @@ public:
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::undirected_t>
     {
         this->_v_list.bind(vertex_id, hyperedge_id);
         this->_e_list.bind(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         this->_v_list.unbind(vertex_id, hyperedge_id);
         this->_e_list.unbind(vertex_id, hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         if (this->degree(vertex_id) <= this->hyperedge_size(hyperedge_id))
             return this->_v_list.are_bound(vertex_id, hyperedge_id);
@@ -855,18 +818,14 @@ public:
             return this->_e_list.are_bound(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void bind_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind_tail(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         this->_v_list.bind_tail(vertex_id, hyperedge_id);
         this->_e_list.bind_tail(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void bind_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind_head(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         this->_v_list.bind_head(vertex_id, hyperedge_id);
@@ -874,7 +833,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
@@ -885,7 +844,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -201,8 +201,7 @@ public:
 #endif
 
 private:
-    using element_type = id_type;
-    using storage_type = flat_jagged_vector<element_type>;
+    using storage_type = flat_jagged_vector<id_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
@@ -480,8 +479,7 @@ public:
 #endif
 
 private:
-    using element_type = id_type;
-    using storage_type = flat_jagged_vector<element_type>;
+    using storage_type = flat_jagged_vector<id_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -47,7 +47,7 @@ public:
 
     incidence_list() = default;
 
-    incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _major_storage{layout_tag::major(n_vertices, n_hyperedges)} {}
 
     incidence_list(const incidence_list&) = default;
@@ -60,62 +60,57 @@ public:
 
     // --- vertex methods ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
-        const types::size_type n_vertices
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
         return this->_size_map<impl::element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
         return this->_size<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
+        const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         auto& minor_storage = this->_major_storage[major_id];
 
@@ -125,9 +120,7 @@ public:
             minor_storage.insert(minor_it, minor_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         auto& minor_storage = this->_major_storage[major_id];
         const auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);
@@ -136,7 +129,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         return this->_contains(
             this->_major_storage[layout_tag::major(vertex_id, hyperedge_id)],
@@ -160,19 +153,19 @@ public:
 #endif
 
 private:
-    using minor_element_type = types::id_type;
+    using minor_element_type = id_type;
     using minor_storage_type = std::vector<minor_element_type>;
     using major_element_type = minor_storage_type;
     using major_storage_type = std::vector<major_element_type>;
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) // add major
             this->_major_storage.resize(this->_major_storage.size() + n);
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_major_storage.erase(
                 this->_major_storage.begin() + static_cast<std::ptrdiff_t>(id)
@@ -190,25 +183,25 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline auto _incident_with(const types::id_type id) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return std::views::all(this->_major_storage[id]);
         }
         else { // incident with minor
             return std::views::iota(0uz, this->_major_storage.size())
-                 | std::views::filter([this, minor_id = id](types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id](id_type major_id) {
                        return this->_contains(this->_major_storage[major_id], minor_id);
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] types::size_type _size(const types::id_type id) const noexcept {
+    [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_major_storage[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto& major_el : this->_major_storage)
                 if (this->_contains(major_el, id))
                     ++size;
@@ -217,16 +210,15 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _size_map(const types::size_type n_elements
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             auto size_map = this->_major_storage | std::views::transform(&major_element_type::size)
-                          | std::ranges::to<std::vector<types::size_type>>();
+                          | std::ranges::to<std::vector<size_type>>();
             size_map.resize(n_elements, 0ull);
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto& major_entry : this->_major_storage)
                 for (const auto& minor_id : major_entry)
                     ++size_map[static_cast<std::size_t>(minor_id)];
@@ -234,9 +226,8 @@ private:
         }
     }
 
-    [[nodiscard]] bool _contains(
-        const minor_storage_type& minor_storage, const types::id_type minor_id
-    ) const noexcept {
+    [[nodiscard]] bool _contains(const minor_storage_type& minor_storage, const id_type minor_id)
+        const noexcept {
         const auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);
         return minor_it != minor_storage.end() and *minor_it == minor_id;
     }
@@ -252,7 +243,7 @@ public:
 
     incidence_list() = default;
 
-    incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _tail_storage{layout_tag::major(n_vertices, n_hyperedges)},
       _head_storage{layout_tag::major(n_vertices, n_hyperedges)} {}
 
@@ -266,57 +257,52 @@ public:
 
     // --- vertex methods : general ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(
             n_vertices, &incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
         return this->_get<impl::element_type::vertex>(vertex_id, &incidence_list::_head_storage);
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
         return this->_size<impl::element_type::vertex>(vertex_id, &incidence_list::_head_storage);
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
         return this->_size_map<impl::element_type::vertex>(
             n_vertices, &incidence_list::_head_storage
         );
@@ -324,66 +310,64 @@ public:
 
     // --- hyperedge methods : general ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(
             hyperedge_id, &incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(
             hyperedge_id, &incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(
             n_hyperedges, &incidence_list::_tail_storage
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_get<impl::element_type::hyperedge>(
             hyperedge_id, &incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
         return this->_size<impl::element_type::hyperedge>(
             hyperedge_id, &incidence_list::_head_storage
         );
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_size_map<impl::element_type::hyperedge>(
             n_hyperedges, &incidence_list::_head_storage
@@ -393,7 +377,7 @@ public:
     // --- binding methods ---
 
     gl_attr_force_inline void bind_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_head_storage[major_id], minor_id);
@@ -401,23 +385,21 @@ public:
     }
 
     gl_attr_force_inline void bind_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_tail_storage[major_id], minor_id);
         this->_unique_insert(this->_head_storage[major_id], minor_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_remove_no_align(this->_tail_storage[major_id], minor_id);
         this->_remove_no_align(this->_head_storage[major_id], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_contains(this->_tail_storage[major_id], minor_id)
@@ -425,14 +407,14 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_contains(this->_tail_storage[major_id], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_contains(this->_head_storage[major_id], minor_id);
@@ -454,12 +436,12 @@ public:
 #endif
 
 private:
-    using minor_element_type = types::id_type;
+    using minor_element_type = id_type;
     using minor_storage_type = std::vector<minor_element_type>;
     using major_storage_type = std::vector<minor_storage_type>;
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_tail_storage.resize(this->_tail_storage.size() + n);
             this->_head_storage.resize(this->_head_storage.size() + n);
@@ -467,7 +449,7 @@ private:
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_tail_storage.erase(
                 this->_tail_storage.begin() + static_cast<std::ptrdiff_t>(id)
@@ -484,13 +466,13 @@ private:
         }
     }
 
-    void _remove_minor(minor_storage_type& minor_storage, const types::id_type id) noexcept {
+    void _remove_minor(minor_storage_type& minor_storage, const id_type id) noexcept {
         auto minor_it = this->_remove_no_align(minor_storage, id);
         while (minor_it != minor_storage.end())
             --(*minor_it++); // decrement ids > id
     }
 
-    auto _remove_no_align(minor_storage_type& minor_storage, const types::id_type id) noexcept {
+    auto _remove_no_align(minor_storage_type& minor_storage, const id_type id) noexcept {
         auto minor_it = std::ranges::lower_bound(minor_storage, id);
         if (minor_it != minor_storage.end() and *minor_it == id)
             minor_it = minor_storage.erase(minor_it); // unbind the element
@@ -498,7 +480,7 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline auto _get(const types::id_type id) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::array<std::span<const minor_element_type>, 2>{
                        this->_tail_storage[id], this->_head_storage[id]
@@ -507,7 +489,7 @@ private:
         }
         else { // get minor
             return std::views::iota(0uz, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id](id_type major_id) {
                        return this->_contains(this->_tail_storage[major_id], minor_id)
                            or this->_contains(this->_head_storage[major_id], minor_id);
                    });
@@ -515,28 +497,26 @@ private:
     }
 
     template <impl::element_type Element, typename Projection = std::identity>
-    [[nodiscard]] gl_attr_force_inline auto _get(
-        const types::id_type id, const Projection storage_proj
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const Projection storage_proj)
+        const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::views::all(std::invoke(storage_proj, this)[id]);
         }
         else { // get minor
             return std::views::iota(0uz, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](types::id_type major_id) {
+                 | std::views::filter([this, storage_proj, minor_id = id](id_type major_id) {
                        return this->_contains(std::invoke(storage_proj, this)[major_id], minor_id);
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline types::size_type _size(const types::id_type id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_tail_storage[id].size() + this->_head_storage[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto [ts, hs] : std::views::zip(this->_tail_storage, this->_head_storage)) {
                 if (this->_contains(ts, id))
                     ++size;
@@ -548,14 +528,13 @@ private:
     }
 
     template <impl::element_type Element, typename Projection = std::identity>
-    [[nodiscard]] gl_attr_force_inline types::size_type _size(
-        const types::id_type id, const Projection storage_proj
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type
+    _size(const id_type id, const Projection storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return std::invoke(storage_proj, this)[id].size();
         }
         else { // size minor
-            types::size_type size = 0uz;
+            size_type size = 0uz;
             for (const auto& minor_storage : std::invoke(storage_proj, this))
                 if (this->_contains(minor_storage, id))
                     ++size;
@@ -564,17 +543,16 @@ private:
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _size_map(const types::size_type n_elements
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             const std::size_t n_segments = this->_tail_storage.size();
             for (std::size_t i = 0uz; i < n_segments; ++i)
                 size_map[i] = this->_tail_storage[i].size() + this->_head_storage[i].size();
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto& minor_storage : this->_tail_storage)
                 for (const auto minor_id : minor_storage)
                     ++size_map[static_cast<std::size_t>(minor_id)];
@@ -586,11 +564,11 @@ private:
     }
 
     template <impl::element_type Element, typename Projection = std::identity>
-    [[nodiscard]] std::vector<types::size_type> _size_map(
-        const types::size_type n_elements, const Projection storage_proj
+    [[nodiscard]] std::vector<size_type> _size_map(
+        const size_type n_elements, const Projection storage_proj
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             const auto& storage = std::invoke(storage_proj, this);
             const std::size_t n_segments = storage.size();
             for (std::size_t i = 0uz; i < n_segments; ++i)
@@ -598,7 +576,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<types::size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0ull);
             for (const auto& minor_storage : std::invoke(storage_proj, this))
                 for (const auto minor_id : minor_storage)
                     ++size_map[static_cast<std::size_t>(minor_id)];
@@ -606,13 +584,13 @@ private:
         }
     }
 
-    void _unique_insert(minor_storage_type& minor_storage, const types::id_type id) noexcept {
+    void _unique_insert(minor_storage_type& minor_storage, const id_type id) noexcept {
         const auto minor_it = std::ranges::lower_bound(minor_storage, id);
         if (minor_it == minor_storage.end() or *minor_it != id)
             minor_storage.insert(minor_it, id);
     }
 
-    [[nodiscard]] bool _contains(const minor_storage_type& minor_storage, const types::id_type id)
+    [[nodiscard]] bool _contains(const minor_storage_type& minor_storage, const id_type id)
         const noexcept {
         const auto minor_it = std::ranges::lower_bound(minor_storage, id);
         return minor_it != minor_storage.end() and *minor_it == id;
@@ -630,7 +608,7 @@ public:
 
     incidence_list() = default;
 
-    incidence_list(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    incidence_list(const size_type n_vertices, const size_type n_hyperedges)
     : _v_list{n_vertices, n_hyperedges}, _e_list{n_vertices, n_hyperedges} {}
 
     incidence_list(const incidence_list&) = default;
@@ -643,69 +621,63 @@ public:
 
     // --- vertex methods : general ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_v_list.add_vertices(n);
         this->_e_list.add_vertices(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_v_list.remove_vertex(vertex_id);
         this->_e_list.remove_vertex(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_v_list.incident_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type degree(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
         return this->_v_list.degree(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> degree_map(
-        const types::size_type n_vertices
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
         return this->_v_list.degree_map(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_degree(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.out_degree_map(n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_degree(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_v_list.in_degree_map(n_vertices);
@@ -713,70 +685,65 @@ public:
 
     // --- hyperedge methods : general ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_v_list.add_hyperedges(n);
         this->_e_list.add_hyperedges(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_v_list.remove_hyperedge(hyperedge_id);
         this->_e_list.remove_hyperedge(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_e_list.incident_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline types::size_type hyperedge_size(
-        const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
         return this->_e_list.hyperedge_size(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
+        const size_type n_hyperedges
     ) const noexcept {
         return this->_e_list.hyperedge_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_size(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.tail_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
-    ) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_vertices(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_size(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
-    ) const noexcept
+    [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         return this->_e_list.head_size_map(n_hyperedges);
@@ -784,24 +751,20 @@ public:
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::undirected_t>
     {
         this->_v_list.bind(vertex_id, hyperedge_id);
         this->_e_list.bind(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         this->_v_list.unbind(vertex_id, hyperedge_id);
         this->_e_list.unbind(vertex_id, hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         if (this->degree(vertex_id) <= this->hyperedge_size(hyperedge_id))
             return this->_v_list.are_bound(vertex_id, hyperedge_id);
@@ -809,18 +772,14 @@ public:
             return this->_e_list.are_bound(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void bind_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind_tail(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         this->_v_list.bind_tail(vertex_id, hyperedge_id);
         this->_e_list.bind_tail(vertex_id, hyperedge_id);
     }
 
-    gl_attr_force_inline void bind_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept
+    gl_attr_force_inline void bind_head(const id_type vertex_id, const id_type hyperedge_id) noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
         this->_v_list.bind_head(vertex_id, hyperedge_id);
@@ -828,7 +787,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
@@ -839,7 +798,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -214,11 +214,11 @@ private:
         if constexpr (Element == layout_tag::major_element) { // size major
             auto size_map = this->_major_storage | std::views::transform(&major_element_type::size)
                           | std::ranges::to<std::vector<size_type>>();
-            size_map.resize(n_elements, 0ull);
+            size_map.resize(n_elements, 0uz);
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& major_entry : this->_major_storage)
                 for (const auto& minor_id : major_entry)
                     ++size_map[static_cast<std::size_t>(minor_id)];
@@ -545,14 +545,14 @@ private:
     template <impl::element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             const std::size_t n_segments = this->_tail_storage.size();
             for (std::size_t i = 0uz; i < n_segments; ++i)
                 size_map[i] = this->_tail_storage[i].size() + this->_head_storage[i].size();
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& minor_storage : this->_tail_storage)
                 for (const auto minor_id : minor_storage)
                     ++size_map[static_cast<std::size_t>(minor_id)];
@@ -568,7 +568,7 @@ private:
         const size_type n_elements, const Projection storage_proj
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             const auto& storage = std::invoke(storage_proj, this);
             const std::size_t n_segments = storage.size();
             for (std::size_t i = 0uz; i < n_segments; ++i)
@@ -576,7 +576,7 @@ private:
             return size_map;
         }
         else { // size minor
-            std::vector<size_type> size_map(n_elements, 0ull);
+            std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& minor_storage : std::invoke(storage_proj, this))
                 for (const auto minor_id : minor_storage)
                     ++size_map[static_cast<std::size_t>(minor_id)];

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -209,16 +209,15 @@ private:
         std::vector<size_type> size_map(n_elements, 0uz);
 
         if constexpr (Element == layout_tag::major_element) { // count map major
-            const size_type limit =
-                std::min(n_elements, static_cast<size_type>(this->_matrix.size()));
-            for (size_type i = 0uz; i < limit; ++i) {
-                size_map[i] = static_cast<size_type>(std::ranges::count(this->_matrix[i], true));
+            const size_type limit = std::min(n_elements, this->_matrix.size());
+            for (auto i = 0uz; i < limit; ++i) {
+                size_map[i] = std::ranges::count(this->_matrix[i], true);
             }
         }
         else { // count map minor
             const size_type limit = std::min(n_elements, this->_matrix_row_size);
             for (const auto& row : this->_matrix) {
-                for (size_type j = 0uz; j < limit; ++j) {
+                for (auto j = 0uz; j < limit; ++j) {
                     if (row[j]) {
                         ++size_map[j];
                     }
@@ -511,24 +510,18 @@ private:
         std::vector<size_type> size_map(n_elements, 0uz);
 
         if constexpr (Element == layout_tag::major_element) { // count map major
-            const size_type limit =
-                std::min(n_elements, static_cast<size_type>(this->_matrix.size()));
-            for (size_type i = 0uz; i < limit; ++i) {
-                for (const auto val : this->_matrix[i]) {
-                    if (pred(val)) {
+            const size_type limit = std::min(n_elements, this->_matrix.size());
+            for (auto i = 0uz; i < limit; ++i)
+                for (const auto val : this->_matrix[i])
+                    if (pred(val))
                         ++size_map[i];
-                    }
-                }
-            }
         }
         else { // count map minor
             for (const auto& row : this->_matrix) {
                 const size_type limit = std::min(n_elements, this->_matrix_row_size);
-                for (size_type j = 0uz; j < limit; ++j) {
-                    if (pred(row[j])) {
+                for (auto j = 0uz; j < limit; ++j)
+                    if (pred(row[j]))
                         ++size_map[j];
-                    }
-                }
             }
         }
 

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -45,7 +45,7 @@ public:
 
     incidence_matrix() = default;
 
-    incidence_matrix(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    incidence_matrix(const size_type n_vertices, const size_type n_hyperedges)
     : _matrix_row_size{layout_tag::minor(n_vertices, n_hyperedges)},
       _matrix(
           layout_tag::major(n_vertices, n_hyperedges), matrix_row_type(_matrix_row_size, false)
@@ -61,72 +61,65 @@ public:
 
     // --- vertex methods ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
         return this->_count<impl::element_type::vertex>(vertex_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
         return this->_count_map<impl::element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
         return this->_count<impl::element_type::hyperedge>(hyperedge_id);
     }
 
-    [[nodiscard]] std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_count_map<impl::element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
 
-    gl_attr_force_inline void bind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_matrix[major_id][minor_id] = true;
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_matrix[major_id][minor_id] = false;
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_matrix[major_id][minor_id];
@@ -153,7 +146,7 @@ private:
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_matrix.resize(
                 this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, false)
@@ -167,7 +160,7 @@ private:
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
         }
@@ -182,53 +175,50 @@ private:
     }
 
     template <impl::element_type Element>
-    gl_attr_force_inline auto _incident_with(const types::id_type id) const noexcept {
+    gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return std::views::iota(0uz, this->_matrix_row_size)
-                 | std::views::filter([&row = this->_matrix[id]](const types::id_type minor_id) {
+                 | std::views::filter([&row = this->_matrix[id]](const id_type minor_id) {
                        return row[minor_id];
                    });
         }
         else { // incident with minor
             return std::views::iota(0uz, this->_matrix.size())
-                 | std::views::filter([this, minor_id = id](const types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id](const id_type major_id) {
                        return this->_matrix[major_id][minor_id];
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline types::size_type _count(const types::id_type id
-    ) const noexcept {
-        types::size_type count = 0uz;
+    [[nodiscard]] gl_attr_force_inline size_type _count(const id_type id) const noexcept {
+        size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
             for (const bool bit : this->_matrix[id])
-                count += static_cast<types::size_type>(bit);
+                count += static_cast<size_type>(bit);
         }
         else { // count minor
             for (const auto& row : this->_matrix)
-                count += static_cast<types::size_type>(row[id]);
+                count += static_cast<size_type>(row[id]);
         }
         return count;
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _count_map(const types::size_type n_elements
-    ) const noexcept {
-        std::vector<types::size_type> size_map(n_elements, 0uz);
+    [[nodiscard]] std::vector<size_type> _count_map(const size_type n_elements) const noexcept {
+        std::vector<size_type> size_map(n_elements, 0uz);
 
         if constexpr (Element == layout_tag::major_element) { // count map major
-            const types::size_type limit =
-                std::min(n_elements, static_cast<types::size_type>(this->_matrix.size()));
-            for (types::size_type i = 0uz; i < limit; ++i) {
-                size_map[i] =
-                    static_cast<types::size_type>(std::ranges::count(this->_matrix[i], true));
+            const size_type limit =
+                std::min(n_elements, static_cast<size_type>(this->_matrix.size()));
+            for (size_type i = 0uz; i < limit; ++i) {
+                size_map[i] = static_cast<size_type>(std::ranges::count(this->_matrix[i], true));
             }
         }
         else { // count map minor
-            const types::size_type limit = std::min(n_elements, this->_matrix_row_size);
+            const size_type limit = std::min(n_elements, this->_matrix_row_size);
             for (const auto& row : this->_matrix) {
-                for (types::size_type j = 0uz; j < limit; ++j) {
+                for (size_type j = 0uz; j < limit; ++j) {
                     if (row[j]) {
                         ++size_map[j];
                     }
@@ -238,7 +228,7 @@ private:
         return size_map;
     }
 
-    types::size_type _matrix_row_size = 0uz;
+    size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
 
@@ -250,7 +240,7 @@ public:
 
     incidence_matrix() = default;
 
-    incidence_matrix(const types::size_type n_vertices, const types::size_type n_hyperedges)
+    incidence_matrix(const size_type n_vertices, const size_type n_hyperedges)
     : _matrix_row_size{layout_tag::minor(n_vertices, n_hyperedges)},
       _matrix(
           layout_tag::major(n_vertices, n_hyperedges),
@@ -267,110 +257,103 @@ public:
 
     // --- vertex methods : general ---
 
-    gl_attr_force_inline void add_vertices(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_vertices(const size_type n) noexcept {
         this->_add<impl::element_type::vertex>(n);
     }
 
-    gl_attr_force_inline void remove_vertex(const types::id_type vertex_id) noexcept {
+    gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
         this->_remove<impl::element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const types::id_type vertex_id
+    [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
         return this->_query<impl::element_type::vertex>(vertex_id, _is_incident);
     }
 
-    [[nodiscard]] types::size_type degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
         return this->_count<impl::element_type::vertex>(vertex_id, _is_incident);
     }
 
-    [[nodiscard]] std::vector<types::size_type> degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
         return this->_count_map<impl::element_type::vertex>(n_vertices, _is_incident);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
         return this->_query<impl::element_type::vertex>(vertex_id, _is_tail);
     }
 
-    [[nodiscard]] types::size_type out_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
         return this->_count<impl::element_type::vertex>(vertex_id, _is_tail);
     }
 
-    [[nodiscard]] std::vector<types::size_type> out_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
         return this->_count_map<impl::element_type::vertex>(n_vertices, _is_tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const types::id_type vertex_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
         return this->_query<impl::element_type::vertex>(vertex_id, _is_head);
     }
 
-    [[nodiscard]] types::size_type in_degree(const types::id_type vertex_id) const noexcept {
+    [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
         return this->_count<impl::element_type::vertex>(vertex_id, _is_head);
     }
 
-    [[nodiscard]] std::vector<types::size_type> in_degree_map(const types::size_type n_vertices
-    ) const noexcept {
+    [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
         return this->_count_map<impl::element_type::vertex>(n_vertices, _is_head);
     }
 
     // --- hyperedge methods : general ---
 
-    gl_attr_force_inline void add_hyperedges(const types::size_type n) noexcept {
+    gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
         this->_add<impl::element_type::hyperedge>(n);
     }
 
-    gl_attr_force_inline void remove_hyperedge(const types::id_type hyperedge_id) noexcept {
+    gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
         this->_remove<impl::element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
-    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
     }
 
-    [[nodiscard]] types::size_type hyperedge_size(const types::id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
         return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
     }
 
-    [[nodiscard]] std::vector<types::size_type> hyperedge_size_map(
-        const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_incident);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
-    [[nodiscard]] types::size_type tail_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
         return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
-    [[nodiscard]] std::vector<types::size_type> tail_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const types::id_type hyperedge_id
+    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
         return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
-    [[nodiscard]] types::size_type head_size(const types::id_type hyperedge_id) const noexcept {
+    [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
         return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
-    [[nodiscard]] std::vector<types::size_type> head_size_map(const types::size_type n_hyperedges
+    [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
         return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_head);
     }
@@ -378,42 +361,40 @@ public:
     // --- binding methods ---
 
     gl_attr_force_inline void bind_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_matrix[major_id][minor_id] = incidence_type::backward;
     }
 
     gl_attr_force_inline void bind_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_matrix[major_id][minor_id] = incidence_type::forward;
     }
 
-    gl_attr_force_inline void unbind(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
-    ) noexcept {
+    gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         this->_matrix[major_id][minor_id] = incidence_type::none;
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_matrix[major_id][minor_id] != incidence_type::none;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_matrix[major_id][minor_id] == incidence_type::backward;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
-        const types::id_type vertex_id, const types::id_type hyperedge_id
+        const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
         return this->_matrix[major_id][minor_id] == incidence_type::forward;
@@ -462,7 +443,7 @@ private:
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
     template <impl::element_type Element>
-    void _add(const types::size_type n) noexcept {
+    void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_matrix.resize(
                 this->_matrix.size() + n,
@@ -477,7 +458,7 @@ private:
     }
 
     template <impl::element_type Element>
-    void _remove(const types::id_type id) noexcept {
+    void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
         }
@@ -492,47 +473,47 @@ private:
 
     template <impl::element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _query(
-        const types::id_type id, std::predicate<incidence_type> auto&& pred
+        const id_type id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // query major
             return std::views::iota(0uz, this->_matrix_row_size)
-                 | std::views::filter([&row = this->_matrix[id], pred](const types::id_type minor_id
-                                      ) { return pred(row[minor_id]); });
+                 | std::views::filter([&row = this->_matrix[id], pred](const id_type minor_id) {
+                       return pred(row[minor_id]);
+                   });
         }
         else { // query minor
             return std::views::iota(0uz, this->_matrix.size())
-                 | std::views::filter([this, minor_id = id, pred](const types::id_type major_id) {
+                 | std::views::filter([this, minor_id = id, pred](const id_type major_id) {
                        return pred(this->_matrix[major_id][minor_id]);
                    });
         }
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] gl_attr_force_inline types::size_type _count(
-        const types::id_type id, std::predicate<incidence_type> auto&& pred
-    ) const noexcept {
-        types::size_type count = 0uz;
+    [[nodiscard]] gl_attr_force_inline size_type
+    _count(const id_type id, std::predicate<incidence_type> auto&& pred) const noexcept {
+        size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
             for (const incidence_type t : this->_matrix[id])
-                count += static_cast<types::size_type>(pred(t));
+                count += static_cast<size_type>(pred(t));
         }
         else { // count minor
             for (const auto& row : this->_matrix)
-                count += static_cast<types::size_type>(pred(row[id]));
+                count += static_cast<size_type>(pred(row[id]));
         }
         return count;
     }
 
     template <impl::element_type Element>
-    [[nodiscard]] std::vector<types::size_type> _count_map(
-        const types::size_type n_elements, std::predicate<incidence_type> auto&& pred
+    [[nodiscard]] std::vector<size_type> _count_map(
+        const size_type n_elements, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
-        std::vector<types::size_type> size_map(n_elements, 0uz);
+        std::vector<size_type> size_map(n_elements, 0uz);
 
         if constexpr (Element == layout_tag::major_element) { // count map major
-            const types::size_type limit =
-                std::min(n_elements, static_cast<types::size_type>(this->_matrix.size()));
-            for (types::size_type i = 0uz; i < limit; ++i) {
+            const size_type limit =
+                std::min(n_elements, static_cast<size_type>(this->_matrix.size()));
+            for (size_type i = 0uz; i < limit; ++i) {
                 for (const auto val : this->_matrix[i]) {
                     if (pred(val)) {
                         ++size_map[i];
@@ -542,8 +523,8 @@ private:
         }
         else { // count map minor
             for (const auto& row : this->_matrix) {
-                const types::size_type limit = std::min(n_elements, this->_matrix_row_size);
-                for (types::size_type j = 0uz; j < limit; ++j) {
+                const size_type limit = std::min(n_elements, this->_matrix_row_size);
+                for (size_type j = 0uz; j < limit; ++j) {
                     if (pred(row[j])) {
                         ++size_map[j];
                     }
@@ -554,7 +535,7 @@ private:
         return size_map;
     }
 
-    types::size_type _matrix_row_size = 0uz;
+    size_type _matrix_row_size = 0uz;
     hypergraph_storage_type _matrix;
 };
 

--- a/include/hgl/impl/layout_tags.hpp
+++ b/include/hgl/impl/layout_tags.hpp
@@ -34,7 +34,7 @@ struct vertex_major_t {
     }
 
     template <std::regular T>
-    [[nodiscard]] static constexpr types::homogeneous_pair<T> majmin(
+    [[nodiscard]] static constexpr homogeneous_pair<T> majmin(
         const T& vertex_el, const T& hyperedge_el
     ) noexcept {
         return std::make_pair(vertex_el, hyperedge_el);
@@ -60,7 +60,7 @@ struct hyperedge_major_t {
     }
 
     template <std::regular T>
-    [[nodiscard]] static constexpr types::homogeneous_pair<T> majmin(
+    [[nodiscard]] static constexpr homogeneous_pair<T> majmin(
         const T& vertex_el, const T& hyperedge_el
     ) noexcept {
         return std::make_pair(hyperedge_el, vertex_el);

--- a/include/hgl/types.hpp
+++ b/include/hgl/types.hpp
@@ -10,6 +10,25 @@
 
 namespace hgl::types {
 
-using namespace gl::types;
+// --- core types ---
+
+using gl::id_type;
+using gl::size_type;
+
+// --- generic data structures ---
+
+using gl::flat_jagged_vector;
+using gl::homogeneous_pair;
+
+// --- property types ---
+
+using gl::bin_color_value;
+using gl::binary_color;
+using gl::binary_color_property;
+using gl::dynamic_properties;
+using gl::empty_properties;
+using gl::empty_properties_map;
+using gl::name_property;
+using gl::weight_property;
 
 } // namespace hgl::types

--- a/include/hgl/types.hpp
+++ b/include/hgl/types.hpp
@@ -8,7 +8,7 @@
 #include "gl/types/flat_jagged_vector.hpp"
 #include "gl/types/properties.hpp"
 
-namespace hgl::types {
+namespace hgl {
 
 // --- core types ---
 
@@ -31,4 +31,4 @@ using gl::empty_properties_map;
 using gl::name_property;
 using gl::weight_property;
 
-} // namespace hgl::types
+} // namespace hgl

--- a/tests/include/testing/gl/alg_utils.hpp
+++ b/tests/include/testing/gl/alg_utils.hpp
@@ -41,7 +41,7 @@ requires(gl::traits::c_readable<T>)
         if (not gl::algorithm::is_reachable(pred_map, vertex_id))
             return false;
 
-        if (vertex_id == constants::first_elem_idx)
+        if (vertex_id == 0uz)
             return pred_map[vertex_id] == vertex_id;
 
         return pred_map[vertex_id] == ((vertex_id - 1uz) / 2uz);

--- a/tests/include/testing/gl/alg_utils.hpp
+++ b/tests/include/testing/gl/alg_utils.hpp
@@ -49,7 +49,7 @@ requires(gl::traits::c_readable<T>)
 }
 
 template <gl::traits::c_instantiation_of<gl::vertex_descriptor> VertexType>
-requires(std::same_as<typename VertexType::properties_type, types::visited_property>)
+requires(std::same_as<typename VertexType::properties_type, visited_property>)
 struct vertex_visited_projection {
     [[nodiscard]] bool operator()(const VertexType& vertex) const {
         return vertex.properties().visited;

--- a/tests/include/testing/gl/alg_utils.hpp
+++ b/tests/include/testing/gl/alg_utils.hpp
@@ -41,7 +41,7 @@ requires(gl::traits::c_readable<T>)
         if (not gl::algorithm::is_reachable(pred_map, vertex_id))
             return false;
 
-        if (vertex_id == constants::first_element_idx)
+        if (vertex_id == constants::first_elem_idx)
             return pred_map[vertex_id] == vertex_id;
 
         return pred_map[vertex_id] == ((vertex_id - 1uz) / 2uz);

--- a/tests/include/testing/gl/alg_utils.hpp
+++ b/tests/include/testing/gl/alg_utils.hpp
@@ -16,7 +16,7 @@ inline const fs::path data_path(TEST_DATA_PATH);
 
 template <typename T>
 requires(gl::traits::c_readable<T>)
-[[nodiscard]] std::vector<T> load_list(const gl::types::size_type n, const fs::path& file_path) {
+[[nodiscard]] std::vector<T> load_list(const gl::size_type n, const fs::path& file_path) {
     std::vector<T> list(n);
 
     std::ifstream file(file_path);
@@ -37,7 +37,7 @@ requires(gl::traits::c_readable<T>)
 [[nodiscard]] inline auto has_correct_bin_predecessor(
     const gl::algorithm::predecessors_map& pred_map
 ) {
-    return [pred_map](const gl::types::id_type vertex_id) {
+    return [pred_map](const gl::id_type vertex_id) {
         if (not gl::algorithm::is_reachable(pred_map, vertex_id))
             return false;
 

--- a/tests/include/testing/gl/alg_utils.hpp
+++ b/tests/include/testing/gl/alg_utils.hpp
@@ -10,7 +10,7 @@
 
 namespace fs = std::filesystem;
 
-namespace gl_testing::alg_common {
+namespace gl_testing {
 
 inline const fs::path data_path(TEST_DATA_PATH);
 
@@ -56,4 +56,4 @@ struct vertex_visited_projection {
     }
 };
 
-} // namespace gl_testing::alg_common
+} // namespace gl_testing

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -22,12 +22,11 @@ IC gl::size_type n_elements_alg = 10ull;
 IC gl::size_type depth = 5ull;
 
 IC gl::size_type first_elem_idx = 0uz;
-IC gl::size_type last_element_idx = n_elements - 1uz;
-IC gl::size_type out_of_range_element_idx = n_elements;
+IC gl::size_type out_of_rng_idx = n_elements;
 
-IC gl::id_type v1_id = first_elem_idx;
-IC gl::id_type v2_id = v1_id + 1uz;
-IC gl::id_type v3_id = v2_id + 1uz;
+IC gl::id_type v1_id = 0uz;
+IC gl::id_type v2_id = 1uz;
+IC gl::id_type v3_id = 2uz;
 IC gl::id_type invalid_id = gl::constants::invalid_id;
 
 IC auto vertex_id_view = std::views::iota(0ull, n_elements);

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -11,7 +11,6 @@
 
 namespace gl_testing::constants {
 
-IC gl::size_type one = 1ull;
 IC gl::size_type two = 2ull;
 IC gl::size_type three = 3ull;
 

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -12,14 +12,14 @@
 namespace gl_testing::constants {
 
 // n_elements for simple tests
-IC gl::size_type n_elements = 3ull;
+IC gl::size_type n_elements = 3uz;
 
 // n_elements for graph topology tests
-IC gl::size_type n_elements_top = 10ull;
+IC gl::size_type n_elements_top = 10uz;
 
 // n_elements for graph algorithm tests
-IC gl::size_type n_elements_alg = 10ull;
-IC gl::size_type depth = 5ull;
+IC gl::size_type n_elements_alg = 10uz;
+IC gl::size_type depth = 5uz;
 
 IC gl::size_type first_elem_idx = 0uz;
 IC gl::size_type out_of_rng_idx = n_elements;
@@ -29,7 +29,7 @@ IC gl::id_type v2_id = 1uz;
 IC gl::id_type v3_id = 2uz;
 IC gl::id_type invalid_id = gl::constants::invalid_id;
 
-IC auto vertex_id_view = std::views::iota(0ull, n_elements);
+IC auto vertex_id_view = std::views::iota(0uz, n_elements);
 
 IC visited_property visited{true};
 IC visited_property not_visited{false};

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -11,14 +11,13 @@
 
 namespace gl_testing::constants {
 
-IC gl::size_type zero = 0ull;
 IC gl::size_type one = 1ull;
 IC gl::size_type two = 2ull;
 IC gl::size_type three = 3ull;
 
-IC gl::size_type n_elements = three;
-IC gl::size_type zero_elements = zero;
-IC gl::size_type one_element = one;
+IC gl::size_type n_elements = 3ull;
+IC gl::size_type zero_elements = 0uz;
+IC gl::size_type one_element = 1uz;
 
 // n_elements for graph topology tests
 IC gl::size_type n_elements_top = 10ull;
@@ -27,16 +26,16 @@ IC gl::size_type n_elements_top = 10ull;
 IC gl::size_type n_elements_alg = 10ull;
 IC gl::size_type depth = 5ull;
 
-IC gl::size_type first_element_idx = zero;
-IC gl::size_type last_element_idx = n_elements - one_element;
+IC gl::size_type first_elem_idx = 0uz;
+IC gl::size_type last_element_idx = n_elements - 1uz;
 IC gl::size_type out_of_range_element_idx = n_elements;
 
-IC gl::id_type vertex_id_1 = first_element_idx;
-IC gl::id_type vertex_id_2 = vertex_id_1 + one_element;
-IC gl::id_type vertex_id_3 = vertex_id_2 + one_element;
+IC gl::id_type v1_id = first_elem_idx;
+IC gl::id_type v2_id = v1_id + one_element;
+IC gl::id_type v3_id = v2_id + one_element;
 IC gl::id_type invalid_id = gl::constants::invalid_id;
 
-IC auto vertex_id_view = std::views::iota(first_element_idx, n_elements);
+IC auto vertex_id_view = std::views::iota(0ull, n_elements);
 
 IC visited_property visited{true};
 IC visited_property not_visited{false};

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -11,7 +11,6 @@
 
 namespace gl_testing::constants {
 
-IC gl::size_type two = 2ull;
 IC gl::size_type three = 3ull;
 
 IC gl::size_type n_elements = 3ull;

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "types.hpp"
+#include "testing/gl/types.hpp"
 
 #include <gl/constants.hpp>
 #include <gl/types/core.hpp>
@@ -38,10 +38,10 @@ IC gl::id_type invalid_id = gl::constants::invalid_id;
 
 IC auto vertex_id_view = std::views::iota(first_element_idx, n_elements);
 
-IC types::visited_property visited{true};
-IC types::visited_property not_visited{false};
+IC visited_property visited{true};
+IC visited_property not_visited{false};
 
-IC types::used_property used{true};
-IC types::used_property not_used{false};
+IC used_property used{true};
+IC used_property not_used{false};
 
 } // namespace gl_testing::constants

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -11,11 +11,8 @@
 
 namespace gl_testing::constants {
 
-IC gl::size_type three = 3ull;
-
+// n_elements for simple tests
 IC gl::size_type n_elements = 3ull;
-IC gl::size_type zero_elements = 0uz;
-IC gl::size_type one_element = 1uz;
 
 // n_elements for graph topology tests
 IC gl::size_type n_elements_top = 10ull;
@@ -29,8 +26,8 @@ IC gl::size_type last_element_idx = n_elements - 1uz;
 IC gl::size_type out_of_range_element_idx = n_elements;
 
 IC gl::id_type v1_id = first_elem_idx;
-IC gl::id_type v2_id = v1_id + one_element;
-IC gl::id_type v3_id = v2_id + one_element;
+IC gl::id_type v2_id = v1_id + 1uz;
+IC gl::id_type v3_id = v2_id + 1uz;
 IC gl::id_type invalid_id = gl::constants::invalid_id;
 
 IC auto vertex_id_view = std::views::iota(0ull, n_elements);

--- a/tests/include/testing/gl/constants.hpp
+++ b/tests/include/testing/gl/constants.hpp
@@ -11,30 +11,30 @@
 
 namespace gl_testing::constants {
 
-IC gl::types::size_type zero = 0ull;
-IC gl::types::size_type one = 1ull;
-IC gl::types::size_type two = 2ull;
-IC gl::types::size_type three = 3ull;
+IC gl::size_type zero = 0ull;
+IC gl::size_type one = 1ull;
+IC gl::size_type two = 2ull;
+IC gl::size_type three = 3ull;
 
-IC gl::types::size_type n_elements = three;
-IC gl::types::size_type zero_elements = zero;
-IC gl::types::size_type one_element = one;
+IC gl::size_type n_elements = three;
+IC gl::size_type zero_elements = zero;
+IC gl::size_type one_element = one;
 
 // n_elements for graph topology tests
-IC gl::types::size_type n_elements_top = 10ull;
+IC gl::size_type n_elements_top = 10ull;
 
 // n_elements for graph algorithm tests
-IC gl::types::size_type n_elements_alg = 10ull;
-IC gl::types::size_type depth = 5ull;
+IC gl::size_type n_elements_alg = 10ull;
+IC gl::size_type depth = 5ull;
 
-IC gl::types::size_type first_element_idx = zero;
-IC gl::types::size_type last_element_idx = n_elements - one_element;
-IC gl::types::size_type out_of_range_element_idx = n_elements;
+IC gl::size_type first_element_idx = zero;
+IC gl::size_type last_element_idx = n_elements - one_element;
+IC gl::size_type out_of_range_element_idx = n_elements;
 
-IC gl::types::id_type vertex_id_1 = first_element_idx;
-IC gl::types::id_type vertex_id_2 = vertex_id_1 + one_element;
-IC gl::types::id_type vertex_id_3 = vertex_id_2 + one_element;
-IC gl::types::id_type invalid_id = gl::constants::invalid_id;
+IC gl::id_type vertex_id_1 = first_element_idx;
+IC gl::id_type vertex_id_2 = vertex_id_1 + one_element;
+IC gl::id_type vertex_id_3 = vertex_id_2 + one_element;
+IC gl::id_type invalid_id = gl::constants::invalid_id;
 
 IC auto vertex_id_view = std::views::iota(first_element_idx, n_elements);
 

--- a/tests/include/testing/gl/functional.hpp
+++ b/tests/include/testing/gl/functional.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace gl_testing::func {
+namespace gl_testing {
 
 template <typename T>
 void discard_result(T&&) {
     // do nothing
 }
 
-} // namespace gl_testing::func
+} // namespace gl_testing

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -4,7 +4,7 @@
 
 #include <doctest.h>
 
-namespace gl_testing::io_common {
+namespace gl_testing {
 
 template <gl::traits::c_graph GraphType>
 void verify_graph_structure(const GraphType& actual, const GraphType& expected) {
@@ -42,4 +42,4 @@ void verify_edge_properties(const GraphType& actual, const GraphType& expected) 
     }));
 }
 
-} // namespace gl_testing::io_common
+} // namespace gl_testing

--- a/tests/include/testing/gl/types.hpp
+++ b/tests/include/testing/gl/types.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace gl_testing::types {
+namespace gl_testing {
 
 struct visited_property {
     bool operator==(const visited_property&) const = default;
@@ -12,4 +12,4 @@ struct used_property {
     bool used;
 };
 
-} // namespace gl_testing::types
+} // namespace gl_testing

--- a/tests/include/testing/hgl/constants.hpp
+++ b/tests/include/testing/hgl/constants.hpp
@@ -9,15 +9,15 @@
 
 namespace hgl_testing::constants {
 
-IC hgl::types::size_type n_vertices = 3uz;
-IC hgl::types::size_type n_hyperedges = 4uz;
+IC hgl::size_type n_vertices = 3uz;
+IC hgl::size_type n_hyperedges = 4uz;
 
-IC hgl::types::id_type id1 = hgl::constants::initial_id;
-IC hgl::types::id_type id2 = id1 + 1uz;
-IC hgl::types::id_type id3 = id2 + 1uz;
-IC hgl::types::id_type id4 = id3 + 1uz;
-IC hgl::types::id_type out_of_rng_vid = n_vertices;
-IC hgl::types::id_type out_of_rng_eid = n_hyperedges;
+IC hgl::id_type id1 = hgl::constants::initial_id;
+IC hgl::id_type id2 = id1 + 1uz;
+IC hgl::id_type id3 = id2 + 1uz;
+IC hgl::id_type id4 = id3 + 1uz;
+IC hgl::id_type out_of_rng_vid = n_vertices;
+IC hgl::id_type out_of_rng_eid = n_hyperedges;
 
 IC auto vertex_ids_view = std::views::iota(hgl::constants::initial_id, n_vertices);
 IC auto hyperedge_ids_view = std::views::iota(hgl::constants::initial_id, n_hyperedges);

--- a/tests/include/testing/hgl/constants.hpp
+++ b/tests/include/testing/hgl/constants.hpp
@@ -22,7 +22,7 @@ IC hgl::types::id_type out_of_rng_eid = n_hyperedges;
 IC auto vertex_ids_view = std::views::iota(hgl::constants::initial_id, n_vertices);
 IC auto hyperedge_ids_view = std::views::iota(hgl::constants::initial_id, n_hyperedges);
 
-IC types::boolean_property p_true{true};
-IC types::boolean_property p_false{false};
+IC boolean_property p_true{true};
+IC boolean_property p_false{false};
 
 } // namespace hgl_testing::constants

--- a/tests/include/testing/hgl/types.hpp
+++ b/tests/include/testing/hgl/types.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace hgl_testing::types {
+namespace hgl_testing {
 
 struct boolean_property {
     bool operator==(const boolean_property&) const = default;
     bool value;
 };
 
-} // namespace hgl_testing::types
+} // namespace hgl_testing

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -71,8 +71,8 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
 
     SUBCASE("equality operator should correctly comparge matrices") {
         SutType sut1(constants::n_elements);
-        sut1.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_2);
-        sut1.add_edge(fixture.next_edge_id++, constants::vertex_id_2, constants::vertex_id_3);
+        sut1.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v2_id);
+        sut1.add_edge(fixture.next_edge_id++, constants::v2_id, constants::v3_id);
 
         SUBCASE("identical lists are equal") {
             const SutType sut2 = sut1;
@@ -86,13 +86,13 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
 
         SUBCASE("lists with different connections are not equal") {
             SutType sut2 = sut1;
-            sut2.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_3);
+            sut2.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v3_id);
             CHECK_NE(sut1, sut2);
         }
 
         SUBCASE("lists with different connection ids are not equal") {
             SutType sut2 = sut1;
-            fixture.get(sut2)[constants::vertex_id_1].front().edge_id = fixture.next_edge_id++;
+            fixture.get(sut2)[constants::v1_id].front().edge_id = fixture.next_edge_id++;
             CHECK_NE(sut1, sut2);
         }
     }
@@ -171,15 +171,15 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     };
 
     SUBCASE("add_edge should add the edge only to the source vertex list") {
-        const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-        REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+        const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
+        REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+        const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
         CHECK_EQ(adjacent_edges_1.size(), constants::one_element);
-        CHECK_EQ(sut.adjacent_edges(constants::vertex_id_2).size(), constants::zero_elements);
+        CHECK_EQ(sut.adjacent_edges(constants::v2_id).size(), constants::zero_elements);
 
-        const auto& new_edge_extracted = adjacent_edges_1[constants::first_element_idx];
+        const auto& new_edge_extracted = adjacent_edges_1[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted, new_edge);
     }
 
@@ -191,86 +191,82 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
             "vertices with the given ids in the specified direction") {
-        add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        add_edge(constants::v1_id, constants::v2_id);
 
-        CHECK(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
-        CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_1));
-        CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_3));
-        CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_3));
+        CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v1_id));
+        CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
     }
 
     SUBCASE("has_edge(edge) should return true if the given edge is present in the graph") {
-        const auto valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
         CHECK(sut.has_edge(valid_edge));
 
-        const edge_type invalid_edge{
-            constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
-        };
+        const edge_type invalid_edge{constants::invalid_id, constants::v1_id, constants::v2_id};
         CHECK_FALSE(sut.has_edge(invalid_edge));
 
         // edge connecting vertices not connected in the actual graph
-        const edge_type not_present_edge{
-            valid_edge.id(), constants::vertex_id_2, constants::vertex_id_3
-        };
+        const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
     SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
     }
 
     SUBCASE("get_edge(id, id) should return the first valid edge if the given vertices are "
             "connected") {
-        const auto& edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        const auto& edge_2 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto& edge_1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto& edge_2 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt.has_value());
         CHECK_EQ(*edge_opt, edge_1);
         CHECK_NE(*edge_opt, edge_2);
 
-        CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
+        CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
     }
 
     SUBCASE("get_edges(id, id) should return an empty if there is no edge connecting the given "
             "vertices") {
-        CHECK(sut.get_edges(constants::vertex_id_1, constants::vertex_id_2).empty());
+        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
     }
 
     SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
     ) {
         std::vector<edge_type> expected_edges;
-        for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
-            expected_edges.push_back(add_edge(constants::vertex_id_1, constants::vertex_id_2));
+        for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+            expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::vertex_id_1, constants::vertex_id_2),
+            sut.get_edges(constants::v1_id, constants::v2_id),
             expected_edges,
             std::ranges::equal_to{}
         ));
 
-        CHECK(sut.get_edges(constants::vertex_id_2, constants::vertex_id_2).empty());
+        CHECK(sut.get_edges(constants::v2_id, constants::v2_id).empty());
     }
 
     SUBCASE("remove_edge should throw when an edge is invalid") {
         // not existing edge between valid vertices
         const edge_type not_existing_edge{
-            constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
+            constants::invalid_id, constants::v1_id, constants::v2_id
         };
         CHECK_THROWS_AS(sut.remove_edge(not_existing_edge), std::invalid_argument);
     }
 
     SUBCASE("remove_edge should remove the edge from the source vertex's list") {
-        fully_connect_vertex(constants::vertex_id_1);
+        fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges[constants::first_element_idx];
+        const auto& edge_to_remove = adjacent_edges[constants::first_elem_idx];
         sut.remove_edge(edge_to_remove);
 
-        adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+        adjacent_edges = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(
             adjacent_edges.size(),
             n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -280,10 +276,10 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     }
 
     SUBCASE("in_edges should return edges where the vertex is the target") {
-        const auto edge1 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
-        const auto edge2 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+        const auto edge1 = add_edge(constants::v2_id, constants::v1_id);
+        const auto edge2 = add_edge(constants::v3_id, constants::v1_id);
 
-        const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+        const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
         REQUIRE_EQ(in_edges.size(), 2uz);
         CHECK(std::ranges::contains(in_edges, edge1));
@@ -291,11 +287,10 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     }
 
     SUBCASE("out_edges should return edges where the vertex is the source") {
-        const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
 
-        const auto out_edges =
-            sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+        const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
         REQUIRE_EQ(out_edges.size(), 2uz);
         CHECK(std::ranges::contains(out_edges, edge1));
@@ -324,11 +319,10 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
             deg_proj
         ));
 
-        add_edge(constants::vertex_id_1, constants::vertex_id_1);
+        add_edge(constants::v1_id, constants::v1_id);
 
         CHECK_EQ(
-            deg_proj(constants::vertex_id_1),
-            n_incident_edges_for_fully_connected_vertex + constants::one
+            deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + constants::one
         );
     }
 
@@ -344,10 +338,10 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
             deg_proj
         ));
 
-        add_edge(constants::vertex_id_1, constants::vertex_id_1);
+        add_edge(constants::v1_id, constants::v1_id);
 
         CHECK_EQ(
-            deg_proj(constants::vertex_id_1),
+            deg_proj(constants::v1_id),
             constants::two * (n_incident_edges_for_fully_connected_vertex + constants::one)
         );
     }
@@ -386,15 +380,15 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     }
 
     SUBCASE("remove_vertex should remove the given vertex and all edges incident with it") {
-        const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        const auto edge3 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
-        const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
-        const auto edge4 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge3 = add_edge(constants::v2_id, constants::v1_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+        const auto edge4 = add_edge(constants::v3_id, constants::v1_id);
 
-        const auto edge5 = add_edge(constants::vertex_id_2, constants::vertex_id_3);
-        const auto edge6 = add_edge(constants::vertex_id_3, constants::vertex_id_2);
+        const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
+        const auto edge6 = add_edge(constants::v3_id, constants::v2_id);
 
-        const auto removed_vertex_id = constants::vertex_id_1;
+        const auto removed_vertex_id = constants::v1_id;
         const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
         constexpr gl::size_type n_removed_edges = 4uz;
@@ -407,15 +401,15 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+        const auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
-        CHECK_EQ(adj_edges_1.front().target(), constants::vertex_id_2);
+        CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+        const auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge6.id() - n_removed_edges);
-        CHECK_EQ(adj_edges_2.front().target(), constants::vertex_id_1);
+        CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);
     }
 }
 
@@ -448,7 +442,7 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
     void init_complete_graph(const bool no_loops = true) {
         for (const auto source_id : constants::vertex_id_view) {
             const auto bound = no_loops ? source_id : source_id + constants::one;
-            for (const auto target_id : std::views::iota(constants::vertex_id_1, bound))
+            for (const auto target_id : std::views::iota(constants::v1_id, bound))
                 add_edge(source_id, target_id);
         }
 
@@ -490,32 +484,32 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     };
 
     SUBCASE("add_edge should add the edge to the lists of both vertices") {
-        const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-        REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+        const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
+        REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-        const auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+        const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+        const auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
         REQUIRE_EQ(adjacent_edges_1.size(), constants::one_element);
         REQUIRE_EQ(adjacent_edges_2.size(), constants::one_element);
 
-        const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_element_idx];
+        const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted_1, new_edge);
 
-        const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_element_idx];
+        const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted_2, new_edge);
     }
 
     SUBCASE("add_edge should add the edge once to the vertex list if the edge is a loop") {
-        const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_1);
+        const auto new_edge = add_edge(constants::v1_id, constants::v1_id);
         REQUIRE(new_edge.is_loop());
-        REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-        const auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+        const auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges.size(), constants::one_element);
 
-        const auto& new_edge_extracted_1 = adjacent_edges[constants::first_element_idx];
+        const auto& new_edge_extracted_1 = adjacent_edges[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
@@ -527,46 +521,42 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
             "vertices with the given ids in any direction") {
-        add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        add_edge(constants::v1_id, constants::v2_id);
 
-        CHECK(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
-        CHECK(sut.has_edge(constants::vertex_id_2, constants::vertex_id_1));
-        CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_3));
-        CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_3));
+        CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+        CHECK(sut.has_edge(constants::v2_id, constants::v1_id));
+        CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
     }
 
     SUBCASE("has_edge(edge_ptr) should return true if the given edge is present in the graph") {
-        const auto& valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto& valid_edge = add_edge(constants::v1_id, constants::v2_id);
         CHECK(sut.has_edge(valid_edge));
 
-        const edge_type invalid_edge{
-            constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
-        };
+        const edge_type invalid_edge{constants::invalid_id, constants::v1_id, constants::v2_id};
         CHECK_FALSE(sut.has_edge(invalid_edge));
 
         // edge connecting vertices not connected in the actual graph
-        const edge_type not_present_edge{
-            valid_edge.id(), constants::vertex_id_2, constants::vertex_id_3
-        };
+        const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
     SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
     }
 
     SUBCASE("get_edge(id, id) should return the first valid edge if the given vertices are "
             "connected") {
-        const auto edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        const auto edge_2 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge_2 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt_1 = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+        const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt_1.has_value());
         CHECK_EQ(*edge_opt_1, edge_1);
         CHECK_NE(*edge_opt_1, edge_2);
 
-        const auto edge_opt_2 = sut.get_edge(constants::vertex_id_2, constants::vertex_id_1);
+        const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
         REQUIRE(edge_opt_2.has_value());
         CHECK_EQ(*edge_opt_2, edge_1);
         CHECK_NE(*edge_opt_2, edge_2);
@@ -574,23 +564,23 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
 
     SUBCASE("get_edges(id, id) should return an empty if there is no edge connecting the given "
             "vertices") {
-        CHECK(sut.get_edges(constants::vertex_id_1, constants::vertex_id_2).empty());
+        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
     }
 
     SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
     ) {
         std::vector<edge_type> expected_edges;
-        for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
-            expected_edges.push_back(add_edge(constants::vertex_id_1, constants::vertex_id_2));
+        for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+            expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::vertex_id_1, constants::vertex_id_2),
+            sut.get_edges(constants::v1_id, constants::v2_id),
             expected_edges,
             std::ranges::equal_to{}
         ));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::vertex_id_2, constants::vertex_id_1),
+            sut.get_edges(constants::v2_id, constants::v1_id),
             expected_edges,
             std::ranges::equal_to{}
         ));
@@ -599,18 +589,18 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     SUBCASE("remove_edge should throw when an edge is invalid") {
         // not existing edge between valid vertices
         const edge_type not_existing_edge{
-            constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
+            constants::invalid_id, constants::v1_id, constants::v2_id
         };
         CHECK_THROWS_AS(sut.remove_edge(not_existing_edge), std::invalid_argument);
     }
 
     SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
-        fully_connect_vertex(constants::vertex_id_1);
+        fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+        auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges_first[constants::first_element_idx];
+        const auto& edge_to_remove = adjacent_edges_first[constants::first_elem_idx];
 
         const auto target_id = edge_to_remove.target();
         REQUIRE_EQ(sut.adjacent_edges(target_id).size(), constants::one_element);
@@ -618,7 +608,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         sut.remove_edge(edge_to_remove);
 
         // validate that the first adjacent edges list has been properly aligned
-        adjacent_edges_first = sut.adjacent_edges(constants::first_element_idx);
+        adjacent_edges_first = sut.adjacent_edges(constants::first_elem_idx);
         REQUIRE_EQ(
             adjacent_edges_first.size(),
             n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -636,15 +626,14 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     }
 
     SUBCASE("in_edges and out_edges should return the same edges for undirected graphs") {
-        add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        add_edge(constants::vertex_id_1, constants::vertex_id_3);
+        add_edge(constants::v1_id, constants::v2_id);
+        add_edge(constants::v1_id, constants::v3_id);
 
-        const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
-        const auto out_edges =
-            sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+        const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
+        const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-        CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::vertex_id_1)));
-        CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::vertex_id_1)));
+        CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
     }
 
     SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from} the given "
@@ -673,10 +662,10 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
             deg_proj
         ));
 
-        add_edge(constants::vertex_id_1, constants::vertex_id_1);
+        add_edge(constants::v1_id, constants::v1_id);
 
         CHECK_EQ(
-            deg_proj(constants::vertex_id_1),
+            deg_proj(constants::v1_id),
             n_incident_edges_for_fully_connected_vertex + constants::two // loops counted twice
         );
     }
@@ -708,14 +697,14 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     }
 
     SUBCASE("remove_vertex should remove the given vertex and all edges incident with it") {
-        const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        const auto edge3 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
-        const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
-        const auto edge4 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge3 = add_edge(constants::v2_id, constants::v1_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+        const auto edge4 = add_edge(constants::v3_id, constants::v1_id);
 
-        const auto edge5 = add_edge(constants::vertex_id_2, constants::vertex_id_3);
+        const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
 
-        const auto removed_vertex_id = constants::first_element_idx;
+        const auto removed_vertex_id = constants::first_elem_idx;
         const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
         constexpr gl::size_type n_removed_edges = 4uz;
@@ -727,15 +716,15 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+        const auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
-        CHECK_EQ(adj_edges_1.front().target(), constants::vertex_id_2);
+        CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+        const auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge5.id() - n_removed_edges);
-        CHECK_EQ(adj_edges_2.front().target(), constants::vertex_id_1);
+        CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);
     }
 }
 

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -329,17 +329,14 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
 
         CHECK(std::ranges::all_of(
             constants::vertex_id_view,
-            [](const auto deg) {
-                return deg == constants::two * n_incident_edges_for_fully_connected_vertex;
-            },
+            [](const auto deg) { return deg == 2uz * n_incident_edges_for_fully_connected_vertex; },
             deg_proj
         ));
 
         add_edge(constants::v1_id, constants::v1_id);
 
         CHECK_EQ(
-            deg_proj(constants::v1_id),
-            constants::two * (n_incident_edges_for_fully_connected_vertex + 1uz)
+            deg_proj(constants::v1_id), 2uz * (n_incident_edges_for_fully_connected_vertex + 1uz)
         );
     }
 
@@ -368,7 +365,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
             "corresponding "
             "vertices") {
         init_complete_graph(false);
-        const auto expected_deg = constants::n_elements * constants::two;
+        const auto expected_deg = constants::n_elements * 2uz;
 
         std::vector<gl::id_type> degree_map = sut.degree_map();
 
@@ -662,7 +659,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
 
         CHECK_EQ(
             deg_proj(constants::v1_id),
-            n_incident_edges_for_fully_connected_vertex + constants::two // loops counted twice
+            n_incident_edges_for_fully_connected_vertex + 2uz // loops counted twice
         );
     }
 

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -19,11 +19,11 @@ struct test_adjacency_list {
         return sut._list;
     }
 
-    gl::types::size_type size(const auto& sut) const {
+    gl::size_type size(const auto& sut) const {
         return sut._list.size();
     }
 
-    gl::types::size_type next_edge_id = 0uz;
+    gl::size_type next_edge_id = 0uz;
 };
 
 TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_list_template) {
@@ -45,10 +45,9 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
 
     SUBCASE("add_vertex should properly extend the current adjacency list") {
         SutType sut{};
-        constexpr gl::types::size_type target_n_vertices = constants::n_elements;
+        constexpr gl::size_type target_n_vertices = constants::n_elements;
 
-        for (gl::types::size_type n_vertices = constants::one_element;
-             n_vertices <= target_n_vertices;
+        for (gl::size_type n_vertices = constants::one_element; n_vertices <= target_n_vertices;
              n_vertices++) {
             sut.add_vertex();
             CHECK_EQ(fixture.size(sut), n_vertices);
@@ -109,7 +108,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 
 namespace {
 
-constexpr gl::types::size_type n_incident_edges_for_fully_connected_vertex =
+constexpr gl::size_type n_incident_edges_for_fully_connected_vertex =
     constants::n_elements - constants::one_element;
 
 } // namespace
@@ -119,13 +118,13 @@ struct test_directed_adjacency_list : public test_adjacency_list {
     using sut_type = SutType;
     using edge_type = typename sut_type::edge_type;
 
-    edge_type add_edge(const gl::types::id_type source_id, const gl::types::id_type target_id) {
+    edge_type add_edge(const gl::id_type source_id, const gl::id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
         sut.add_edge(new_edge_id, source_id, target_id);
         return edge_type{new_edge_id, source_id, target_id};
     }
 
-    void fully_connect_vertex(const gl::types::id_type source_id, const bool no_loops = true) {
+    void fully_connect_vertex(const gl::id_type source_id, const bool no_loops = true) {
         for (const auto target_id : constants::vertex_id_view) {
             if (target_id == source_id and no_loops)
                 continue;
@@ -160,12 +159,11 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     auto& sut = fixture.sut;
 
     const auto size = [&fixture](const auto& sut) { return fixture.size(sut); };
-    const auto add_edge =
-        [&fixture](const gl::types::id_type source_id, const gl::types::id_type target_id) {
-            return fixture.add_edge(source_id, target_id);
-        };
+    const auto add_edge = [&fixture](const gl::id_type source_id, const gl::id_type target_id) {
+        return fixture.add_edge(source_id, target_id);
+    };
     const auto fully_connect_vertex =
-        [&fixture](const gl::types::id_type source_id, const bool no_loops = true) {
+        [&fixture](const gl::id_type source_id, const bool no_loops = true) {
             fixture.fully_connect_vertex(source_id, no_loops);
         };
     const auto init_complete_graph = [&fixture](const bool no_loops = true) {
@@ -308,7 +306,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     ) {
         init_complete_graph();
 
-        std::function<gl::types::size_type(const gl::types::id_type)> deg_proj;
+        std::function<gl::size_type(const gl::id_type)> deg_proj;
 
         SUBCASE("in_degree") {
             deg_proj = [&sut](const auto vertex_id) { return sut.in_degree(vertex_id); };
@@ -359,7 +357,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         init_complete_graph(false);
         const auto expected_deg = constants::n_elements;
 
-        std::vector<gl::types::id_type> degree_map;
+        std::vector<gl::id_type> degree_map;
 
         SUBCASE("in_degree") {
             degree_map = sut.in_degree_map();
@@ -381,7 +379,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         init_complete_graph(false);
         const auto expected_deg = constants::n_elements * constants::two;
 
-        std::vector<gl::types::id_type> degree_map = sut.degree_map();
+        std::vector<gl::id_type> degree_map = sut.degree_map();
 
         REQUIRE_EQ(degree_map.size(), constants::n_elements);
         CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
@@ -399,7 +397,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         const auto removed_vertex_id = constants::vertex_id_1;
         const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
-        constexpr gl::types::size_type n_removed_edges = 4uz;
+        constexpr gl::size_type n_removed_edges = 4uz;
         REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
         for (const auto edge_id : {edge1.id(), edge2.id(), edge3.id(), edge4.id()})
             CHECK(std::ranges::contains(removed_edge_ids, edge_id));
@@ -432,13 +430,13 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
     using sut_type = SutType;
     using edge_type = typename sut_type::edge_type;
 
-    edge_type add_edge(const gl::types::id_type source_id, const gl::types::id_type target_id) {
+    edge_type add_edge(const gl::id_type source_id, const gl::id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
         sut.add_edge(new_edge_id, source_id, target_id);
         return edge_type{new_edge_id, source_id, target_id};
     }
 
-    void fully_connect_vertex(const gl::types::id_type source_id, const bool no_loops = true) {
+    void fully_connect_vertex(const gl::id_type source_id, const bool no_loops = true) {
         for (const auto target_id : constants::vertex_id_view) {
             if (target_id == source_id and no_loops)
                 continue;
@@ -467,7 +465,7 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
 
     sut_type sut{constants::n_elements};
 
-    const gl::types::size_type n_unique_edges_in_full_graph =
+    const gl::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;
 };
 
@@ -480,12 +478,11 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     auto& sut = fixture.sut;
 
     const auto size = [&fixture](const auto& sut) { return fixture.size(sut); };
-    const auto add_edge =
-        [&fixture](const gl::types::id_type source_id, const gl::types::id_type target_id) {
-            return fixture.add_edge(source_id, target_id);
-        };
+    const auto add_edge = [&fixture](const gl::id_type source_id, const gl::id_type target_id) {
+        return fixture.add_edge(source_id, target_id);
+    };
     const auto fully_connect_vertex =
-        [&fixture](const gl::types::id_type source_id, const bool no_loops = true) {
+        [&fixture](const gl::id_type source_id, const bool no_loops = true) {
             fixture.fully_connect_vertex(source_id, no_loops);
         };
     const auto init_complete_graph = [&fixture](const bool no_loops = true) {
@@ -654,7 +651,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
             "vertex") {
         init_complete_graph();
 
-        std::function<gl::types::size_type(const gl::types::id_type)> deg_proj;
+        std::function<gl::size_type(const gl::id_type)> deg_proj;
 
         SUBCASE("degree") {
             deg_proj = [&sut](const auto vertex_id) { return sut.degree(vertex_id); };
@@ -690,7 +687,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         init_complete_graph(false);
         const auto expected_deg = constants::n_elements + 1;
 
-        std::vector<gl::types::id_type> degree_map;
+        std::vector<gl::id_type> degree_map;
 
         SUBCASE("in_degree") {
             degree_map = sut.in_degree_map();
@@ -721,7 +718,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto removed_vertex_id = constants::first_element_idx;
         const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
-        constexpr gl::types::size_type n_removed_edges = 4uz;
+        constexpr gl::size_type n_removed_edges = 4uz;
         REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
         for (const auto edge_id : {edge1.id(), edge2.id(), edge3.id(), edge4.id()})
             CHECK(std::ranges::contains(removed_edge_ids, edge_id));

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -176,7 +176,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         CHECK_EQ(adjacent_edges_1.size(), 1uz);
         CHECK_EQ(sut.adjacent_edges(constants::v2_id).size(), 0uz);
 
-        const auto& new_edge_extracted = adjacent_edges_1[constants::first_elem_idx];
+        const auto& new_edge_extracted = adjacent_edges_1[0uz];
         CHECK_EQ(new_edge_extracted, new_edge);
     }
 
@@ -234,7 +234,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
     ) {
         std::vector<edge_type> expected_edges;
-        for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+        for (auto _ = 0uz; _ < constants::n_elements; _++)
             expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
@@ -260,7 +260,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges[constants::first_elem_idx];
+        const auto& edge_to_remove = adjacent_edges[0uz];
         sut.remove_edge(edge_to_remove);
 
         adjacent_edges = sut.adjacent_edges(constants::v1_id);
@@ -482,10 +482,10 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE_EQ(adjacent_edges_1.size(), 1uz);
         REQUIRE_EQ(adjacent_edges_2.size(), 1uz);
 
-        const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_elem_idx];
+        const auto& new_edge_extracted_1 = adjacent_edges_1[0uz];
         CHECK_EQ(new_edge_extracted_1, new_edge);
 
-        const auto& new_edge_extracted_2 = adjacent_edges_2[constants::first_elem_idx];
+        const auto& new_edge_extracted_2 = adjacent_edges_2[0uz];
         CHECK_EQ(new_edge_extracted_2, new_edge);
     }
 
@@ -497,7 +497,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges.size(), 1uz);
 
-        const auto& new_edge_extracted_1 = adjacent_edges[constants::first_elem_idx];
+        const auto& new_edge_extracted_1 = adjacent_edges[0uz];
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
@@ -558,7 +558,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
     ) {
         std::vector<edge_type> expected_edges;
-        for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+        for (auto _ = 0uz; _ < constants::n_elements; _++)
             expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
@@ -588,7 +588,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
         REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges_first[constants::first_elem_idx];
+        const auto& edge_to_remove = adjacent_edges_first[0uz];
 
         const auto target_id = edge_to_remove.target();
         REQUIRE_EQ(sut.adjacent_edges(target_id).size(), 1uz);
@@ -596,7 +596,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         sut.remove_edge(edge_to_remove);
 
         // validate that the first adjacent edges list has been properly aligned
-        adjacent_edges_first = sut.adjacent_edges(constants::first_elem_idx);
+        adjacent_edges_first = sut.adjacent_edges(0uz);
         REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         CHECK_EQ(
             std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end()
@@ -689,7 +689,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
 
         const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
 
-        const auto removed_vertex_id = constants::first_elem_idx;
+        const auto removed_vertex_id = 0uz;
         const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
         constexpr gl::size_type n_removed_edges = 4uz;

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -31,7 +31,7 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
 
     SUBCASE("should be initialized with no vertices and no edges by default") {
         SutType sut{};
-        CHECK_EQ(fixture.size(sut), constants::zero_elements);
+        CHECK_EQ(fixture.size(sut), 0uz);
     }
 
     SUBCASE("constructed with the n_vertices parameter should properly initialize the adjacency "
@@ -47,8 +47,7 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
         SutType sut{};
         constexpr gl::size_type target_n_vertices = constants::n_elements;
 
-        for (gl::size_type n_vertices = constants::one_element; n_vertices <= target_n_vertices;
-             n_vertices++) {
+        for (gl::size_type n_vertices = 1uz; n_vertices <= target_n_vertices; n_vertices++) {
             sut.add_vertex();
             CHECK_EQ(fixture.size(sut), n_vertices);
         }
@@ -108,8 +107,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 
 namespace {
 
-constexpr gl::size_type n_incident_edges_for_fully_connected_vertex =
-    constants::n_elements - constants::one_element;
+constexpr gl::size_type n_incident_edges_for_fully_connected_vertex = constants::n_elements - 1uz;
 
 } // namespace
 
@@ -175,8 +173,8 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
         const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-        CHECK_EQ(adjacent_edges_1.size(), constants::one_element);
-        CHECK_EQ(sut.adjacent_edges(constants::v2_id).size(), constants::zero_elements);
+        CHECK_EQ(adjacent_edges_1.size(), 1uz);
+        CHECK_EQ(sut.adjacent_edges(constants::v2_id).size(), 0uz);
 
         const auto& new_edge_extracted = adjacent_edges_1[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted, new_edge);
@@ -266,10 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         sut.remove_edge(edge_to_remove);
 
         adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(
-            adjacent_edges.size(),
-            n_incident_edges_for_fully_connected_vertex - constants::one_element
-        );
+        REQUIRE_EQ(adjacent_edges.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         // validate that the adjacent edges list has been properly aligned
         CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
     }
@@ -484,8 +479,8 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
         const auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-        REQUIRE_EQ(adjacent_edges_1.size(), constants::one_element);
-        REQUIRE_EQ(adjacent_edges_2.size(), constants::one_element);
+        REQUIRE_EQ(adjacent_edges_1.size(), 1uz);
+        REQUIRE_EQ(adjacent_edges_2.size(), 1uz);
 
         const auto& new_edge_extracted_1 = adjacent_edges_1[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted_1, new_edge);
@@ -500,7 +495,7 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
         const auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(adjacent_edges.size(), constants::one_element);
+        REQUIRE_EQ(adjacent_edges.size(), 1uz);
 
         const auto& new_edge_extracted_1 = adjacent_edges[constants::first_elem_idx];
         CHECK_EQ(new_edge_extracted_1, new_edge);
@@ -596,23 +591,20 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto& edge_to_remove = adjacent_edges_first[constants::first_elem_idx];
 
         const auto target_id = edge_to_remove.target();
-        REQUIRE_EQ(sut.adjacent_edges(target_id).size(), constants::one_element);
+        REQUIRE_EQ(sut.adjacent_edges(target_id).size(), 1uz);
 
         sut.remove_edge(edge_to_remove);
 
         // validate that the first adjacent edges list has been properly aligned
         adjacent_edges_first = sut.adjacent_edges(constants::first_elem_idx);
-        REQUIRE_EQ(
-            adjacent_edges_first.size(),
-            n_incident_edges_for_fully_connected_vertex - constants::one_element
-        );
+        REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         CHECK_EQ(
             std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end()
         );
 
         // validate that the second adjacent edges list has been properly aligned
         const auto adjacent_edges_second = sut.adjacent_edges(target_id);
-        REQUIRE_EQ(adjacent_edges_second.size(), constants::zero_elements);
+        REQUIRE_EQ(adjacent_edges_second.size(), 0uz);
         CHECK_EQ(
             std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end()
         );

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -142,8 +142,7 @@ struct test_directed_adjacency_list : public test_adjacency_list {
             }));
         else
             REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size()
-                    == n_incident_edges_for_fully_connected_vertex + constants::one;
+                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 
@@ -321,9 +320,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
 
         add_edge(constants::v1_id, constants::v1_id);
 
-        CHECK_EQ(
-            deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + constants::one
-        );
+        CHECK_EQ(deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + 1uz);
     }
 
     SUBCASE("degree should return the number of edges incident with the given vertex") {
@@ -342,7 +339,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
 
         CHECK_EQ(
             deg_proj(constants::v1_id),
-            constants::two * (n_incident_edges_for_fully_connected_vertex + constants::one)
+            constants::two * (n_incident_edges_for_fully_connected_vertex + 1uz)
         );
     }
 
@@ -441,7 +438,7 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
 
     void init_complete_graph(const bool no_loops = true) {
         for (const auto source_id : constants::vertex_id_view) {
-            const auto bound = no_loops ? source_id : source_id + constants::one;
+            const auto bound = no_loops ? source_id : source_id + 1uz;
             for (const auto target_id : std::views::iota(constants::v1_id, bound))
                 add_edge(source_id, target_id);
         }
@@ -452,8 +449,7 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
             }));
         else
             REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size()
-                    == n_incident_edges_for_fully_connected_vertex + constants::one;
+                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -43,7 +43,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         SutType sut{constants::n_elements};
         REQUIRE_EQ(fixture.size(sut), constants::n_elements);
         CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& matrix_row) {
-            return std::ranges::count_if(matrix_row, is_valid_id) == constants::zero;
+            return std::ranges::count_if(matrix_row, is_valid_id) == 0uz;
         }));
     }
 
@@ -59,7 +59,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CHECK_EQ(fixture.size(sut), target_n_vertices);
         CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& matrix_row) {
-            return std::ranges::count_if(matrix_row, is_valid_id) == constants::zero;
+            return std::ranges::count_if(matrix_row, is_valid_id) == 0uz;
         }));
     }
 
@@ -69,7 +69,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CHECK_EQ(fixture.size(sut), constants::n_elements);
         CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& matrix_row) {
-            return std::ranges::count_if(matrix_row, is_valid_id) == constants::zero;
+            return std::ranges::count_if(matrix_row, is_valid_id) == 0uz;
         }));
     }
 
@@ -77,11 +77,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         using edge_type = typename SutType::edge_type;
 
         SutType sut{constants::n_elements};
-        sut.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_2);
-        REQUIRE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
+        sut.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v2_id);
+        REQUIRE(sut.has_edge(constants::v1_id, constants::v2_id));
 
         CHECK_THROWS_AS(
-            sut.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_2),
+            sut.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v2_id),
             std::logic_error
         );
     }
@@ -90,30 +90,25 @@ TEST_CASE_TEMPLATE_DEFINE(
         using edge_type = typename SutType::edge_type;
 
         SutType sut{constants::n_elements};
-        const auto target_ids = {
-            constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
-        };
+        const auto target_ids = {constants::v1_id, constants::v2_id, constants::v3_id};
 
-        sut.add_edges_from(
-            std::views::iota(0uz, target_ids.size()), constants::vertex_id_1, target_ids
-        );
+        sut.add_edges_from(std::views::iota(0uz, target_ids.size()), constants::v1_id, target_ids);
 
         REQUIRE(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto target_id) {
-            return sut.has_edge(constants::vertex_id_1, target_id);
+            return sut.has_edge(constants::v1_id, target_id);
         }));
 
         std::ranges::for_each(target_ids, [&sut, &fixture](const auto target_id) {
             CHECK_THROWS_AS(
-                sut.add_edge(fixture.next_edge_id++, constants::vertex_id_1, target_id),
-                std::logic_error
+                sut.add_edge(fixture.next_edge_id++, constants::v1_id, target_id), std::logic_error
             );
         });
     }
 
     SUBCASE("equality operator should correctly comparge matrices") {
         SutType sut1(constants::n_elements);
-        sut1.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_2);
-        sut1.add_edge(fixture.next_edge_id++, constants::vertex_id_2, constants::vertex_id_3);
+        sut1.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v2_id);
+        sut1.add_edge(fixture.next_edge_id++, constants::v2_id, constants::v3_id);
 
         SUBCASE("identical matrices are equal") {
             const SutType sut2 = sut1;
@@ -127,14 +122,13 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("matrices with different connections are not equal") {
             SutType sut2 = sut1;
-            sut2.add_edge(fixture.next_edge_id++, constants::vertex_id_1, constants::vertex_id_3);
+            sut2.add_edge(fixture.next_edge_id++, constants::v1_id, constants::v3_id);
             CHECK_NE(sut1, sut2);
         }
 
         SUBCASE("matrices with different connection ids are not equal") {
             SutType sut2 = sut1;
-            fixture.get(sut2)[constants::vertex_id_1][constants::vertex_id_2] =
-                fixture.next_edge_id++;
+            fixture.get(sut2)[constants::v1_id][constants::v2_id] = fixture.next_edge_id++;
             CHECK_NE(sut1, sut2);
         }
     }
@@ -197,16 +191,14 @@ struct test_directed_adjacency_matrix : public test_adjacency_matrix {
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix, "add_edge should add the edge only to the source vertex list"
 ) {
-    const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
 
-    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+    REQUIRE(new_edge.is_incident_from(constants::v1_id));
+    REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-    auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
     CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
-    CHECK_EQ(
-        gl::util::range_size(sut.adjacent_edges(constants::vertex_id_2)), constants::zero_elements
-    );
+    CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), constants::zero_elements);
 
     const auto& new_edge_extracted = *std::ranges::begin(adjacent_edges_1);
     CHECK_EQ(new_edge_extracted, new_edge);
@@ -232,8 +224,8 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "adjacent_edges should return a filtered view of edges adjacent with the given vertex"
 ) {
-    const auto vertex_id = constants::vertex_id_1;
-    const auto edge = add_edge(vertex_id, constants::vertex_id_2);
+    const auto vertex_id = constants::v1_id;
+    const auto edge = add_edge(vertex_id, constants::v2_id);
     auto adjacent_edges = sut.adjacent_edges(vertex_id);
 
     REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
@@ -245,30 +237,26 @@ TEST_CASE_FIXTURE(
     "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
     "with the given ids in the specified direction"
 ) {
-    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    add_edge(constants::v1_id, constants::v2_id);
 
-    CHECK(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
-    CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_1));
-    CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_3));
-    CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_3));
+    CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v1_id));
+    CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
 }
 
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
-    const auto valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
-    };
+    const edge_type invalid_edge{constants::invalid_id, constants::v1_id, constants::v2_id};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        valid_edge.id(), constants::vertex_id_2, constants::vertex_id_3
-    };
+    const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -276,20 +264,20 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
 ) {
-    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
 }
 
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "get_edge(id, id) should return a valid edge if the given vertices are connected"
 ) {
-    const auto edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
 
-    const auto edge_opt = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
     REQUIRE(edge_opt.has_value());
     CHECK_EQ(*edge_opt, edge_1);
 
-    CHECK_FALSE(sut.get_edge(constants::vertex_id_2, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
 }
 
 TEST_CASE_FIXTURE(
@@ -297,7 +285,7 @@ TEST_CASE_FIXTURE(
 ) {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(edge_type{next_edge_id++, constants::vertex_id_1, constants::vertex_id_2}),
+        sut.remove_edge(edge_type{next_edge_id++, constants::v1_id, constants::v2_id}),
         std::invalid_argument
     );
 }
@@ -306,16 +294,16 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_edge should remove the edge from the source vertex's list"
 ) {
-    fully_connect_vertex(constants::vertex_id_1);
+    fully_connect_vertex(constants::v1_id);
 
-    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex);
 
     const auto edge_to_remove = *std::ranges::begin(adjacent_edges);
     sut.remove_edge(edge_to_remove);
 
     // validate that the adjacent edges list has been properly aligned
-    adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    adjacent_edges = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(
         gl::util::range_size(adjacent_edges),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -326,10 +314,10 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix, "in_edges should return edges where the vertex is the target"
 ) {
-    const auto edge1 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
-    const auto edge2 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+    const auto edge1 = add_edge(constants::v2_id, constants::v1_id);
+    const auto edge2 = add_edge(constants::v3_id, constants::v1_id);
 
-    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+    const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
     REQUIRE_EQ(in_edges.size(), 2uz);
     CHECK(std::ranges::contains(in_edges, edge1));
@@ -339,10 +327,10 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix, "out_edges should return edges where the vertex is the source"
 ) {
-    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
+    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
 
-    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+    const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
     REQUIRE_EQ(out_edges.size(), 2uz);
     CHECK(std::ranges::contains(out_edges, edge1));
@@ -373,11 +361,10 @@ TEST_CASE_FIXTURE(
         deg_proj
     ));
 
-    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+    add_edge(constants::v1_id, constants::v1_id);
 
     CHECK_EQ(
-        deg_proj(constants::vertex_id_1),
-        n_incident_edges_for_fully_connected_vertex + constants::one
+        deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + constants::one
     );
 }
 
@@ -396,10 +383,10 @@ TEST_CASE_FIXTURE(
         deg_proj
     ));
 
-    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+    add_edge(constants::v1_id, constants::v1_id);
 
     CHECK_EQ(
-        deg_proj(constants::vertex_id_1),
+        deg_proj(constants::v1_id),
         constants::two * (n_incident_edges_for_fully_connected_vertex + constants::one)
     );
 }
@@ -446,15 +433,15 @@ TEST_CASE_FIXTURE(
     test_directed_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    const auto edge3 = add_edge(constants::vertex_id_2, constants::vertex_id_1);
-    const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
-    const auto edge4 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+    const auto edge3 = add_edge(constants::v2_id, constants::v1_id);
+    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+    const auto edge4 = add_edge(constants::v3_id, constants::v1_id);
 
-    const auto edge5 = add_edge(constants::vertex_id_2, constants::vertex_id_3);
-    const auto edge6 = add_edge(constants::vertex_id_3, constants::vertex_id_2);
+    const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
+    const auto edge6 = add_edge(constants::v3_id, constants::v2_id);
 
-    const auto removed_vertex_id = constants::vertex_id_1;
+    const auto removed_vertex_id = constants::v1_id;
     const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
     constexpr gl::size_type n_removed_edges = 4uz;
@@ -467,15 +454,15 @@ TEST_CASE_FIXTURE(
     // Check the structure of the graph considering the aligned IDs
     CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-    auto adj_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+    auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
     CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
     CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge5.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::vertex_id_2);
+    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-    auto adj_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+    auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
     CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
     CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge6.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::vertex_id_1);
+    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
 }
 
 struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
@@ -500,7 +487,7 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
     void init_complete_graph(const bool no_loops = true) {
         for (const auto source_id : constants::vertex_id_view) {
             const auto bound = no_loops ? source_id : source_id + constants::one;
-            for (const auto target_id : std::views::iota(constants::vertex_id_1, bound))
+            for (const auto target_id : std::views::iota(constants::v1_id, bound))
                 add_edge(source_id, target_id);
         }
 
@@ -525,12 +512,12 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix, "add_edge should add the edge to the lists of both vertices"
 ) {
-    const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-    REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+    const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
+    REQUIRE(new_edge.is_incident_from(constants::v1_id));
+    REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-    auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-    auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+    auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+    auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
     REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
     REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
@@ -546,11 +533,11 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "add_edge should add the edge once to the vertex list if the edge is a loop"
 ) {
-    const auto new_edge = add_edge(constants::vertex_id_1, constants::vertex_id_1);
+    const auto new_edge = add_edge(constants::v1_id, constants::v1_id);
     REQUIRE(new_edge.is_loop());
-    REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
+    REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-    auto adjacent_edges = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(gl::util::range_size(adjacent_edges), constants::one_element);
 
     const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges);
@@ -561,32 +548,32 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "at should return a view equivalent to the matrix row of the given vertex"
 ) {
-    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    const auto edge2 = add_edge(constants::vertex_id_2, constants::vertex_id_3);
-    const auto edge3 = add_edge(constants::vertex_id_3, constants::vertex_id_1);
+    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+    const auto edge2 = add_edge(constants::v2_id, constants::v3_id);
+    const auto edge3 = add_edge(constants::v3_id, constants::v1_id);
 
-    auto v1_row_view = sut.at(constants::vertex_id_1);
+    auto v1_row_view = sut.at(constants::v1_id);
     REQUIRE_EQ(std::ranges::count_if(v1_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v1_row_view[constants::vertex_id_2], edge1);
-    CHECK_EQ(v1_row_view[constants::vertex_id_3], edge3);
+    CHECK_EQ(v1_row_view[constants::v2_id], edge1);
+    CHECK_EQ(v1_row_view[constants::v3_id], edge3);
 
-    auto v2_row_view = sut.at(constants::vertex_id_2);
+    auto v2_row_view = sut.at(constants::v2_id);
     REQUIRE_EQ(std::ranges::count_if(v2_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v2_row_view[constants::vertex_id_1], edge1);
-    CHECK_EQ(v2_row_view[constants::vertex_id_3], edge2);
+    CHECK_EQ(v2_row_view[constants::v1_id], edge1);
+    CHECK_EQ(v2_row_view[constants::v3_id], edge2);
 
-    auto v3_row_view = sut.at(constants::vertex_id_3);
+    auto v3_row_view = sut.at(constants::v3_id);
     REQUIRE_EQ(std::ranges::count_if(v3_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v3_row_view[constants::vertex_id_1], edge3);
-    CHECK_EQ(v3_row_view[constants::vertex_id_2], edge2);
+    CHECK_EQ(v3_row_view[constants::v1_id], edge3);
+    CHECK_EQ(v3_row_view[constants::v2_id], edge2);
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "adjacent_edges should return a filtered view of edges adjacent with the given vertex"
 ) {
-    const auto vertex_id = constants::vertex_id_1;
-    const auto edge = add_edge(vertex_id, constants::vertex_id_2);
+    const auto vertex_id = constants::v1_id;
+    const auto edge = add_edge(vertex_id, constants::v2_id);
     auto adjacent_edges = sut.adjacent_edges(vertex_id);
 
     REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
@@ -598,30 +585,26 @@ TEST_CASE_FIXTURE(
     "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
     "with the given ids in any direction"
 ) {
-    add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    add_edge(constants::v1_id, constants::v2_id);
 
-    CHECK(sut.has_edge(constants::vertex_id_1, constants::vertex_id_2));
-    CHECK(sut.has_edge(constants::vertex_id_2, constants::vertex_id_1));
-    CHECK_FALSE(sut.has_edge(constants::vertex_id_1, constants::vertex_id_3));
-    CHECK_FALSE(sut.has_edge(constants::vertex_id_2, constants::vertex_id_3));
+    CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+    CHECK(sut.has_edge(constants::v2_id, constants::v1_id));
+    CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "has_edge(edge_ptr) should return true if the given edge is present in the graph"
 ) {
-    const auto valid_edge = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
     CHECK(sut.has_edge(valid_edge));
 
-    const edge_type invalid_edge{
-        constants::invalid_id, constants::vertex_id_1, constants::vertex_id_2
-    };
+    const edge_type invalid_edge{constants::invalid_id, constants::v1_id, constants::v2_id};
     CHECK_FALSE(sut.has_edge(invalid_edge));
 
     // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{
-        valid_edge.id(), constants::vertex_id_2, constants::vertex_id_3
-    };
+    const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
     CHECK_FALSE(sut.has_edge(not_present_edge));
 }
 
@@ -629,20 +612,20 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
 ) {
-    CHECK_FALSE(sut.get_edge(constants::vertex_id_1, constants::vertex_id_2));
+    CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
 }
 
 TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "get_edge(id, id) should return a valid edge if the given vertices are connected"
 ) {
-    const auto edge_1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
 
-    const auto edge_opt_1 = sut.get_edge(constants::vertex_id_1, constants::vertex_id_2);
+    const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
     REQUIRE(edge_opt_1.has_value());
     CHECK_EQ(*edge_opt_1, edge_1);
 
-    const auto edge_opt_2 = sut.get_edge(constants::vertex_id_2, constants::vertex_id_1);
+    const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
     REQUIRE(edge_opt_2.has_value());
     CHECK_EQ(*edge_opt_2, edge_1);
 }
@@ -652,7 +635,7 @@ TEST_CASE_FIXTURE(
 ) {
     // not existing edge between valid vertices
     CHECK_THROWS_AS(
-        sut.remove_edge(edge_type{next_edge_id++, constants::vertex_id_1, constants::vertex_id_2}),
+        sut.remove_edge(edge_type{next_edge_id++, constants::v1_id, constants::v2_id}),
         std::invalid_argument
     );
 }
@@ -661,9 +644,9 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_edge should remove the edge from both the first and second vertices' list"
 ) {
-    fully_connect_vertex(constants::vertex_id_1);
+    fully_connect_vertex(constants::v1_id);
 
-    auto adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(
         gl::util::range_size(adjacent_edges_first), n_incident_edges_for_fully_connected_vertex
     );
@@ -676,7 +659,7 @@ TEST_CASE_FIXTURE(
     sut.remove_edge(edge_to_remove);
 
     // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges(constants::vertex_id_1);
+    adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(
         gl::util::range_size(adjacent_edges_first),
         n_incident_edges_for_fully_connected_vertex - constants::one_element
@@ -693,14 +676,14 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "in_edges and out_edges should return the same edges for undirected graphs"
 ) {
-    add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    add_edge(constants::vertex_id_1, constants::vertex_id_3);
+    add_edge(constants::v1_id, constants::v2_id);
+    add_edge(constants::v1_id, constants::v3_id);
 
-    const auto in_edges = sut.in_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
-    const auto out_edges = sut.out_edges(constants::vertex_id_1) | std::ranges::to<std::vector>();
+    const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
+    const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-    CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::vertex_id_1)));
-    CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::vertex_id_1)));
+    CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
+    CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
 }
 
 TEST_CASE_FIXTURE(
@@ -731,10 +714,10 @@ TEST_CASE_FIXTURE(
         deg_proj
     ));
 
-    add_edge(constants::vertex_id_1, constants::vertex_id_1);
+    add_edge(constants::v1_id, constants::v1_id);
 
     CHECK_EQ(
-        deg_proj(constants::vertex_id_1),
+        deg_proj(constants::v1_id),
         n_incident_edges_for_fully_connected_vertex + constants::two // loops counted twice
     );
 }
@@ -771,11 +754,11 @@ TEST_CASE_FIXTURE(
     test_undirected_adjacency_matrix,
     "remove_vertex should remove the given vertex and all edges incident with it"
 ) {
-    const auto edge1 = add_edge(constants::vertex_id_1, constants::vertex_id_2);
-    const auto edge2 = add_edge(constants::vertex_id_1, constants::vertex_id_3);
-    const auto edge3 = add_edge(constants::vertex_id_2, constants::vertex_id_3);
+    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+    const auto edge3 = add_edge(constants::v2_id, constants::v3_id);
 
-    const auto removed_vertex_id = constants::first_element_idx;
+    const auto removed_vertex_id = constants::first_elem_idx;
     const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
     constexpr gl::size_type n_removed_edges = 2uz;
@@ -787,15 +770,15 @@ TEST_CASE_FIXTURE(
     // Check the structure of the graph considering the aligned IDs
     CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-    auto adj_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+    auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
     CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
     CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge3.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::vertex_id_2);
+    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-    auto adj_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+    auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
     CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
     CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge3.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::vertex_id_1);
+    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
 }
 
 TEST_SUITE_END(); // test_adjacency_matrix

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -375,18 +375,13 @@ TEST_CASE_FIXTURE(
 
     CHECK(std::ranges::all_of(
         constants::vertex_id_view,
-        [](const auto deg) {
-            return deg == constants::two * n_incident_edges_for_fully_connected_vertex;
-        },
+        [](const auto deg) { return deg == 2uz * n_incident_edges_for_fully_connected_vertex; },
         deg_proj
     ));
 
     add_edge(constants::v1_id, constants::v1_id);
 
-    CHECK_EQ(
-        deg_proj(constants::v1_id),
-        constants::two * (n_incident_edges_for_fully_connected_vertex + 1uz)
-    );
+    CHECK_EQ(deg_proj(constants::v1_id), 2uz * (n_incident_edges_for_fully_connected_vertex + 1uz));
 }
 
 TEST_CASE_FIXTURE(
@@ -419,7 +414,7 @@ TEST_CASE_FIXTURE(
     "vertices"
 ) {
     init_complete_graph(false);
-    const auto expected_deg = constants::n_elements * constants::two;
+    const auto expected_deg = constants::n_elements * 2uz;
 
     std::vector<gl::id_type> degree_map = sut.degree_map();
 
@@ -716,7 +711,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(
         deg_proj(constants::v1_id),
-        n_incident_edges_for_fully_connected_vertex + constants::two // loops counted twice
+        n_incident_edges_for_fully_connected_vertex + 2uz // loops counted twice
     );
 }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -35,7 +35,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("should be initialized with no vertices and no edges by default") {
         SutType sut{};
-        CHECK_EQ(fixture.size(sut), constants::zero_elements);
+        CHECK_EQ(fixture.size(sut), 0uz);
     }
 
     SUBCASE("constructed with the n_vertices parameter should properly initialize the adjacency "
@@ -51,8 +51,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         SutType sut{};
         constexpr gl::size_type target_n_vertices = constants::n_elements;
 
-        for (gl::size_type n_vertices = constants::one_element; n_vertices <= target_n_vertices;
-             n_vertices++) {
+        for (gl::size_type n_vertices = 1uz; n_vertices <= target_n_vertices; n_vertices++) {
             sut.add_vertex();
             CHECK_EQ(fixture.size(sut), n_vertices);
         }
@@ -142,8 +141,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 
 namespace {
 
-constexpr gl::size_type n_incident_edges_for_fully_connected_vertex =
-    constants::n_elements - constants::one_element;
+constexpr gl::size_type n_incident_edges_for_fully_connected_vertex = constants::n_elements - 1uz;
 
 } // namespace
 
@@ -197,8 +195,8 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
     auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-    CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
-    CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), constants::zero_elements);
+    CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+    CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), 0uz);
 
     const auto& new_edge_extracted = *std::ranges::begin(adjacent_edges_1);
     CHECK_EQ(new_edge_extracted, new_edge);
@@ -305,8 +303,7 @@ TEST_CASE_FIXTURE(
     // validate that the adjacent edges list has been properly aligned
     adjacent_edges = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(
-        gl::util::range_size(adjacent_edges),
-        n_incident_edges_for_fully_connected_vertex - constants::one_element
+        gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex - 1uz
     );
     CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
 }
@@ -512,8 +509,8 @@ TEST_CASE_FIXTURE(
     auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
     auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+    REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+    REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
 
     const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
     CHECK_EQ(new_edge_extracted_1, new_edge);
@@ -531,7 +528,7 @@ TEST_CASE_FIXTURE(
     REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
     auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges), constants::one_element);
+    REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
 
     const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges);
     CHECK_EQ(new_edge_extracted_1, new_edge);
@@ -647,7 +644,7 @@ TEST_CASE_FIXTURE(
     const auto edge_to_remove = *std::ranges::begin(adjacent_edges_first);
 
     const auto target_id = edge_to_remove.target();
-    REQUIRE_EQ(gl::util::range_size(sut.adjacent_edges(target_id)), constants::one_element);
+    REQUIRE_EQ(gl::util::range_size(sut.adjacent_edges(target_id)), 1uz);
 
     sut.remove_edge(edge_to_remove);
 
@@ -655,13 +652,13 @@ TEST_CASE_FIXTURE(
     adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
     REQUIRE_EQ(
         gl::util::range_size(adjacent_edges_first),
-        n_incident_edges_for_fully_connected_vertex - constants::one_element
+        n_incident_edges_for_fully_connected_vertex - 1uz
     );
     CHECK_EQ(std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end());
 
     // validate that the second adjacent edges list has been properly aligned
     auto adjacent_edges_second = sut.adjacent_edges(target_id);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), constants::zero_elements);
+    REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), 0uz);
     CHECK_EQ(std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end());
 }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -19,11 +19,11 @@ struct test_adjacency_matrix {
         return sut._matrix;
     }
 
-    gl::types::size_type size(const auto& sut) const {
+    gl::size_type size(const auto& sut) const {
         return sut._matrix.size();
     }
 
-    gl::types::size_type next_edge_id = 0uz;
+    gl::size_type next_edge_id = 0uz;
 };
 
 inline constexpr auto is_valid_id = [](const auto& id) { return id != constants::invalid_id; };
@@ -49,10 +49,9 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("add_vertex should properly extend the current adjacency matrix") {
         SutType sut{};
-        constexpr gl::types::size_type target_n_vertices = constants::n_elements;
+        constexpr gl::size_type target_n_vertices = constants::n_elements;
 
-        for (gl::types::size_type n_vertices = constants::one_element;
-             n_vertices <= target_n_vertices;
+        for (gl::size_type n_vertices = constants::one_element; n_vertices <= target_n_vertices;
              n_vertices++) {
             sut.add_vertex();
             CHECK_EQ(fixture.size(sut), n_vertices);
@@ -149,7 +148,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 
 namespace {
 
-constexpr gl::types::size_type n_incident_edges_for_fully_connected_vertex =
+constexpr gl::size_type n_incident_edges_for_fully_connected_vertex =
     constants::n_elements - constants::one_element;
 
 } // namespace
@@ -158,13 +157,13 @@ struct test_directed_adjacency_matrix : public test_adjacency_matrix {
     using edge_type = gl::directed_edge<>;
     using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>;
 
-    edge_type add_edge(const gl::types::id_type source_id, const gl::types::id_type target_id) {
+    edge_type add_edge(const gl::id_type source_id, const gl::id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
         sut.add_edge(new_edge_id, source_id, target_id);
         return edge_type{new_edge_id, source_id, target_id};
     }
 
-    void fully_connect_vertex(const gl::types::id_type source_id, const bool no_loops = true) {
+    void fully_connect_vertex(const gl::id_type source_id, const bool no_loops = true) {
         for (const auto target_id : constants::vertex_id_view) {
             if (target_id == source_id and no_loops)
                 continue;
@@ -191,7 +190,7 @@ struct test_directed_adjacency_matrix : public test_adjacency_matrix {
 
     sut_type sut{constants::n_elements};
 
-    static constexpr gl::types::size_type n_unique_edges_in_full_graph =
+    static constexpr gl::size_type n_unique_edges_in_full_graph =
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
 };
 
@@ -356,7 +355,7 @@ TEST_CASE_FIXTURE(
 ) {
     init_complete_graph();
 
-    std::function<gl::types::size_type(const gl::types::id_type)> deg_proj;
+    std::function<gl::size_type(const gl::id_type)> deg_proj;
 
     SUBCASE("in_degree") {
         deg_proj = [this](const auto vertex_id) { return sut.in_degree(vertex_id); };
@@ -413,7 +412,7 @@ TEST_CASE_FIXTURE(
     init_complete_graph(false);
     const auto expected_deg = constants::n_elements;
 
-    std::vector<gl::types::id_type> degree_map;
+    std::vector<gl::id_type> degree_map;
 
     SUBCASE("in_degree") {
         degree_map = sut.in_degree_map();
@@ -437,7 +436,7 @@ TEST_CASE_FIXTURE(
     init_complete_graph(false);
     const auto expected_deg = constants::n_elements * constants::two;
 
-    std::vector<gl::types::id_type> degree_map = sut.degree_map();
+    std::vector<gl::id_type> degree_map = sut.degree_map();
 
     REQUIRE_EQ(degree_map.size(), constants::n_elements);
     CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
@@ -458,7 +457,7 @@ TEST_CASE_FIXTURE(
     const auto removed_vertex_id = constants::vertex_id_1;
     const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
-    constexpr gl::types::size_type n_removed_edges = 4uz;
+    constexpr gl::size_type n_removed_edges = 4uz;
     REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
     for (const auto edge_id : {edge1.id(), edge2.id(), edge3.id(), edge4.id()})
         CHECK(std::ranges::contains(removed_edge_ids, edge_id));
@@ -483,13 +482,13 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
     using edge_type = gl::undirected_edge<>;
     using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>;
 
-    edge_type add_edge(const gl::types::id_type source_id, const gl::types::id_type target_id) {
+    edge_type add_edge(const gl::id_type source_id, const gl::id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
         sut.add_edge(new_edge_id, source_id, target_id);
         return edge_type{new_edge_id, source_id, target_id};
     }
 
-    void fully_connect_vertex(const gl::types::id_type source_id, const bool no_loops = true) {
+    void fully_connect_vertex(const gl::id_type source_id, const bool no_loops = true) {
         for (const auto target_id : constants::vertex_id_view) {
             if (target_id == source_id and no_loops)
                 continue;
@@ -519,7 +518,7 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
 
     sut_type sut{constants::n_elements};
 
-    static constexpr gl::types::size_type n_unique_edges_in_full_graph =
+    static constexpr gl::size_type n_unique_edges_in_full_graph =
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;
 };
 
@@ -710,7 +709,7 @@ TEST_CASE_FIXTURE(
 ) {
     init_complete_graph();
 
-    std::function<gl::types::size_type(const gl::types::id_type)> deg_proj;
+    std::function<gl::size_type(const gl::id_type)> deg_proj;
 
     SUBCASE("degree") {
         deg_proj = [this](const auto vertex_id) { return sut.degree(vertex_id); };
@@ -748,7 +747,7 @@ TEST_CASE_FIXTURE(
     init_complete_graph(false);
     const auto expected_deg = constants::n_elements + 1;
 
-    std::vector<gl::types::id_type> degree_map;
+    std::vector<gl::id_type> degree_map;
 
     SUBCASE("in_degree") {
         degree_map = sut.in_degree_map();
@@ -779,7 +778,7 @@ TEST_CASE_FIXTURE(
     const auto removed_vertex_id = constants::first_element_idx;
     const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
-    constexpr gl::types::size_type n_removed_edges = 2uz;
+    constexpr gl::size_type n_removed_edges = 2uz;
     REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
     for (const auto edge_id : {edge1.id(), edge2.id()})
         CHECK(std::ranges::contains(removed_edge_ids, edge_id));

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -178,7 +178,7 @@ struct test_directed_adjacency_matrix : public test_adjacency_matrix {
         else
             REQUIRE(std::ranges::all_of(get(sut), [&](const auto& matrix_row) {
                 return std::ranges::count_if(matrix_row, is_valid_id)
-                    == n_incident_edges_for_fully_connected_vertex + constants::one;
+                    == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 
@@ -363,9 +363,7 @@ TEST_CASE_FIXTURE(
 
     add_edge(constants::v1_id, constants::v1_id);
 
-    CHECK_EQ(
-        deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + constants::one
-    );
+    CHECK_EQ(deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + 1uz);
 }
 
 TEST_CASE_FIXTURE(
@@ -387,7 +385,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(
         deg_proj(constants::v1_id),
-        constants::two * (n_incident_edges_for_fully_connected_vertex + constants::one)
+        constants::two * (n_incident_edges_for_fully_connected_vertex + 1uz)
     );
 }
 
@@ -486,7 +484,7 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
 
     void init_complete_graph(const bool no_loops = true) {
         for (const auto source_id : constants::vertex_id_view) {
-            const auto bound = no_loops ? source_id : source_id + constants::one;
+            const auto bound = no_loops ? source_id : source_id + 1uz;
             for (const auto target_id : std::views::iota(constants::v1_id, bound))
                 add_edge(source_id, target_id);
         }
@@ -499,7 +497,7 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
         else
             REQUIRE(std::ranges::all_of(get(sut), [&](const auto& matrix_row) {
                 return std::ranges::count_if(matrix_row, is_valid_id)
-                    == n_incident_edges_for_fully_connected_vertex + constants::one;
+                    == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -748,7 +748,7 @@ TEST_CASE_FIXTURE(
     const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
     const auto edge3 = add_edge(constants::v2_id, constants::v3_id);
 
-    const auto removed_vertex_id = constants::first_elem_idx;
+    const auto removed_vertex_id = 0uz;
     const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
 
     constexpr gl::size_type n_removed_edges = 2uz;

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -81,23 +81,22 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     bfs_no_return_graph_template,
-    gl::graph<
-        gl::list_graph_traits<gl::directed_t, types::visited_property>>, // directed adjacency list
+    gl::graph<gl::list_graph_traits<gl::directed_t, visited_property>>, // directed adjacency list
     gl::graph<gl::list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected adjacency list
+        visited_property>>, // undirected adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed flat adjacency list
+        visited_property>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected flat adjacency list
+        visited_property>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed adjacency matrix
+        visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        types::visited_property>> // undirected adjacency matrix
+        visited_property>> // undirected adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -112,19 +112,19 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
-        root_vertex_id = constants::vertex_id_1;
+        root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
 
     SUBCASE("clique") {
         graph = gl::topology::clique<graph_type>(constants::n_elements_alg);
-        root_vertex_id = constants::vertex_id_3;
+        root_vertex_id = constants::v3_id;
 
         for (auto id = gl::constants::initial_id; id < constants::n_elements_alg; id++) {
-            if (id != constants::vertex_id_3)
+            if (id != constants::v3_id)
                 expected_previsit_order.push_back(id);
         }
-        expected_previsit_order.push_front(constants::vertex_id_3);
+        expected_previsit_order.push_front(constants::v3_id);
     }
 
     CAPTURE(graph);

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -49,7 +49,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         B = {3, 4}
         root = 0 -> connected to B -> connected to A (root already visited)
         */
-        graph = gl::topology::biclique<graph_type>(constants::three, constants::two);
+        graph = gl::topology::biclique<graph_type>(3uz, 2uz);
         expected_previsit_order = {0, 3, 4, 1, 2};
     }
 

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -75,7 +75,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
     CHECK(std::ranges::all_of(
-        graph.vertices(), std::identity{}, alg_common::vertex_visited_projection<vertex_type>{}
+        graph.vertices(), std::identity{}, vertex_visited_projection<vertex_type>{}
     ));
 }
 
@@ -173,8 +173,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     // verify the predecessors of each vertex
     REQUIRE_EQ(pred_map.size(), graph.order());
-    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pred_map))
-    );
+    CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -19,7 +19,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using vertex_type = typename GraphType::vertex_type;
 
     graph_type graph;
-    std::vector<gl::types::id_type> expected_previsit_order;
+    std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
         graph = gl::topology::clique<graph_type>(constants::zero_elements);
@@ -56,17 +56,17 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(graph);
     CAPTURE(expected_previsit_order);
 
-    std::vector<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
+    std::vector<gl::id_type> expected_postvisit_order = expected_previsit_order;
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::breadth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
             vertex_properties[vertex_id].visited = true;
         }
@@ -108,8 +108,8 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
 
     graph_type graph;
-    gl::types::id_type root_vertex_id = constants::invalid_id;
-    std::deque<gl::types::id_type> expected_previsit_order;
+    gl::id_type root_vertex_id = constants::invalid_id;
+    std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
@@ -132,16 +132,16 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(root_vertex_id);
     CAPTURE(expected_previsit_order);
 
-    std::deque<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
+    std::deque<gl::id_type> expected_postvisit_order = expected_previsit_order;
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     gl::algorithm::breadth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
         }
     );

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -22,12 +22,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
-        graph = gl::topology::clique<graph_type>(constants::zero_elements);
+        graph = gl::topology::clique<graph_type>(0uz);
         expected_previsit_order = {};
     }
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         expected_previsit_order = {0};
     }
 
@@ -111,7 +111,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
@@ -167,7 +167,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::depth);
     const auto pred_map =
         gl::algorithm::breadth_first_search<gl::algorithm::ret, graph_type>(graph);
 

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -32,7 +32,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
             expected_coloring =
                 std::vector<gl::binary_color>(n_vertices_a, gl::bin_color_value::black);
-            for (gl::size_type i = constants::first_elem_idx; i < n_vertices_b; i++)
+            for (gl::size_type i = 0uz; i < n_vertices_b; i++)
                 expected_coloring.emplace_back(gl::bin_color_value::white);
         }
 

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -74,18 +74,16 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
         SUBCASE("custom graph") {
             fs::path gsf_file_path =
-                alg_common::data_path
+                data_path
                 / (gl::traits::c_directed_graph<sut_type>
                        ? "bicoloring_directed_bipartite_graph.gsf"
                        : "bicoloring_undirected_bipartite_graph.gsf");
 
             sut = gl::io::load<sut_type>(gsf_file_path);
 
-            fs::path coloring_file_path =
-                alg_common::data_path / "bicoloring_bipartite_graph_coloring.txt";
+            fs::path coloring_file_path = data_path / "bicoloring_bipartite_graph_coloring.txt";
 
-            const auto coloring_values =
-                alg_common::load_list<std::uint16_t>(sut.order(), coloring_file_path);
+            const auto coloring_values = load_list<std::uint16_t>(sut.order(), coloring_file_path);
 
             std::transform(
                 coloring_values.begin(),
@@ -140,7 +138,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
         SUBCASE("custom graph") {
             fs::path gsf_file_path =
-                alg_common::data_path
+                data_path
                 / (gl::traits::c_directed_graph<sut_type>
                        ? "bicoloring_directed_not_bipartite_graph.gsf"
                        : "bicoloring_undirected_not_bipartite_graph.gsf");

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -39,7 +39,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
 
-            gl::size_type n_vertices = constants::one_element;
+            gl::size_type n_vertices = 1uz;
             gl::binary_color c{gl::bin_color_value::black};
 
             for (auto d = 0uz; d < constants::depth; d++) {

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -46,7 +46,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
                 for (auto i = 0uz; i < n_vertices; i++)
                     expected_coloring.push_back(c);
 
-                n_vertices *= constants::two;
+                n_vertices *= 2uz;
                 c = c.next();
             }
         }
@@ -62,7 +62,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         }
 
         SUBCASE("even cycle graph") {
-            const auto n_vertices = constants::two * constants::n_elements_alg;
+            const auto n_vertices = 2uz * constants::n_elements_alg;
             sut = gl::topology::cycle<sut_type>(n_vertices);
 
             gl::binary_color c{gl::bin_color_value::black};
@@ -124,7 +124,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         }
 
         SUBCASE("odd cycle graph") {
-            sut = gl::topology::cycle<sut_type>(constants::two * constants::n_elements_alg + 1uz);
+            sut = gl::topology::cycle<sut_type>(2uz * constants::n_elements_alg + 1uz);
         }
 
         SUBCASE("regular binary tree with an additional edge between siblings") {

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -32,7 +32,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
             expected_coloring =
                 std::vector<gl::binary_color>(n_vertices_a, gl::bin_color_value::black);
-            for (gl::size_type i = constants::first_element_idx; i < n_vertices_b; i++)
+            for (gl::size_type i = constants::first_elem_idx; i < n_vertices_b; i++)
                 expected_coloring.emplace_back(gl::bin_color_value::white);
         }
 
@@ -42,8 +42,8 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             gl::size_type n_vertices = constants::one_element;
             gl::binary_color c{gl::bin_color_value::black};
 
-            for (gl::size_type d = constants::zero; d < constants::depth; d++) {
-                for (gl::size_type i = constants::zero; i < n_vertices; i++)
+            for (auto d = 0uz; d < constants::depth; d++) {
+                for (auto i = 0uz; i < n_vertices; i++)
                     expected_coloring.push_back(c);
 
                 n_vertices *= constants::two;
@@ -55,7 +55,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             sut = gl::topology::path<sut_type>(constants::n_elements_alg);
 
             gl::binary_color c{gl::bin_color_value::black};
-            for (gl::size_type i = constants::zero; i < constants::n_elements_alg; i++) {
+            for (auto i = 0uz; i < constants::n_elements_alg; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
             }
@@ -66,7 +66,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             sut = gl::topology::cycle<sut_type>(n_vertices);
 
             gl::binary_color c{gl::bin_color_value::black};
-            for (gl::size_type i = constants::zero; i < n_vertices; i++) {
+            for (auto i = 0uz; i < n_vertices; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
             }
@@ -131,13 +131,13 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
         SUBCASE("regular binary tree with an additional edge between siblings") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            sut.add_edge(constants::vertex_id_2, constants::vertex_id_3);
+            sut.add_edge(constants::v2_id, constants::v3_id);
         }
 
         SUBCASE("biclique with an additional edge between vertices from the same set") {
             const auto [n_vertices_a, n_vertices_b] = std::make_pair(4ull, 6ull);
             sut = gl::topology::biclique<sut_type>(n_vertices_a, n_vertices_b);
-            sut.add_edge(constants::vertex_id_1, constants::vertex_id_2);
+            sut.add_edge(constants::v1_id, constants::v2_id);
         }
 
         SUBCASE("custom graph") {

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -32,18 +32,18 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
             expected_coloring =
                 std::vector<gl::types::binary_color>(n_vertices_a, gl::bin_color_value::black);
-            for (gl::types::size_type i = constants::first_element_idx; i < n_vertices_b; i++)
+            for (gl::size_type i = constants::first_element_idx; i < n_vertices_b; i++)
                 expected_coloring.emplace_back(gl::bin_color_value::white);
         }
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
 
-            gl::types::size_type n_vertices = constants::one_element;
+            gl::size_type n_vertices = constants::one_element;
             gl::types::binary_color c{gl::bin_color_value::black};
 
-            for (gl::types::size_type d = constants::zero; d < constants::depth; d++) {
-                for (gl::types::size_type i = constants::zero; i < n_vertices; i++)
+            for (gl::size_type d = constants::zero; d < constants::depth; d++) {
+                for (gl::size_type i = constants::zero; i < n_vertices; i++)
                     expected_coloring.push_back(c);
 
                 n_vertices *= constants::two;
@@ -55,7 +55,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             sut = gl::topology::path<sut_type>(constants::n_elements_alg);
 
             gl::types::binary_color c{gl::bin_color_value::black};
-            for (gl::types::size_type i = constants::zero; i < constants::n_elements_alg; i++) {
+            for (gl::size_type i = constants::zero; i < constants::n_elements_alg; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
             }
@@ -66,7 +66,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             sut = gl::topology::cycle<sut_type>(n_vertices);
 
             gl::types::binary_color c{gl::bin_color_value::black};
-            for (gl::types::size_type i = constants::zero; i < n_vertices; i++) {
+            for (gl::size_type i = constants::zero; i < n_vertices; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
             }

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -17,21 +17,21 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
     SUBCASE("apply_coloring should return false if the size of coloring is different then "
             "n_vertices") {
         sut_type sut{constants::n_elements_alg};
-        std::vector<gl::types::binary_color> empty_coloring;
+        std::vector<gl::binary_color> empty_coloring;
 
         CHECK_FALSE(gl::algorithm::apply_coloring(sut, empty_coloring));
     }
 
     SUBCASE("bipartite graph") {
         sut_type sut;
-        std::vector<gl::types::binary_color> expected_coloring;
+        std::vector<gl::binary_color> expected_coloring;
 
         SUBCASE("biclique") {
             const auto [n_vertices_a, n_vertices_b] = std::make_pair(4ull, 6ull);
             sut = gl::topology::biclique<sut_type>(n_vertices_a, n_vertices_b);
 
             expected_coloring =
-                std::vector<gl::types::binary_color>(n_vertices_a, gl::bin_color_value::black);
+                std::vector<gl::binary_color>(n_vertices_a, gl::bin_color_value::black);
             for (gl::size_type i = constants::first_element_idx; i < n_vertices_b; i++)
                 expected_coloring.emplace_back(gl::bin_color_value::white);
         }
@@ -40,7 +40,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
 
             gl::size_type n_vertices = constants::one_element;
-            gl::types::binary_color c{gl::bin_color_value::black};
+            gl::binary_color c{gl::bin_color_value::black};
 
             for (gl::size_type d = constants::zero; d < constants::depth; d++) {
                 for (gl::size_type i = constants::zero; i < n_vertices; i++)
@@ -54,7 +54,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         SUBCASE("path graph") {
             sut = gl::topology::path<sut_type>(constants::n_elements_alg);
 
-            gl::types::binary_color c{gl::bin_color_value::black};
+            gl::binary_color c{gl::bin_color_value::black};
             for (gl::size_type i = constants::zero; i < constants::n_elements_alg; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
@@ -65,7 +65,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
             const auto n_vertices = constants::two * constants::n_elements_alg;
             sut = gl::topology::cycle<sut_type>(n_vertices);
 
-            gl::types::binary_color c{gl::bin_color_value::black};
+            gl::binary_color c{gl::bin_color_value::black};
             for (gl::size_type i = constants::zero; i < n_vertices; i++) {
                 expected_coloring.push_back(c);
                 c = c.next();
@@ -164,22 +164,22 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     traits_type_template,
     gl::list_graph_traits<
         gl::directed_t,
-        gl::types::binary_color_property>, // directed adjacency list graph
+        gl::binary_color_property>, // directed adjacency list graph
     gl::list_graph_traits<
         gl::undirected_t,
-        gl::types::binary_color_property>, // undirected adjacency list graph
+        gl::binary_color_property>, // undirected adjacency list graph
     gl::flat_list_graph_traits<
         gl::directed_t,
-        gl::types::binary_color_property>, // directed flat adjacency list graph
+        gl::binary_color_property>, // directed flat adjacency list graph
     gl::flat_list_graph_traits<
         gl::undirected_t,
-        gl::types::binary_color_property>, // undirected flat adjacency list graph
+        gl::binary_color_property>, // undirected flat adjacency list graph
     gl::matrix_graph_traits<
         gl::directed_t,
-        gl::types::binary_color_property>, // directed adjacency matrix graph
+        gl::binary_color_property>, // directed adjacency matrix graph
     gl::matrix_graph_traits<
         gl::undirected_t,
-        gl::types::binary_color_property> // undirected adjacency matrix graph
+        gl::binary_color_property> // undirected adjacency matrix graph
 );
 
 TEST_SUITE_END(); // test_alg_coloring

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -124,9 +124,7 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
         }
 
         SUBCASE("odd cycle graph") {
-            sut = gl::topology::cycle<sut_type>(
-                constants::two * constants::n_elements_alg + constants::one
-            );
+            sut = gl::topology::cycle<sut_type>(constants::two * constants::n_elements_alg + 1uz);
         }
 
         SUBCASE("regular binary tree with an additional edge between siblings") {

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -120,19 +120,19 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
-        root_vertex_id = constants::vertex_id_1;
+        root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
 
     SUBCASE("clique") {
         graph = gl::topology::clique<graph_type>(constants::n_elements_alg);
-        root_vertex_id = constants::vertex_id_3;
+        root_vertex_id = constants::v3_id;
 
         for (auto id = gl::constants::initial_id; id < constants::n_elements_alg; id++) {
-            if (id != constants::vertex_id_3)
+            if (id != constants::v3_id)
                 expected_previsit_order.push_front(id);
         }
-        expected_previsit_order.push_front(constants::vertex_id_3);
+        expected_previsit_order.push_front(constants::v3_id);
     }
 
     CAPTURE(graph);
@@ -308,17 +308,17 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
-        root_vertex_id = constants::vertex_id_1;
+        root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
 
     SUBCASE("clique") {
         graph = gl::topology::clique<graph_type>(constants::n_elements_alg);
-        root_vertex_id = constants::vertex_id_3;
+        root_vertex_id = constants::v3_id;
 
-        expected_previsit_order.push_back(constants::vertex_id_3);
+        expected_previsit_order.push_back(constants::v3_id);
         for (auto id = gl::constants::initial_id; id < constants::n_elements_alg; id++) {
-            if (id != constants::vertex_id_3)
+            if (id != constants::v3_id)
                 expected_previsit_order.push_back(id);
         }
     }

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -82,7 +82,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
     CHECK(std::ranges::all_of(
-        graph.vertices(), std::identity{}, alg_common::vertex_visited_projection<vertex_type>{}
+        graph.vertices(), std::identity{}, vertex_visited_projection<vertex_type>{}
     ));
 }
 
@@ -179,8 +179,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     // verify the predecessors of each vertex
     REQUIRE_EQ(pred_map.size(), graph.order());
-    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pred_map))
-    );
+    CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -270,7 +269,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
     CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
     CHECK(std::ranges::all_of(
-        graph.vertices(), std::identity{}, alg_common::vertex_visited_projection<vertex_type>{}
+        graph.vertices(), std::identity{}, vertex_visited_projection<vertex_type>{}
     ));
 }
 
@@ -373,8 +372,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     // verify the predecessors of each vertex
     REQUIRE_EQ(pred_map.size(), graph.order());
-    CHECK(std::ranges::all_of(graph.vertex_ids(), alg_common::has_correct_bin_predecessor(pred_map))
-    );
+    CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -21,7 +21,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using vertex_type = typename GraphType::vertex_type;
 
     graph_type graph;
-    std::deque<gl::types::id_type> expected_previsit_order;
+    std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
         graph = gl::topology::clique<graph_type>(constants::zero_elements);
@@ -64,17 +64,17 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(graph);
     CAPTURE(expected_previsit_order);
 
-    std::deque<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
+    std::deque<gl::id_type> expected_postvisit_order = expected_previsit_order;
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::depth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
             vertex_properties[vertex_id].visited = true;
         }
@@ -116,8 +116,8 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
 
     graph_type graph;
-    gl::types::id_type root_vertex_id;
-    std::deque<gl::types::id_type> expected_previsit_order;
+    gl::id_type root_vertex_id;
+    std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
@@ -140,16 +140,16 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(root_vertex_id);
     CAPTURE(expected_previsit_order);
 
-    std::deque<gl::types::id_type> expected_postvisit_order = expected_previsit_order;
+    std::deque<gl::id_type> expected_postvisit_order = expected_previsit_order;
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     gl::algorithm::depth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
         }
     );
@@ -206,7 +206,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using vertex_type = typename GraphType::vertex_type;
 
     graph_type graph;
-    std::vector<gl::types::id_type> expected_previsit_order;
+    std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
         graph = gl::topology::clique<graph_type>(constants::zero_elements);
@@ -255,15 +255,15 @@ TEST_CASE_TEMPLATE_DEFINE(
     */
     const auto expected_postvisit_order = std::views::reverse(expected_previsit_order);
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     const auto vertex_properties = graph.vertex_properties_map();
     gl::algorithm::recursive_depth_first_search<gl::algorithm::noret>(
         graph,
         gl::algorithm::no_root_vertex,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
             vertex_properties[vertex_id].visited = true;
         }
@@ -305,8 +305,8 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
 
     graph_type graph;
-    gl::types::id_type root_vertex_id = constants::invalid_id;
-    std::vector<gl::types::id_type> expected_previsit_order;
+    gl::id_type root_vertex_id = constants::invalid_id;
+    std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
         graph = gl::topology::clique<graph_type>(constants::one_element);
@@ -336,14 +336,14 @@ TEST_CASE_TEMPLATE_DEFINE(
     */
     const auto expected_postvisit_order = std::views::reverse(expected_previsit_order);
 
-    std::vector<gl::types::id_type> previsit_order, postvisit_order;
+    std::vector<gl::id_type> previsit_order, postvisit_order;
     gl::algorithm::recursive_depth_first_search<gl::algorithm::noret>(
         graph,
         root_vertex_id,
-        [&](const gl::types::id_type vertex_id) { // previsit
+        [&](const gl::id_type vertex_id) { // previsit
             previsit_order.push_back(vertex_id);
         },
-        [&](const gl::types::id_type vertex_id) { // postvisit
+        [&](const gl::id_type vertex_id) { // postvisit
             postvisit_order.push_back(vertex_id);
         }
     );

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -35,8 +35,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique") {
         graph = gl::topology::clique<graph_type>(constants::n_elements_alg);
-        for (auto id = gl::constants::initial_id + constants::one; id < constants::n_elements_alg;
-             id++)
+        for (auto id = 1uz; id < constants::n_elements_alg; id++)
             expected_previsit_order.push_front(id);
         expected_previsit_order.push_front(gl::constants::initial_id);
     }

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -24,12 +24,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
-        graph = gl::topology::clique<graph_type>(constants::zero_elements);
+        graph = gl::topology::clique<graph_type>(0uz);
         expected_previsit_order = {};
     }
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         expected_previsit_order = {0};
     }
 
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         -> 2 connected to B (4 visited) [s: 3 1 3]
         finally: 0 -> 4 -> 2 -> 1 -> 3
         */
-        graph = gl::topology::biclique<graph_type>(constants::three, 2uz);
+        graph = gl::topology::biclique<graph_type>(3uz, 2uz);
         expected_previsit_order = {0, 4, 2, 3, 1};
     }
 
@@ -118,7 +118,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::deque<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
@@ -174,7 +174,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::depth);
     const auto pred_map = gl::algorithm::depth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
@@ -207,12 +207,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("empty graph") {
-        graph = gl::topology::clique<graph_type>(constants::zero_elements);
+        graph = gl::topology::clique<graph_type>(0uz);
         expected_previsit_order = {};
     }
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         expected_previsit_order = {0};
     }
 
@@ -239,7 +239,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         -> 4 connected to A (2)
         finally: 0 -> 3 -> 1 -> 4 -> 2
         */
-        graph = gl::topology::biclique<graph_type>(constants::three, 2uz);
+        graph = gl::topology::biclique<graph_type>(3uz, 2uz);
         expected_previsit_order = {0, 3, 1, 4, 2};
     }
 
@@ -306,7 +306,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<gl::id_type> expected_previsit_order;
 
     SUBCASE("single vertex graph") {
-        graph = gl::topology::clique<graph_type>(constants::one_element);
+        graph = gl::topology::clique<graph_type>(1uz);
         root_vertex_id = constants::v1_id;
         expected_previsit_order = {0};
     }
@@ -367,7 +367,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using graph_type = GraphType;
     using vertex_type = typename graph_type::vertex_type;
 
-    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::three);
+    const auto graph = gl::topology::regular_binary_tree<graph_type>(constants::depth);
     const auto pred_map =
         gl::algorithm::recursive_depth_first_search<gl::algorithm::ret, graph_type>(graph);
 

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         -> 2 connected to B (4 visited) [s: 3 1 3]
         finally: 0 -> 4 -> 2 -> 1 -> 3
         */
-        graph = gl::topology::biclique<graph_type>(constants::three, constants::two);
+        graph = gl::topology::biclique<graph_type>(constants::three, 2uz);
         expected_previsit_order = {0, 4, 2, 3, 1};
     }
 
@@ -239,7 +239,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         -> 4 connected to A (2)
         finally: 0 -> 3 -> 1 -> 4 -> 2
         */
-        graph = gl::topology::biclique<graph_type>(constants::three, constants::two);
+        graph = gl::topology::biclique<graph_type>(constants::three, 2uz);
         expected_previsit_order = {0, 3, 1, 4, 2};
     }
 

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -89,23 +89,22 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     dfs_no_return_graph_template,
-    gl::graph<
-        gl::list_graph_traits<gl::directed_t, types::visited_property>>, // directed adjacency list
+    gl::graph<gl::list_graph_traits<gl::directed_t, visited_property>>, // directed adjacency list
     gl::graph<gl::list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected adjacency list
+        visited_property>>, // undirected adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed flat adjacency list
+        visited_property>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected flat adjacency list
+        visited_property>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed adjacency matrix
+        visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        types::visited_property>> // undirected adjacency matrix
+        visited_property>> // undirected adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -278,23 +277,22 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     rdfs_no_return_graph_template,
-    gl::graph<
-        gl::list_graph_traits<gl::directed_t, types::visited_property>>, // directed adjacency list
+    gl::graph<gl::list_graph_traits<gl::directed_t, visited_property>>, // directed adjacency list
     gl::graph<gl::list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected adjacency list
+        visited_property>>, // undirected adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed flat adjacency list
+        visited_property>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<
         gl::undirected_t,
-        types::visited_property>>, // undirected flat adjacency list
+        visited_property>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<
         gl::directed_t,
-        types::visited_property>>, // directed adjacency matrix
+        visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        types::visited_property>> // undirected adjacency matrix
+        visited_property>> // undirected adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -1,3 +1,4 @@
+#include "gl/constants.hpp"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 #include "testing/gl/functional.hpp"
@@ -27,11 +28,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("should throw if there is an edge with a negative weight") {
         const auto sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-        sut.get_edge(constants::vertex_id_1, constants::vertex_id_2)->properties().weight =
+        sut.get_edge(constants::v1_id, constants::v2_id)->properties().weight =
             -static_cast<weight_type>(constants::n_elements_alg);
 
         CHECK_THROWS_AS(
-            discard_result(gl::algorithm::dijkstra_shortest_paths(sut, constants::vertex_id_1)),
+            discard_result(gl::algorithm::dijkstra_shortest_paths(sut, constants::v1_id)),
             std::invalid_argument
         );
     }
@@ -42,36 +43,31 @@ TEST_CASE_TEMPLATE_DEFINE(
         std::vector<gl::id_type> expected_predecessors;
         std::vector<distance_type> expected_distances;
 
-        const auto source_distance = static_cast<distance_type>(constants::zero);
+        const distance_type source_distance = 0;
 
         SUBCASE("clique") {
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
             expected_distances.push_back(source_distance);
             const auto edge_weight = static_cast<weight_type>(constants::n_elements_alg);
-            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++) {
-                sut.get_edge(constants::vertex_id_1, id)->properties().weight = edge_weight;
+            for (gl::id_type id = constants::v2_id; id < constants::n_elements_alg; id++) {
+                sut.get_edge(constants::v1_id, id)->properties().weight = edge_weight;
                 expected_distances.push_back(edge_weight);
             }
         }
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             for (const auto id : sut.vertex_ids()) {
-                const auto parent_id =
-                    id == constants::zero
-                        ? constants::zero
-                        : (id - constants::one) / constants::two;
+                const auto parent_id = id == 0uz ? 0uz : (id - 1uz) / 2uz;
                 expected_predecessors.push_back(parent_id);
 
-                const auto vertex_depth =
-                    constants::zero ? constants::zero
-                                    : static_cast<gl::size_type>(std::log2(id + constants::one));
+                const auto vertex_depth = static_cast<gl::size_type>(std::log2(id + 1uz));
                 expected_distances.push_back(vertex_depth);
             }
         }
@@ -85,7 +81,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = alg_common::data_path / (file_name_prefix + "graph.gsf");
 
             sut = gl::io::load<sut_type>(gsf_file_path);
-            source_id = constants::first_element_idx;
+            source_id = gl::constants::initial_id;
 
             const fs::path predecessors_file_path =
                 alg_common::data_path / (file_name_prefix + "predecessors.txt");
@@ -158,33 +154,28 @@ TEST_CASE_TEMPLATE_DEFINE(
         std::vector<gl::id_type> expected_predecessors;
         std::vector<distance_type> expected_distances;
 
-        const auto source_distance = static_cast<distance_type>(constants::zero);
+        const distance_type source_distance = 0;
 
         SUBCASE("clique") {
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
             expected_distances.push_back(source_distance);
-            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++)
+            for (gl::id_type id = constants::v2_id; id < constants::n_elements_alg; id++)
                 expected_distances.push_back(constants::one);
         }
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             for (const auto id : sut.vertex_ids()) {
-                const auto parent_id =
-                    id == constants::zero
-                        ? constants::zero
-                        : (id - constants::one) / constants::two;
+                const auto parent_id = id == 0uz ? 0uz : (id - 1uz) / 2uz;
                 expected_predecessors.push_back(parent_id);
 
-                const auto vertex_depth =
-                    constants::zero ? constants::zero
-                                    : static_cast<gl::size_type>(std::log2(id + constants::one));
+                const auto vertex_depth = static_cast<gl::size_type>(std::log2(id + 1uz));
                 expected_distances.push_back(vertex_depth);
             }
         }

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -163,8 +163,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
             expected_distances.push_back(source_distance);
-            for (gl::id_type id = constants::v2_id; id < constants::n_elements_alg; id++)
-                expected_distances.push_back(constants::one);
+            for (auto id = constants::v2_id; id < constants::n_elements_alg; id++)
+                expected_distances.push_back(1uz);
         }
 
         SUBCASE("regular binary tree") {
@@ -208,7 +208,7 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 
 TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {
     const std::vector<std::optional<gl::id_type>> predecessor_map = {0, 3, 1, std::nullopt};
-    gl::id_type vertex_id = predecessor_map.size() - constants::one;
+    gl::id_type vertex_id = predecessor_map.size() - 1uz;
 
     CHECK_THROWS_AS(
         discard_result(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)),

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -78,20 +78,17 @@ TEST_CASE_TEMPLATE_DEFINE(
                     ? "dijkstra_directed_"
                     : "dijkstra_undirected_";
 
-            const fs::path gsf_file_path = alg_common::data_path / (file_name_prefix + "graph.gsf");
+            const fs::path gsf_file_path = data_path / (file_name_prefix + "graph.gsf");
 
             sut = gl::io::load<sut_type>(gsf_file_path);
             source_id = gl::constants::initial_id;
 
             const fs::path predecessors_file_path =
-                alg_common::data_path / (file_name_prefix + "predecessors.txt");
-            expected_predecessors =
-                alg_common::load_list<gl::id_type>(sut.order(), predecessors_file_path);
+                data_path / (file_name_prefix + "predecessors.txt");
+            expected_predecessors = load_list<gl::id_type>(sut.order(), predecessors_file_path);
 
-            const fs::path distances_file_path =
-                alg_common::data_path / (file_name_prefix + "distances.txt");
-            expected_distances =
-                alg_common::load_list<distance_type>(sut.order(), distances_file_path);
+            const fs::path distances_file_path = data_path / (file_name_prefix + "distances.txt");
+            expected_distances = load_list<distance_type>(sut.order(), distances_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -39,8 +39,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("should return a proper paths descriptor for a valid graph") {
         sut_type sut;
-        gl::types::id_type source_id;
-        std::vector<gl::types::id_type> expected_predecessors;
+        gl::id_type source_id;
+        std::vector<gl::id_type> expected_predecessors;
         std::vector<distance_type> expected_distances;
 
         const auto source_distance = static_cast<distance_type>(constants::zero);
@@ -49,13 +49,11 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
             source_id = constants::first_element_idx;
 
-            expected_predecessors =
-                std::vector<gl::types::id_type>(constants::n_elements_alg, source_id);
+            expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
             expected_distances.push_back(source_distance);
             const auto edge_weight = static_cast<weight_type>(constants::n_elements_alg);
-            for (gl::types::id_type id = constants::vertex_id_2; id < constants::n_elements_alg;
-                 id++) {
+            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++) {
                 sut.get_edge(constants::vertex_id_1, id)->properties().weight = edge_weight;
                 expected_distances.push_back(edge_weight);
             }
@@ -73,9 +71,8 @@ TEST_CASE_TEMPLATE_DEFINE(
                 expected_predecessors.push_back(parent_id);
 
                 const auto vertex_depth =
-                    constants::zero
-                        ? constants::zero
-                        : static_cast<gl::types::size_type>(std::log2(id + constants::one));
+                    constants::zero ? constants::zero
+                                    : static_cast<gl::size_type>(std::log2(id + constants::one));
                 expected_distances.push_back(vertex_depth);
             }
         }
@@ -94,7 +91,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path predecessors_file_path =
                 alg_common::data_path / (file_name_prefix + "predecessors.txt");
             expected_predecessors =
-                alg_common::load_list<gl::types::id_type>(sut.order(), predecessors_file_path);
+                alg_common::load_list<gl::id_type>(sut.order(), predecessors_file_path);
 
             const fs::path distances_file_path =
                 alg_common::data_path / (file_name_prefix + "distances.txt");
@@ -158,8 +155,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("should return a proper paths descriptor for a valid graph") {
         sut_type sut;
-        gl::types::id_type source_id;
-        std::vector<gl::types::id_type> expected_predecessors;
+        gl::id_type source_id;
+        std::vector<gl::id_type> expected_predecessors;
         std::vector<distance_type> expected_distances;
 
         const auto source_distance = static_cast<distance_type>(constants::zero);
@@ -168,12 +165,10 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
             source_id = constants::first_element_idx;
 
-            expected_predecessors =
-                std::vector<gl::types::id_type>(constants::n_elements_alg, source_id);
+            expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
             expected_distances.push_back(source_distance);
-            for (gl::types::id_type id = constants::vertex_id_2; id < constants::n_elements_alg;
-                 id++)
+            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++)
                 expected_distances.push_back(constants::one);
         }
 
@@ -189,9 +184,8 @@ TEST_CASE_TEMPLATE_DEFINE(
                 expected_predecessors.push_back(parent_id);
 
                 const auto vertex_depth =
-                    constants::zero
-                        ? constants::zero
-                        : static_cast<gl::types::size_type>(std::log2(id + constants::one));
+                    constants::zero ? constants::zero
+                                    : static_cast<gl::size_type>(std::log2(id + constants::one));
                 expected_distances.push_back(vertex_depth);
             }
         }
@@ -223,8 +217,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {
-    const std::vector<std::optional<gl::types::id_type>> predecessor_map = {0, 3, 1, std::nullopt};
-    gl::types::id_type vertex_id = predecessor_map.size() - constants::one;
+    const std::vector<std::optional<gl::id_type>> predecessor_map = {0, 3, 1, std::nullopt};
+    gl::id_type vertex_id = predecessor_map.size() - constants::one;
 
     CHECK_THROWS_AS(
         func::discard_result(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)),
@@ -233,10 +227,10 @@ TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {
 }
 
 TEST_CASE("reconstruct_path should properly reconstruct the search path to the specified vertex") {
-    const std::vector<std::optional<gl::types::id_type>> predecessor_map = {0, 3, 1, 0};
+    const std::vector<std::optional<gl::id_type>> predecessor_map = {0, 3, 1, 0};
 
-    gl::types::id_type vertex_id;
-    std::deque<gl::types::id_type> expected_path;
+    gl::id_type vertex_id;
+    std::deque<gl::id_type> expected_path;
 
     SUBCASE("starting vertex = 0") {
         vertex_id = 0;

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -31,8 +31,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             -static_cast<weight_type>(constants::n_elements_alg);
 
         CHECK_THROWS_AS(
-            func::discard_result(gl::algorithm::dijkstra_shortest_paths(sut, constants::vertex_id_1)
-            ),
+            discard_result(gl::algorithm::dijkstra_shortest_paths(sut, constants::vertex_id_1)),
             std::invalid_argument
         );
     }
@@ -221,7 +220,7 @@ TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {
     gl::id_type vertex_id = predecessor_map.size() - constants::one;
 
     CHECK_THROWS_AS(
-        func::discard_result(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)),
+        discard_result(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)),
         std::invalid_argument
     );
 }

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -119,28 +119,28 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     wieghted_edge_traits_type_template,
     gl::list_graph_traits<
         gl::directed_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>>, // directed adjacency list graph
+        gl::empty_properties,
+        gl::weight_property<>>, // directed adjacency list graph
     gl::list_graph_traits<
         gl::undirected_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>>, // undirected adjacency list graph
+        gl::empty_properties,
+        gl::weight_property<>>, // undirected adjacency list graph
     gl::flat_list_graph_traits<
         gl::directed_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>>, // directed flat adjacency list graph
+        gl::empty_properties,
+        gl::weight_property<>>, // directed flat adjacency list graph
     gl::flat_list_graph_traits<
         gl::undirected_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>>, // undirected flat adjacency list graph
+        gl::empty_properties,
+        gl::weight_property<>>, // undirected flat adjacency list graph
     gl::matrix_graph_traits<
         gl::directed_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>>, // directed adjacency matrix graph
+        gl::empty_properties,
+        gl::weight_property<>>, // directed adjacency matrix graph
     gl::matrix_graph_traits<
         gl::undirected_t,
-        gl::types::empty_properties,
-        gl::types::weight_property<>> // undirected adjacency matrix graph
+        gl::empty_properties,
+        gl::weight_property<>> // undirected adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -149,7 +149,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     unwieghted_edge_traits_type_template
 ) {
     using sut_type = gl::graph<TraitsType>;
-    using distance_type = gl::types::default_vertex_distance_type;
+    using distance_type = gl::default_vertex_distance_type;
 
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -47,7 +47,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("clique") {
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
@@ -61,7 +61,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             for (const auto id : sut.vertex_ids()) {
                 const auto parent_id = id == 0uz ? 0uz : (id - 1uz) / 2uz;
@@ -155,7 +155,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("clique") {
             sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             expected_predecessors = std::vector<gl::id_type>(constants::n_elements_alg, source_id);
 
@@ -166,7 +166,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             for (const auto id : sut.vertex_ids()) {
                 const auto parent_id = id == 0uz ? 0uz : (id - 1uz) / 2uz;

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -35,7 +35,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             const weight_type edge_weight = constants::three;
             for (const auto vertex_id : sut.vertex_ids()) {
@@ -52,7 +52,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
@@ -120,7 +120,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::id_type source_id = constants::first_element_idx;
+    const gl::id_type source_id = constants::first_elem_idx;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
@@ -176,7 +176,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             const weight_type edge_weight = constants::three;
             for (const auto vertex_id : sut.vertex_ids()) {
@@ -193,7 +193,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
-            source_id = constants::first_element_idx;
+            source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
@@ -261,7 +261,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::id_type source_id = constants::first_element_idx;
+    const gl::id_type source_id = constants::first_elem_idx;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -113,7 +113,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     edge_heap_prim_unwieghted_edge_traits_type_template
 ) {
     using sut_type = gl::graph<TraitsType>;
-    using distance_type = gl::types::default_vertex_distance_type;
+    using distance_type = gl::default_vertex_distance_type;
     using weight_type = distance_type;
     using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 
@@ -254,7 +254,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     vertex_heap_prim_unwieghted_edge_traits_type_template
 ) {
     using sut_type = gl::graph<TraitsType>;
-    using distance_type = gl::types::default_vertex_distance_type;
+    using distance_type = gl::default_vertex_distance_type;
     using weight_type = distance_type;
     using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -26,10 +26,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     SUBCASE("should return a proper mst descriptor for a valid graph") {
-        using vertex_id_pair = std::pair<gl::types::id_type, gl::types::id_type>;
+        using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 
         sut_type sut;
-        gl::types::id_type source_id;
+        gl::id_type source_id;
         std::vector<vertex_id_pair> expected_edges;
         distance_type expected_weight;
 
@@ -57,8 +57,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
             const auto vertex_id_list =
-                alg_common::load_list<gl::types::id_type>(n_vertex_ids, edges_file_path);
-            for (gl::types::size_type i = 0; i < n_vertex_ids; i += constants::two)
+                alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
+            for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
@@ -115,12 +115,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     using sut_type = gl::graph<TraitsType>;
     using distance_type = gl::types::default_vertex_distance_type;
     using weight_type = distance_type;
-    using vertex_id_pair = std::pair<gl::types::id_type, gl::types::id_type>;
+    using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::types::id_type source_id = constants::first_element_idx;
+    const gl::id_type source_id = constants::first_element_idx;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
@@ -167,10 +167,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     SUBCASE("should return a proper mst descriptor for a valid graph") {
-        using vertex_id_pair = std::pair<gl::types::id_type, gl::types::id_type>;
+        using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 
         sut_type sut;
-        gl::types::id_type source_id;
+        gl::id_type source_id;
         std::vector<vertex_id_pair> expected_edges;
         distance_type expected_weight;
 
@@ -198,8 +198,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
             const auto vertex_id_list =
-                alg_common::load_list<gl::types::id_type>(n_vertex_ids, edges_file_path);
-            for (gl::types::size_type i = 0; i < n_vertex_ids; i += constants::two)
+                alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
+            for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
@@ -256,12 +256,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     using sut_type = gl::graph<TraitsType>;
     using distance_type = gl::types::default_vertex_distance_type;
     using weight_type = distance_type;
-    using vertex_id_pair = std::pair<gl::types::id_type, gl::types::id_type>;
+    using vertex_id_pair = std::pair<gl::id_type, gl::id_type>;
 
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::types::id_type source_id = constants::first_element_idx;
+    const gl::id_type source_id = constants::first_element_idx;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -37,7 +37,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_elem_idx;
 
-            const weight_type edge_weight = constants::three;
+            const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
                 for (const auto& edge : sut.adjacent_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
@@ -177,7 +177,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
             source_id = constants::first_elem_idx;
 
-            const weight_type edge_weight = constants::three;
+            const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
                 for (const auto& edge : sut.adjacent_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -45,7 +45,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * (sut.order() - constants::one);
+            expected_weight = edge_weight * (sut.order() - 1uz);
         }
 
         SUBCASE("custom graph") {
@@ -55,15 +55,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
+            const auto n_vertex_ids = (sut.order() - 1uz) * constants::two;
             const auto vertex_id_list =
                 alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
             for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight =
-                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
+            expected_weight = alg_common::load_list<weight_type>(1uz, weight_file_path).front();
         }
 
         CAPTURE(sut);
@@ -73,7 +72,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
+        REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -127,11 +126,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.adjacent_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const weight_type expected_weight = sut.order() - constants::one;
+    const weight_type expected_weight = sut.order() - 1uz;
 
     const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
+    REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -186,7 +185,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * (sut.order() - constants::one);
+            expected_weight = edge_weight * (sut.order() - 1uz);
         }
 
         SUBCASE("custom graph") {
@@ -196,15 +195,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - constants::one) * constants::two;
+            const auto n_vertex_ids = (sut.order() - 1uz) * constants::two;
             const auto vertex_id_list =
                 alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
             for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight =
-                alg_common::load_list<weight_type>(constants::one, weight_file_path).front();
+            expected_weight = alg_common::load_list<weight_type>(1uz, weight_file_path).front();
         }
 
         CAPTURE(sut);
@@ -214,7 +212,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
+        REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -268,11 +266,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.adjacent_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const weight_type expected_weight = sut.order() - constants::one;
+    const weight_type expected_weight = sut.order() - 1uz;
 
     const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.order() - constants::one);
+    REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -49,20 +49,19 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("custom graph") {
-            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
+            const fs::path gsf_file_path = data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
             source_id = constants::first_elem_idx;
 
-            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
+            const fs::path edges_file_path = data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
-            const auto vertex_id_list =
-                alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
+            const auto vertex_id_list = load_list<gl::id_type>(n_vertex_ids, edges_file_path);
             for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
-            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight = alg_common::load_list<weight_type>(1uz, weight_file_path).front();
+            const fs::path weight_file_path = data_path / "mst_weight.txt";
+            expected_weight = load_list<weight_type>(1uz, weight_file_path).front();
         }
 
         CAPTURE(sut);
@@ -189,20 +188,19 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("custom graph") {
-            const fs::path gsf_file_path = alg_common::data_path / "mst_graph.gsf";
+            const fs::path gsf_file_path = data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
             source_id = constants::first_elem_idx;
 
-            const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
+            const fs::path edges_file_path = data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
-            const auto vertex_id_list =
-                alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
+            const auto vertex_id_list = load_list<gl::id_type>(n_vertex_ids, edges_file_path);
             for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
-            const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
-            expected_weight = alg_common::load_list<weight_type>(1uz, weight_file_path).front();
+            const fs::path weight_file_path = data_path / "mst_weight.txt";
+            expected_weight = load_list<weight_type>(1uz, weight_file_path).front();
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -94,16 +94,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     edge_heap_prim_wieghted_edge_traits_type_template,
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::list_t>, // undirected adjacency list graph
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::flat_list_t>, // undirected flat adjacency list graph
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::matrix_t> // undirected adjacency matrix graph
 );
 
@@ -235,16 +235,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     vertex_heap_prim_wieghted_edge_traits_type_template,
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::list_t>, // undirected adjacency list graph
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::flat_list_t>, // undirected flat adjacency list graph
     gl::undirected_graph_traits<
-        gl::types::empty_properties,
-        gl::types::weight_property<>,
+        gl::empty_properties,
+        gl::weight_property<>,
         gl::impl::matrix_t> // undirected adjacency matrix graph
 );
 

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -55,10 +55,10 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - 1uz) * constants::two;
+            const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
             const auto vertex_id_list =
                 alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
-            for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
+            for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";
@@ -195,10 +195,10 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = constants::first_elem_idx;
 
             const fs::path edges_file_path = alg_common::data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - 1uz) * constants::two;
+            const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
             const auto vertex_id_list =
                 alg_common::load_list<gl::id_type>(n_vertex_ids, edges_file_path);
-            for (gl::size_type i = 0; i < n_vertex_ids; i += constants::two)
+            for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
                 expected_edges.emplace_back(vertex_id_list[i], vertex_id_list[i + 1]);
 
             const fs::path weight_file_path = alg_common::data_path / "mst_weight.txt";

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -35,7 +35,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
@@ -52,7 +52,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             const fs::path edges_file_path = data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
@@ -118,7 +118,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::id_type source_id = constants::first_elem_idx;
+    const gl::id_type source_id = 0uz;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
@@ -174,7 +174,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("regular binary tree") {
             sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
@@ -191,7 +191,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path gsf_file_path = data_path / "mst_graph.gsf";
 
             sut = gl::io::load<sut_type>(gsf_file_path);
-            source_id = constants::first_elem_idx;
+            source_id = 0uz;
 
             const fs::path edges_file_path = data_path / "mst_edges.txt";
             const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
@@ -257,7 +257,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     static_assert(not gl::traits::c_weight_properties_type<typename sut_type::edge_properties_type>);
 
     const auto sut = gl::topology::regular_binary_tree<sut_type>(constants::depth);
-    const gl::id_type source_id = constants::first_elem_idx;
+    const gl::id_type source_id = 0uz;
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -50,13 +50,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("custom graph") {
             const fs::path gsf_file_path =
-                alg_common::data_path / "topological_sort_directed_acyclic_graph.gsf";
+                data_path / "topological_sort_directed_acyclic_graph.gsf";
             sut = gl::io::load<sut_type>(gsf_file_path);
 
             const fs::path order_file_path =
-                alg_common::data_path / "topological_sort_directed_acyclic_order.txt";
-            expected_topological_order =
-                alg_common::load_list<gl::id_type>(sut.order(), order_file_path);
+                data_path / "topological_sort_directed_acyclic_order.txt";
+            expected_topological_order = load_list<gl::id_type>(sut.order(), order_file_path);
         }
 
         CAPTURE(sut);
@@ -81,7 +80,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("custom graph") {
             const fs::path gsf_file_path =
-                alg_common::data_path / "topological_sort_directed_not_acyclic_graph.gsf";
+                data_path / "topological_sort_directed_not_acyclic_graph.gsf";
             sut = gl::io::load<sut_type>(gsf_file_path);
         }
 

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -20,7 +20,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("acyclic graph") {
         sut_type sut;
-        std::vector<gl::types::id_type> expected_topological_order;
+        std::vector<gl::id_type> expected_topological_order;
 
         SUBCASE("path graph") {
             sut = gl::topology::path<sut_type>(constants::n_elements_alg);
@@ -37,8 +37,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             expected_topological_order.push_back(constants::vertex_id_1);
             expected_topological_order.push_back(additional_vertex.id());
-            for (gl::types::id_type id = constants::vertex_id_2; id < constants::n_elements_alg;
-                 id++)
+            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++)
                 expected_topological_order.push_back(id);
         }
 
@@ -57,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path order_file_path =
                 alg_common::data_path / "topological_sort_directed_acyclic_order.txt";
             expected_topological_order =
-                alg_common::load_list<gl::types::id_type>(sut.order(), order_file_path);
+                alg_common::load_list<gl::id_type>(sut.order(), order_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -33,11 +33,11 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut = gl::topology::path<sut_type>(constants::n_elements_alg);
 
             const auto& additional_vertex = sut.add_vertex();
-            sut.add_edge(additional_vertex.id(), constants::vertex_id_2);
+            sut.add_edge(additional_vertex.id(), constants::v2_id);
 
-            expected_topological_order.push_back(constants::vertex_id_1);
+            expected_topological_order.push_back(constants::v1_id);
             expected_topological_order.push_back(additional_vertex.id());
-            for (gl::id_type id = constants::vertex_id_2; id < constants::n_elements_alg; id++)
+            for (gl::id_type id = constants::v2_id; id < constants::n_elements_alg; id++)
                 expected_topological_order.push_back(id);
         }
 

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -19,7 +19,7 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_conversion");
 
-constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
+constexpr auto get_id = [](auto&& element) -> gl::id_type { return element.id(); };
 
 struct test_conversion {
     using property_type = gl::types::name_property;
@@ -72,8 +72,8 @@ struct test_conversion {
                 CHECK_EQ(graph.get_edge_properties(eid), "edge_" + std::to_string(eid));
     }
 
-    gl::types::size_type test_order{5};
-    std::vector<gl::types::homogeneous_pair<gl::types::id_type>> test_edges{
+    gl::size_type test_order{5};
+    std::vector<gl::homogeneous_pair<gl::id_type>> test_edges{
         {0, 1},
         {0, 2},
         {1, 3},

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -22,7 +22,7 @@ TEST_SUITE_BEGIN("test_conversion");
 constexpr auto get_id = [](auto&& element) -> gl::id_type { return element.id(); };
 
 struct test_conversion {
-    using property_type = gl::types::name_property;
+    using property_type = gl::name_property;
 
     template <gl::traits::c_graph GraphType>
     [[nodiscard]] GraphType create_test_graph() {
@@ -125,36 +125,36 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     graph_params_template,
     std::tuple<
         gl::directed_t,
-        gl::types::empty_properties,
-        gl::types::empty_properties>, // directed graph, no properties
+        gl::empty_properties,
+        gl::empty_properties>, // directed graph, no properties
     std::tuple<
         gl::undirected_t,
-        gl::types::empty_properties,
-        gl::types::empty_properties>, // undirected graph, no properties
+        gl::empty_properties,
+        gl::empty_properties>, // undirected graph, no properties
     std::tuple<
         gl::directed_t,
-        gl::types::name_property,
-        gl::types::empty_properties>, // directed graph, vertex properties
+        gl::name_property,
+        gl::empty_properties>, // directed graph, vertex properties
     std::tuple<
         gl::undirected_t,
-        gl::types::name_property,
-        gl::types::empty_properties>, // undirected graph, vertex properties
+        gl::name_property,
+        gl::empty_properties>, // undirected graph, vertex properties
     std::tuple<
         gl::directed_t,
-        gl::types::empty_properties,
-        gl::types::name_property>, // directed graph, edge properties
+        gl::empty_properties,
+        gl::name_property>, // directed graph, edge properties
     std::tuple<
         gl::undirected_t,
-        gl::types::empty_properties,
-        gl::types::name_property>, // undirected graph, edge properties
+        gl::empty_properties,
+        gl::name_property>, // undirected graph, edge properties
     std::tuple<
         gl::directed_t,
-        gl::types::name_property,
-        gl::types::name_property>, // directed graph, all properties
+        gl::name_property,
+        gl::name_property>, // directed graph, all properties
     std::tuple<
         gl::undirected_t,
-        gl::types::name_property,
-        gl::types::name_property> // undirected graph, all properties
+        gl::name_property,
+        gl::name_property> // undirected graph, all properties
 );
 
 TEST_SUITE_END(); // test_conversion

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -79,27 +79,27 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("accessing properties should throw for invalid edges") {
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 EdgeType(constants::invalid_id, fixture.v1, fixture.v2, used).properties()
             ),
             std::logic_error
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 EdgeType(fixture.id1, constants::invalid_id, fixture.v2, used).properties()
             ),
             std::logic_error
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 EdgeType(fixture.id1, fixture.v1, constants::invalid_id, used).properties()
             ),
             std::logic_error
         );
 
-        CHECK_THROWS_AS(func::discard_result(EdgeType::invalid().properties()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(EdgeType::invalid().properties()), std::logic_error);
     }
 }
 
@@ -145,9 +145,7 @@ TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directi
     }
 
     SUBCASE("incident_vertex should throw if input vertex is not incident with the edge") {
-        CHECK_THROWS_AS(
-            func::discard_result(sut.incident_vertex(fixture.v3)), std::invalid_argument
-        );
+        CHECK_THROWS_AS(discard_result(sut.incident_vertex(fixture.v3)), std::invalid_argument);
     }
 
     SUBCASE("incident_vertex should return the vertex incident with the input vertex") {

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -13,12 +13,12 @@ TEST_SUITE_BEGIN("test_edge_descriptor");
 struct test_edge_descriptor {
     using vertex_type = gl::vertex_descriptor<>;
 
-    static constexpr gl::types::id_type id1 = constants::first_element_idx;
-    static constexpr gl::types::id_type id2 = id1 + constants::one;
+    static constexpr gl::id_type id1 = constants::first_element_idx;
+    static constexpr gl::id_type id2 = id1 + constants::one;
 
-    static constexpr gl::types::id_type v1 = constants::vertex_id_1;
-    static constexpr gl::types::id_type v2 = constants::vertex_id_2;
-    static constexpr gl::types::id_type v3 = constants::vertex_id_3;
+    static constexpr gl::id_type v1 = constants::vertex_id_1;
+    static constexpr gl::id_type v2 = constants::vertex_id_2;
+    static constexpr gl::id_type v3 = constants::vertex_id_3;
 };
 
 TEST_CASE_FIXTURE(

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -13,12 +13,12 @@ TEST_SUITE_BEGIN("test_edge_descriptor");
 struct test_edge_descriptor {
     using vertex_type = gl::vertex_descriptor<>;
 
-    static constexpr gl::id_type id1 = constants::first_element_idx;
+    static constexpr gl::id_type id1 = constants::first_elem_idx;
     static constexpr gl::id_type id2 = id1 + constants::one;
 
-    static constexpr gl::id_type v1 = constants::vertex_id_1;
-    static constexpr gl::id_type v2 = constants::vertex_id_2;
-    static constexpr gl::id_type v3 = constants::vertex_id_3;
+    static constexpr gl::id_type v1 = constants::v1_id;
+    static constexpr gl::id_type v2 = constants::v2_id;
+    static constexpr gl::id_type v3 = constants::v3_id;
 };
 
 TEST_CASE_FIXTURE(

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -70,7 +70,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     "properties accessing tests", EdgeType, properties_directional_tag_template
 ) {
     test_edge_descriptor fixture;
-    types::used_property used{true};
+    used_property used{true};
 
     SUBCASE("properties should be properly initialized for valid edges") {
         const EdgeType sut{fixture.id1, fixture.v1, fixture.v2, used};
@@ -104,7 +104,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 // TODO: fix .clang-format to split such lines
-TEST_CASE_TEMPLATE_INSTANTIATE(properties_directional_tag_template, gl::directed_edge<types::used_property>, gl::undirected_edge<types::used_property>);
+TEST_CASE_TEMPLATE_INSTANTIATE(properties_directional_tag_template, gl::directed_edge<used_property>, gl::undirected_edge<used_property>);
 
 TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directional_tag_template) {
     test_edge_descriptor fixture{};

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -13,8 +13,8 @@ TEST_SUITE_BEGIN("test_edge_descriptor");
 struct test_edge_descriptor {
     using vertex_type = gl::vertex_descriptor<>;
 
-    static constexpr gl::id_type id1 = constants::first_elem_idx;
-    static constexpr gl::id_type id2 = id1 + constants::one;
+    static constexpr gl::id_type id1 = 0uz;
+    static constexpr gl::id_type id2 = id1 + 1uz;
 
     static constexpr gl::id_type v1 = constants::v1_id;
     static constexpr gl::id_type v2 = constants::v2_id;

--- a/tests/source/gl/test_edge_tags.cpp
+++ b/tests/source/gl/test_edge_tags.cpp
@@ -10,9 +10,9 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_edge_tags");
 
 struct test_edge_tags {
-    static constexpr gl::id_type id = constants::first_element_idx;
-    static constexpr gl::id_type v1 = constants::vertex_id_1;
-    static constexpr gl::id_type v2 = constants::vertex_id_2;
+    static constexpr gl::id_type id = constants::first_elem_idx;
+    static constexpr gl::id_type v1 = constants::v1_id;
+    static constexpr gl::id_type v2 = constants::v2_id;
 };
 
 struct test_directed_edge_tag : test_edge_tags {

--- a/tests/source/gl/test_edge_tags.cpp
+++ b/tests/source/gl/test_edge_tags.cpp
@@ -10,7 +10,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_edge_tags");
 
 struct test_edge_tags {
-    static constexpr gl::id_type id = constants::first_elem_idx;
+    static constexpr gl::id_type id = 0uz;
     static constexpr gl::id_type v1 = constants::v1_id;
     static constexpr gl::id_type v2 = constants::v2_id;
 };

--- a/tests/source/gl/test_edge_tags.cpp
+++ b/tests/source/gl/test_edge_tags.cpp
@@ -10,9 +10,9 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_edge_tags");
 
 struct test_edge_tags {
-    static constexpr gl::types::id_type id = constants::first_element_idx;
-    static constexpr gl::types::id_type v1 = constants::vertex_id_1;
-    static constexpr gl::types::id_type v2 = constants::vertex_id_2;
+    static constexpr gl::id_type id = constants::first_element_idx;
+    static constexpr gl::id_type v1 = constants::vertex_id_1;
+    static constexpr gl::id_type v2 = constants::vertex_id_2;
 };
 
 struct test_directed_edge_tag : test_edge_tags {

--- a/tests/source/gl/test_flat_jagged_vector.cpp
+++ b/tests/source/gl/test_flat_jagged_vector.cpp
@@ -13,7 +13,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_flat_jagged_vector");
 
 struct test_flat_jagged_vector_constructors {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -157,7 +157,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_flat_jagged_vector_comparison {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -206,7 +206,7 @@ TEST_CASE_FIXTURE(test_flat_jagged_vector_comparison, "empty segment_vectors sho
 }
 
 struct test_flat_jagged_vector_capacity {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
     sut_type sut;
 };
 
@@ -386,7 +386,7 @@ TEST_CASE_FIXTURE(test_flat_jagged_vector_capacity, "clear should remove all seg
 }
 
 struct test_segment_vector_accessors {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 
     sut_type sut{
         {1, 2, 3},
@@ -687,7 +687,7 @@ TEST_CASE_FIXTURE(test_segment_vector_accessors, "const back() should return con
 }
 
 struct test_flat_jagged_vector_element_accessors {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 
     std::vector<int> seg0{1, 2, 3};
     std::vector<int> seg1{4, 5};
@@ -871,7 +871,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_flat_jagged_vector_segment_modifiers {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 
     sut_type sut;
     std::vector<int> seg0{1, 2, 3};
@@ -1031,7 +1031,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_flat_jagged_vector_element_modifiers {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
     sut_type sut{
         {1, 2, 3},
         {4, 5}
@@ -1218,7 +1218,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_flat_jagged_vector_complex_operations {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 };
 
 TEST_CASE_FIXTURE(
@@ -1283,7 +1283,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_flat_jagged_vector_iterators {
-    using sut_type = gl::types::flat_jagged_vector<int>;
+    using sut_type = gl::flat_jagged_vector<int>;
 
     sut_type sut{
         {1, 2, 3},

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -311,7 +311,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             vertex_id_list{constants::v1_id, constants::v3_id, constants::v1_id}
         );
 
-        constexpr auto expected_n_vertices = n_vertices - constants::two;
+        constexpr auto expected_n_vertices = n_vertices - 2uz;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
         constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;
@@ -336,7 +336,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
-        constexpr auto expected_n_vertices = n_vertices - constants::two;
+        constexpr auto expected_n_vertices = n_vertices - 2uz;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
         constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -58,7 +58,7 @@ struct test_graph {
                 if (first != second)
                     graph.add_edge(first, second);
 
-        const gl::types::size_type n_unique_edges_in_full_graph =
+        const gl::size_type n_unique_edges_in_full_graph =
             n_incident_edges_for_fully_connected_vertex(graph) * graph.order();
 
         REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
@@ -74,7 +74,7 @@ struct test_graph {
                 if (first < second)
                     graph.add_edge(first, second);
 
-        const gl::types::size_type n_unique_edges_in_full_graph =
+        const gl::size_type n_unique_edges_in_full_graph =
             (n_incident_edges_for_fully_connected_vertex(graph) * graph.order()) / 2;
 
         REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
@@ -86,13 +86,13 @@ struct test_graph {
         REQUIRE(std::ranges::all_of(
             graph.vertex_ids(),
             [&graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
-                const gl::types::id_type vertex_id
+                const gl::id_type vertex_id
             ) { return gl::util::range_size(graph.adjacent_edges(vertex_id)) == expected_n_edges; }
         ));
     }
 
     template <gl::traits::c_instantiation_of<gl::graph> GraphType>
-    gl::types::size_type n_incident_edges_for_fully_connected_vertex(const GraphType& graph) {
+    gl::size_type n_incident_edges_for_fully_connected_vertex(const GraphType& graph) {
         return graph.order() - constants::one_element;
     }
 
@@ -100,9 +100,9 @@ struct test_graph {
     const vertex_type invalid_vertex{constants::invalid_id}; // remove?
 };
 
-using vertex_id_list = std::vector<gl::types::id_type>;
+using vertex_id_list = std::vector<gl::id_type>;
 
-inline constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
+inline constexpr auto get_id = [](auto&& element) -> gl::id_type { return element.id(); };
 
 TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_template) {
     using fixture_type = test_graph<TraitsType>;
@@ -137,12 +137,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             std::out_of_range
         );
 
-        CHECK(std::ranges::all_of(
-            constants::vertex_id_view,
-            [&sut](const gl::types::id_type vertex_id) {
-                return sut.adjacent_edges(vertex_id).empty();
-            }
-        ));
+        CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const gl::id_type vertex_id) {
+            return sut.adjacent_edges(vertex_id).empty();
+        }));
     }
 
     // --- vertex method tests ---
@@ -150,8 +147,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("add_vertex should return a vertex_descriptor with an incremented id and no edges") {
         sut_type sut;
 
-        constexpr gl::types::size_type target_n_vertices = constants::n_elements;
-        for (gl::types::id_type v_id = constants::zero_elements; v_id < target_n_vertices; v_id++) {
+        constexpr gl::size_type target_n_vertices = constants::n_elements;
+        for (gl::id_type v_id = constants::zero_elements; v_id < target_n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
             CHECK_EQ(sut.order(), v_id + constants::one_element);
@@ -249,7 +246,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.remove_vertex(constants::vertex_id_1);
 
-        constexpr gl::types::size_type n_vertices_after_remove =
+        constexpr gl::size_type n_vertices_after_remove =
             constants::n_elements - constants::one_element;
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
@@ -261,7 +258,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         ));
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
-            [&sut, expected_n_incident_edges](const gl::types::id_type vertex_id) {
+            [&sut, expected_n_incident_edges](const gl::id_type vertex_id) {
                 return gl::util::range_size(sut.adjacent_edges(vertex_id))
                     == expected_n_incident_edges;
             }
@@ -284,7 +281,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.remove_vertex(constants::vertex_id_1);
 
-        constexpr gl::types::size_type n_vertices_after_remove =
+        constexpr gl::size_type n_vertices_after_remove =
             constants::n_elements - constants::one_element;
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
@@ -296,7 +293,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         ));
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
-            [&sut, expected_n_incident_edges](const gl::types::id_type vertex_id) {
+            [&sut, expected_n_incident_edges](const gl::id_type vertex_id) {
                 return gl::util::range_size(sut.adjacent_edges(vertex_id))
                     == expected_n_incident_edges;
             }
@@ -451,7 +448,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.size(), constants::zero_elements);
 
             constexpr auto source_id = constants::vertex_id_1;
-            const std::vector<gl::types::id_type> target_id_list{
+            const std::vector<gl::id_type> target_id_list{
                 constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
             };
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -165,7 +165,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto vertex = sut.add_vertex_with(constants::visited);
         REQUIRE_EQ(sut.order(), constants::one_element);
 
-        CHECK_EQ(vertex.id(), constants::vertex_id_1);
+        CHECK_EQ(vertex.id(), constants::v1_id);
         CHECK_EQ(vertex.properties(), constants::visited);
     }
 
@@ -244,7 +244,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
         fixture.init_complete_graph(sut);
 
-        sut.remove_vertex(constants::vertex_id_1);
+        sut.remove_vertex(constants::v1_id);
 
         constexpr gl::size_type n_vertices_after_remove =
             constants::n_elements - constants::one_element;
@@ -254,7 +254,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto vertex_id_view = sut.vertex_ids();
 
         REQUIRE(std::ranges::equal(
-            vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)
+            vertex_id_view, std::views::iota(constants::v1_id, n_vertices_after_remove)
         ));
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
@@ -277,7 +277,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
         fixture.init_complete_graph(sut);
 
-        sut.remove_vertex(constants::vertex_id_1);
+        sut.remove_vertex(constants::v1_id);
 
         constexpr gl::size_type n_vertices_after_remove =
             constants::n_elements - constants::one_element;
@@ -287,7 +287,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto vertex_id_view = sut.vertex_ids();
 
         REQUIRE(std::ranges::equal(
-            vertex_id_view, std::views::iota(constants::vertex_id_1, n_vertices_after_remove)
+            vertex_id_view, std::views::iota(constants::v1_id, n_vertices_after_remove)
         ));
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
@@ -308,7 +308,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         fixture.init_complete_graph(sut);
 
         sut.remove_vertices_from(
-            vertex_id_list{constants::vertex_id_1, constants::vertex_id_3, constants::vertex_id_1}
+            vertex_id_list{constants::v1_id, constants::v3_id, constants::v1_id}
         );
 
         constexpr auto expected_n_vertices = n_vertices - constants::two;
@@ -331,8 +331,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{n_vertices};
         fixture.init_complete_graph(sut);
 
-        const auto v1 = sut.get_vertex(constants::vertex_id_1);
-        const auto v3 = sut.get_vertex(constants::vertex_id_3);
+        const auto v1 = sut.get_vertex(constants::v1_id);
+        const auto v3 = sut.get_vertex(constants::v3_id);
 
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
@@ -355,34 +355,34 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         const auto vertices = sut.vertices();
-        const auto vertex_1 = vertices[constants::vertex_id_1];
-        const auto vertex_2 = vertices[constants::vertex_id_2];
-        const auto vertex_3 = vertices[constants::vertex_id_3];
+        const auto vertex_1 = vertices[constants::v1_id];
+        const auto vertex_2 = vertices[constants::v2_id];
+        const auto vertex_3 = vertices[constants::v3_id];
 
         SUBCASE("add_edge(ids) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
-                sut.add_edge(constants::out_of_range_element_idx, constants::vertex_id_2),
+                sut.add_edge(constants::out_of_range_element_idx, constants::v2_id),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                sut.add_edge(constants::vertex_id_1, constants::out_of_range_element_idx),
+                sut.add_edge(constants::v1_id, constants::out_of_range_element_idx),
                 std::out_of_range
             );
         }
 
         SUBCASE("add_edge(ids) should properly add the new edge") {
-            const auto new_edge = sut.add_edge(constants::vertex_id_1, constants::vertex_id_2);
-            REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-            REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+            const auto new_edge = sut.add_edge(constants::v1_id, constants::v2_id);
+            REQUIRE(new_edge.is_incident_from(constants::v1_id));
+            REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
@@ -405,12 +405,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
@@ -432,8 +432,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
-                    constants::vertex_id_1,
-                    vertex_id_list{constants::vertex_id_2, constants::out_of_range_element_idx}
+                    constants::v1_id,
+                    vertex_id_list{constants::v2_id, constants::out_of_range_element_idx}
                 ),
                 std::out_of_range
             );
@@ -443,9 +443,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("add_edges_from(ids) should properly extend the graph if all ids are valid") {
             REQUIRE_EQ(sut.size(), constants::zero_elements);
 
-            constexpr auto source_id = constants::vertex_id_1;
+            constexpr auto source_id = constants::v1_id;
             const std::vector<gl::id_type> target_id_list{
-                constants::vertex_id_1, constants::vertex_id_2, constants::vertex_id_3
+                constants::v1_id, constants::v2_id, constants::v3_id
             };
 
             sut.add_edges_from(source_id, target_id_list);
@@ -494,8 +494,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
             REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
@@ -504,8 +504,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+            adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::zero_elements);
             CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
@@ -547,20 +547,20 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         gl::graph<properties_traits_type> sut{constants::n_elements};
 
         const auto vertices = sut.vertices();
-        const auto vertex_1 = vertices[constants::vertex_id_1];
-        const auto vertex_2 = vertices[constants::vertex_id_2];
-        const auto vertex_3 = vertices[constants::vertex_id_3];
+        const auto vertex_1 = vertices[constants::v1_id];
+        const auto vertex_2 = vertices[constants::v2_id];
+        const auto vertex_3 = vertices[constants::v3_id];
 
         SUBCASE("add_edge_with(ids, property) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
                 sut.add_edge_with(
-                    constants::out_of_range_element_idx, constants::vertex_id_2, constants::used
+                    constants::out_of_range_element_idx, constants::v2_id, constants::used
                 ),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
                 sut.add_edge_with(
-                    constants::vertex_id_1, constants::out_of_range_element_idx, constants::used
+                    constants::v1_id, constants::out_of_range_element_idx, constants::used
                 ),
                 std::out_of_range
             );
@@ -568,19 +568,19 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge_with(ids, property) should properly add the new edge") {
             const auto new_edge =
-                sut.add_edge_with(constants::vertex_id_1, constants::vertex_id_2, constants::used);
-            REQUIRE(new_edge.is_incident_from(constants::vertex_id_1));
-            REQUIRE(new_edge.is_incident_to(constants::vertex_id_2));
+                sut.add_edge_with(constants::v1_id, constants::v2_id, constants::used);
+            REQUIRE(new_edge.is_incident_from(constants::v1_id));
+            REQUIRE(new_edge.is_incident_to(constants::v2_id));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
@@ -610,12 +610,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
@@ -631,8 +631,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), constants::one_element);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
             REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
@@ -641,8 +641,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), constants::zero_elements);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::vertex_id_1);
-            adjacent_edges_2 = sut.adjacent_edges(constants::vertex_id_2);
+            adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+            adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
             CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::zero_elements);
             CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
@@ -681,8 +681,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("has_edge(vertex, vertex) should throw if one of the vertices is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto vd_1 = sut.get_vertex(constants::vertex_id_1);
-        const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
+        const auto vd_1 = sut.get_vertex(constants::v1_id);
+        const auto vd_2 = sut.get_vertex(constants::v2_id);
 
         CHECK_THROWS_AS(
             discard_result(sut.has_edge(fixture.out_of_range_vertex, vd_2)), std::out_of_range
@@ -696,9 +696,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             "vertices in the graph") {
         sut_type sut{constants::n_elements};
 
-        const auto vd_1 = sut.get_vertex(constants::vertex_id_1);
-        const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
-        const auto vd_3 = sut.get_vertex(constants::vertex_id_3);
+        const auto vd_1 = sut.get_vertex(constants::v1_id);
+        const auto vd_2 = sut.get_vertex(constants::v2_id);
+        const auto vd_3 = sut.get_vertex(constants::v3_id);
 
         sut.add_edge(vd_1, vd_2);
 
@@ -709,7 +709,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("get_edge(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
-        const auto valid_vertex = sut.get_vertex(constants::vertex_id_1);
+        const auto valid_vertex = sut.get_vertex(constants::v1_id);
 
         const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
         CHECK_THROWS_AS(
@@ -727,16 +727,15 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("get_edge(vertex, vertex) should return nullopt if the given vertices are not incident"
     ) {
         sut_type sut{constants::n_elements};
-        CHECK_FALSE(sut.get_edge(
-            sut.get_vertex(constants::vertex_id_1), sut.get_vertex(constants::vertex_id_2)
-        ));
+        CHECK_FALSE(sut.get_edge(sut.get_vertex(constants::v1_id), sut.get_vertex(constants::v2_id))
+        );
     }
 
     SUBCASE("get_edge(vertex, vertex) should return a valid edge if the given vetices are incident"
     ) {
         sut_type sut{constants::n_elements};
-        const auto vd_1 = sut.get_vertex(constants::vertex_id_1);
-        const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
+        const auto vd_1 = sut.get_vertex(constants::v1_id);
+        const auto vd_2 = sut.get_vertex(constants::v2_id);
 
         const auto edge = sut.add_edge(vd_1, vd_2);
 
@@ -758,15 +757,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(
-                sut.get_edges(constants::out_of_range_element_idx, constants::vertex_id_2)
-            ),
+            discard_result(sut.get_edges(constants::out_of_range_element_idx, constants::v2_id)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(
-                sut.get_edges(constants::vertex_id_1, constants::out_of_range_element_idx)
-            ),
+            discard_result(sut.get_edges(constants::v1_id, constants::out_of_range_element_idx)),
             std::out_of_range
         );
     }
@@ -774,7 +769,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("get_edges(id, id) should return an empty vector if the given vertices are not incident"
     ) {
         sut_type sut{constants::n_elements};
-        CHECK(sut.get_edges(constants::vertex_id_1, constants::vertex_id_2).empty());
+        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
     }
 
     SUBCASE("get_edges(id, id) should return a valid edge reference vector if the given vertices "
@@ -783,26 +778,22 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         std::vector<edge_type> expected_edges;
 
         if constexpr (std::same_as<typename sut_type::implementation_tag, gl::impl::list_t>) {
-            for (auto _ = constants::first_element_idx; _ < constants::n_elements; _++)
-                expected_edges.emplace_back(
-                    sut.add_edge(constants::vertex_id_1, constants::vertex_id_2)
-                );
+            for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+                expected_edges.emplace_back(sut.add_edge(constants::v1_id, constants::v2_id));
         }
         else {
-            expected_edges.emplace_back(sut.add_edge(constants::vertex_id_1, constants::vertex_id_2)
-            );
+            expected_edges.emplace_back(sut.add_edge(constants::v1_id, constants::v2_id));
         }
 
-        CHECK(std::ranges::equal(
-            sut.get_edges(constants::vertex_id_1, constants::vertex_id_2), expected_edges
-        ));
+        CHECK(std::ranges::equal(sut.get_edges(constants::v1_id, constants::v2_id), expected_edges)
+        );
 
         if constexpr (gl::traits::c_directed_edge<edge_type>) {
-            CHECK(sut.get_edges(constants::vertex_id_2, constants::vertex_id_2).empty());
+            CHECK(sut.get_edges(constants::v2_id, constants::v2_id).empty());
         }
         else {
             CHECK(std::ranges::equal(
-                sut.get_edges(constants::vertex_id_2, constants::vertex_id_1), expected_edges
+                sut.get_edges(constants::v2_id, constants::v1_id), expected_edges
             ));
         }
     }
@@ -810,8 +801,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("get_edges(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto vd_1 = sut.get_vertex(constants::vertex_id_1);
-        const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
+        const auto vd_1 = sut.get_vertex(constants::v1_id);
+        const auto vd_2 = sut.get_vertex(constants::v2_id);
 
         CHECK_THROWS_AS(
             discard_result(sut.get_edges(fixture.out_of_range_vertex, vd_2)), std::out_of_range
@@ -834,7 +825,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         CHECK_NOTHROW([&sut]() {
             CHECK_EQ(
-                gl::util::range_size(sut.adjacent_edges(constants::first_element_idx)),
+                gl::util::range_size(sut.adjacent_edges(constants::first_elem_idx)),
                 constants::zero_elements
             );
         }());
@@ -850,7 +841,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("adjacent_edges(vertex) should return a proper iterator range for a valid vertex") {
         sut_type sut{constants::one_element};
-        const auto vertex = sut.get_vertex(constants::first_element_idx);
+        const auto vertex = sut.get_vertex(constants::first_elem_idx);
 
         CHECK_NOTHROW([&sut, &vertex]() {
             CHECK_EQ(gl::util::range_size(sut.adjacent_edges(vertex)), constants::zero_elements);
@@ -872,8 +863,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     const auto create_test_p_hypergraph = [&set_properties]() {
         p_sut_type sut(constants::n_elements);
-        sut.add_edge(constants::vertex_id_1, constants::vertex_id_2);
-        sut.add_edge(constants::vertex_id_2, constants::vertex_id_3);
+        sut.add_edge(constants::v1_id, constants::v2_id);
+        sut.add_edge(constants::v2_id, constants::v3_id);
         set_properties(sut);
         return sut;
     };
@@ -892,7 +883,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         }
 
         SUBCASE("graphs with different connections are not equal") {
-            sut2.add_edge(constants::vertex_id_1, constants::vertex_id_3);
+            sut2.add_edge(constants::v1_id, constants::v3_id);
             CHECK_NE(sut1, sut2);
         }
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -314,7 +314,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto expected_n_vertices = n_vertices - constants::two;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
-        constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
+        constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(
             sut.vertices(),
             [&sut, expected_n_adjacent_edges](const auto& vertex) {
@@ -339,7 +339,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto expected_n_vertices = n_vertices - constants::two;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
-        constexpr auto expected_n_adjacent_edges = expected_n_vertices - constants::one;
+        constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(
             sut.vertices(),
             [&sut, expected_n_adjacent_edges](const auto& vertex) {

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -873,7 +873,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             edge_property = std::format("edge_{}", id);
     };
 
-    using p_graph_traits = add_properties<TraitsType, gl::types::name_property>;
+    using p_graph_traits = add_properties<TraitsType, gl::name_property>;
     using p_sut_type = gl::graph<p_graph_traits>;
 
     const auto create_test_p_hypergraph = [&set_properties]() {
@@ -971,28 +971,28 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     property_graph_traits_template,
     gl::list_graph_traits<
         gl::directed_t,
-        gl::types::name_property,
-        gl::types::name_property>, // directed adjacency list
+        gl::name_property,
+        gl::name_property>, // directed adjacency list
     gl::list_graph_traits<
         gl::undirected_t,
-        gl::types::name_property,
-        gl::types::name_property>, // undirected adjacency list
+        gl::name_property,
+        gl::name_property>, // undirected adjacency list
     gl::flat_list_graph_traits<
         gl::directed_t,
-        gl::types::name_property,
-        gl::types::name_property>, // directed flat adjacency list
+        gl::name_property,
+        gl::name_property>, // directed flat adjacency list
     gl::flat_list_graph_traits<
         gl::undirected_t,
-        gl::types::name_property,
-        gl::types::name_property>, // undirected flat adjacency list
+        gl::name_property,
+        gl::name_property>, // undirected flat adjacency list
     gl::matrix_graph_traits<
         gl::directed_t,
-        gl::types::name_property,
-        gl::types::name_property>, // directed adjacency matrix
+        gl::name_property,
+        gl::name_property>, // directed adjacency matrix
     gl::matrix_graph_traits<
         gl::undirected_t,
-        gl::types::name_property,
-        gl::types::name_property> // undirected adjacency matrix
+        gl::name_property,
+        gl::name_property> // undirected adjacency matrix
 );
 
 TEST_SUITE_END(); // test_graph

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -96,7 +96,7 @@ struct test_graph {
         return graph.order() - 1uz;
     }
 
-    const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
+    const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
     const vertex_type invalid_vertex{constants::invalid_id}; // remove?
 };
 
@@ -133,8 +133,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
 
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::out_of_range_element_idx)),
-            std::out_of_range
+            static_cast<void>(sut.get_vertex(constants::out_of_rng_idx)), std::out_of_range
         );
 
         CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const gl::id_type vertex_id) {
@@ -207,7 +206,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto vertex_id) {
             return sut.has_vertex(vertex_id);
         }));
-        CHECK_FALSE(sut.has_vertex(constants::out_of_range_element_idx));
+        CHECK_FALSE(sut.has_vertex(constants::out_of_rng_idx));
     }
 
     SUBCASE("get_vertex should throw if the given id is invalid") {
@@ -268,7 +267,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("remove_vertex(id) should throw if the given id is invalid") {
         sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(sut.remove_vertex(constants::out_of_range_element_idx), std::out_of_range);
+        CHECK_THROWS_AS(sut.remove_vertex(constants::out_of_rng_idx), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should remove the given vertex and align ids of remaining vertices"
@@ -359,12 +358,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge(ids) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
-                sut.add_edge(constants::out_of_range_element_idx, constants::v2_id),
-                std::out_of_range
+                sut.add_edge(constants::out_of_rng_idx, constants::v2_id), std::out_of_range
             );
             CHECK_THROWS_AS(
-                sut.add_edge(constants::v1_id, constants::out_of_range_element_idx),
-                std::out_of_range
+                sut.add_edge(constants::v1_id, constants::out_of_rng_idx), std::out_of_range
             );
         }
 
@@ -423,15 +420,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
-                sut.add_edges_from(constants::out_of_range_element_idx, vertex_id_list{}),
-                std::out_of_range
+                sut.add_edges_from(constants::out_of_rng_idx, vertex_id_list{}), std::out_of_range
             );
             CHECK_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
-                    constants::v1_id,
-                    vertex_id_list{constants::v2_id, constants::out_of_range_element_idx}
+                    constants::v1_id, vertex_id_list{constants::v2_id, constants::out_of_rng_idx}
                 ),
                 std::out_of_range
             );
@@ -551,15 +546,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edge_with(ids, property) should throw if either vertex id is invalid") {
             CHECK_THROWS_AS(
-                sut.add_edge_with(
-                    constants::out_of_range_element_idx, constants::v2_id, constants::used
-                ),
+                sut.add_edge_with(constants::out_of_rng_idx, constants::v2_id, constants::used),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                sut.add_edge_with(
-                    constants::v1_id, constants::out_of_range_element_idx, constants::used
-                ),
+                sut.add_edge_with(constants::v1_id, constants::out_of_rng_idx, constants::used),
                 std::out_of_range
             );
         }
@@ -709,7 +700,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
         const auto valid_vertex = sut.get_vertex(constants::v1_id);
 
-        const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
+        const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
         CHECK_THROWS_AS(
             discard_result(sut.get_edge(valid_vertex, out_of_range_vertex)), std::out_of_range
         );
@@ -755,11 +746,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(constants::out_of_range_element_idx, constants::v2_id)),
+            discard_result(sut.get_edges(constants::out_of_rng_idx, constants::v2_id)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(constants::v1_id, constants::out_of_range_element_idx)),
+            discard_result(sut.get_edges(constants::v1_id, constants::out_of_rng_idx)),
             std::out_of_range
         );
     }
@@ -776,7 +767,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         std::vector<edge_type> expected_edges;
 
         if constexpr (std::same_as<typename sut_type::implementation_tag, gl::impl::list_t>) {
-            for (auto _ = constants::first_elem_idx; _ < constants::n_elements; _++)
+            for (auto _ = 0uz; _ < constants::n_elements; _++)
                 expected_edges.emplace_back(sut.add_edge(constants::v1_id, constants::v2_id));
         }
         else {
@@ -813,17 +804,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            discard_result(sut.adjacent_edges(constants::out_of_range_element_idx)),
-            std::out_of_range
+            discard_result(sut.adjacent_edges(constants::out_of_rng_idx)), std::out_of_range
         );
     }
 
     SUBCASE("adjacent_edges(id) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
 
-        CHECK_NOTHROW([&sut]() {
-            CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::first_elem_idx)), 0uz);
-        }());
+        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.adjacent_edges(0uz)), 0uz); }());
     }
 
     SUBCASE("adjacent_edges(vertex) should throw if the vertex is invalid") {
@@ -836,7 +824,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("adjacent_edges(vertex) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
-        const auto vertex = sut.get_vertex(constants::first_elem_idx);
+        const auto vertex = sut.get_vertex(0uz);
 
         CHECK_NOTHROW([&sut, &vertex]() {
             CHECK_EQ(gl::util::range_size(sut.adjacent_edges(vertex)), 0uz);
@@ -929,8 +917,7 @@ TEST_CASE_TEMPLATE_DEFINE("properties getter tests", TraitsType, property_graph_
     }
 
     CHECK_THROWS_AS(
-        discard_result(sut.get_vertex_properties(constants::out_of_range_element_idx)),
-        std::out_of_range
+        discard_result(sut.get_vertex_properties(constants::out_of_rng_idx)), std::out_of_range
     );
 
     auto emap = sut.edge_properties_map();
@@ -942,8 +929,7 @@ TEST_CASE_TEMPLATE_DEFINE("properties getter tests", TraitsType, property_graph_
     }
 
     CHECK_THROWS_AS(
-        discard_result(sut.get_edge_properties(constants::out_of_range_element_idx)),
-        std::out_of_range
+        discard_result(sut.get_edge_properties(constants::out_of_rng_idx)), std::out_of_range
     );
 }
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -93,7 +93,7 @@ struct test_graph {
 
     template <gl::traits::c_instantiation_of<gl::graph> GraphType>
     gl::size_type n_incident_edges_for_fully_connected_vertex(const GraphType& graph) {
-        return graph.order() - constants::one_element;
+        return graph.order() - 1uz;
     }
 
     const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
@@ -118,8 +118,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     SUBCASE("graph should be initialized with no vertices and no edges by default") {
         sut_type sut;
 
-        CHECK_EQ(sut.order(), constants::zero_elements);
-        CHECK_EQ(sut.size(), constants::zero_elements);
+        CHECK_EQ(sut.order(), 0uz);
+        CHECK_EQ(sut.size(), 0uz);
     }
 
     SUBCASE("graph constructed with n_vertices parameter should contain n_vertices vertices and no "
@@ -148,10 +148,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut;
 
         constexpr gl::size_type target_n_vertices = constants::n_elements;
-        for (gl::id_type v_id = constants::zero_elements; v_id < target_n_vertices; v_id++) {
+        for (gl::id_type v_id = 0uz; v_id < target_n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
-            CHECK_EQ(sut.order(), v_id + constants::one_element);
+            CHECK_EQ(sut.order(), v_id + 1uz);
             CHECK(sut.adjacent_edges(v_id).empty());
         }
 
@@ -163,7 +163,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         gl::graph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::visited);
-        REQUIRE_EQ(sut.order(), constants::one_element);
+        REQUIRE_EQ(sut.order(), 1uz);
 
         CHECK_EQ(vertex.id(), constants::v1_id);
         CHECK_EQ(vertex.properties(), constants::visited);
@@ -174,7 +174,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut.add_vertices(constants::n_elements);
 
         CHECK_EQ(sut.order(), constants::n_elements);
-        CHECK_EQ(sut.size(), constants::zero_elements);
+        CHECK_EQ(sut.size(), 0uz);
     }
 
     SUBCASE("add_vertices_with should properly extend the current adjacency list with the given "
@@ -190,7 +190,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut.add_vertices_with(properties_list);
 
         REQUIRE_EQ(sut.order(), expected_n_vertices);
-        CHECK_EQ(sut.size(), constants::zero_elements);
+        CHECK_EQ(sut.size(), 0uz);
 
         CHECK(std::ranges::equal(
             sut.vertices(),
@@ -246,8 +246,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.remove_vertex(constants::v1_id);
 
-        constexpr gl::size_type n_vertices_after_remove =
-            constants::n_elements - constants::one_element;
+        constexpr gl::size_type n_vertices_after_remove = constants::n_elements - 1uz;
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
 
@@ -279,8 +278,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         sut.remove_vertex(constants::v1_id);
 
-        constexpr gl::size_type n_vertices_after_remove =
-            constants::n_elements - constants::one_element;
+        constexpr gl::size_type n_vertices_after_remove = constants::n_elements - 1uz;
         const auto expected_n_incident_edges =
             fixture.n_incident_edges_for_fully_connected_vertex(sut);
 
@@ -302,7 +300,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("remove_vetices_from(ids) should properly remove elements at given indices (ignoring "
             "duplicate indices)") {
-        constexpr auto n_vertices = constants::n_elements + constants::one_element;
+        constexpr auto n_vertices = constants::n_elements + 1uz;
 
         sut_type sut{n_vertices};
         fixture.init_complete_graph(sut);
@@ -326,7 +324,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("remove_vetices_from(vertices) should properly remove elements at given indices "
             "(ignoring duplicate vertex references)") {
-        constexpr auto n_vertices = constants::n_elements + constants::one_element;
+        constexpr auto n_vertices = constants::n_elements + 1uz;
 
         sut_type sut{n_vertices};
         fixture.init_complete_graph(sut);
@@ -375,21 +373,21 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_from(constants::v1_id));
             REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
             }
         }
 
@@ -403,32 +401,32 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_from(vertex_1.id()));
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
             }
         }
 
         SUBCASE("add_edges_from(ids) should throw if any id is invalid and not extend the graph") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(constants::out_of_range_element_idx, vertex_id_list{}),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -437,11 +435,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
         }
 
         SUBCASE("add_edges_from(ids) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             constexpr auto source_id = constants::v1_id;
             const std::vector<gl::id_type> target_id_list{
@@ -458,13 +456,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         SUBCASE("add_edges_from(vertices) should throw if any vertex is invalid and not extend the "
                 "graph") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(fixture.out_of_range_vertex, std::vector<vertex_type>{}),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -472,11 +470,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
         }
 
         SUBCASE("add_edges_from(vertices) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             const auto source = vertex_1;
             const std::vector<vertex_type> target_list{vertex_1, vertex_2, vertex_3};
@@ -492,27 +490,27 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
             const auto added_edge = sut.add_edge(vertex_1, vertex_2);
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
-                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
 
             adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::zero_elements);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 0uz);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             const auto edge_1 = sut.add_edge(vertex_1, vertex_2);
             const auto edge_2 = sut.add_edge(vertex_2, vertex_3);
@@ -522,7 +520,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge(vertex_1, vertex_4);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements + constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::n_elements + 1uz);
 
             std::vector<edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -533,7 +531,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.size(), constants::one_element);
+            CHECK_EQ(sut.size(), 1uz);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
@@ -573,21 +571,21 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_to(constants::v2_id));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
             }
         }
 
@@ -608,48 +606,48 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
             }
         }
 
         SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
             const auto added_edge = sut.add_edge_with(vertex_1, vertex_2, constants::used);
 
-            REQUIRE_EQ(sut.size(), constants::one_element);
+            REQUIRE_EQ(sut.size(), 1uz);
 
             auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), constants::one_element);
+            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
-                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), constants::one_element);
+                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.size(), constants::zero_elements);
+            CHECK_EQ(sut.size(), 0uz);
 
             adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
             adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), constants::zero_elements);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_2), constants::zero_elements);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 0uz);
+            CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.size(), constants::zero_elements);
+            REQUIRE_EQ(sut.size(), 0uz);
 
             const auto edge_1 = sut.add_edge_with(vertex_1, vertex_2, constants::not_used);
             const auto edge_2 = sut.add_edge_with(vertex_2, vertex_3, constants::not_used);
@@ -659,7 +657,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge_with(vertex_1, vertex_4, constants::used);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements + constants::one_element);
+            REQUIRE_EQ(sut.size(), constants::n_elements + 1uz);
 
             const std::vector<property_edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -670,7 +668,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.size(), constants::one_element);
+            CHECK_EQ(sut.size(), 1uz);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
@@ -821,13 +819,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     }
 
     SUBCASE("adjacent_edges(id) should return a proper iterator range for a valid vertex") {
-        sut_type sut{constants::one_element};
+        sut_type sut{1uz};
 
         CHECK_NOTHROW([&sut]() {
-            CHECK_EQ(
-                gl::util::range_size(sut.adjacent_edges(constants::first_elem_idx)),
-                constants::zero_elements
-            );
+            CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::first_elem_idx)), 0uz);
         }());
     }
 
@@ -840,11 +835,11 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     }
 
     SUBCASE("adjacent_edges(vertex) should return a proper iterator range for a valid vertex") {
-        sut_type sut{constants::one_element};
+        sut_type sut{1uz};
         const auto vertex = sut.get_vertex(constants::first_elem_idx);
 
         CHECK_NOTHROW([&sut, &vertex]() {
-            CHECK_EQ(gl::util::range_size(sut.adjacent_edges(vertex)), constants::zero_elements);
+            CHECK_EQ(gl::util::range_size(sut.adjacent_edges(vertex)), 0uz);
         }());
     }
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -159,7 +159,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
-        using properties_traits_type = add_vertex_property<traits_type, types::visited_property>;
+        using properties_traits_type = add_vertex_property<traits_type, visited_property>;
         gl::graph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::visited);
@@ -179,10 +179,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
     SUBCASE("add_vertices_with should properly extend the current adjacency list with the given "
             "properties") {
-        using properties_traits_type = add_vertex_property<traits_type, types::visited_property>;
+        using properties_traits_type = add_vertex_property<traits_type, visited_property>;
         gl::graph<properties_traits_type> sut;
 
-        const std::vector<types::visited_property> properties_list{
+        const std::vector<visited_property> properties_list{
             constants::visited, constants::not_visited, constants::visited
         };
         const auto expected_n_vertices = properties_list.size();
@@ -546,7 +546,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
     }
 
     SUBCASE("edge method tests for non-default properties type") {
-        using properties_traits_type = add_edge_property<traits_type, types::used_property>;
+        using properties_traits_type = add_edge_property<traits_type, used_property>;
         using property_edge_type = typename properties_traits_type::edge_type;
         gl::graph<properties_traits_type> sut{constants::n_elements};
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -264,9 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             }
         ));
 
-        CHECK_THROWS_AS(
-            func::discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should throw if the given id is invalid") {
@@ -299,9 +297,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             }
         ));
 
-        CHECK_THROWS_AS(
-            func::discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vetices_from(ids) should properly remove elements at given indices (ignoring "
@@ -689,10 +685,10 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(fixture.out_of_range_vertex, vd_2)), std::out_of_range
+            discard_result(sut.has_edge(fixture.out_of_range_vertex, vd_2)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.has_edge(vd_1, fixture.out_of_range_vertex)), std::out_of_range
+            discard_result(sut.has_edge(vd_1, fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -717,13 +713,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
         const vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
         CHECK_THROWS_AS(
-            func::discard_result(sut.get_edge(valid_vertex, out_of_range_vertex)), std::out_of_range
+            discard_result(sut.get_edge(valid_vertex, out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.get_edge(out_of_range_vertex, valid_vertex)), std::out_of_range
+            discard_result(sut.get_edge(out_of_range_vertex, valid_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.get_edge(out_of_range_vertex, out_of_range_vertex)),
+            discard_result(sut.get_edge(out_of_range_vertex, out_of_range_vertex)),
             std::out_of_range
         );
     }
@@ -762,13 +758,13 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 sut.get_edges(constants::out_of_range_element_idx, constants::vertex_id_2)
             ),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 sut.get_edges(constants::vertex_id_1, constants::out_of_range_element_idx)
             ),
             std::out_of_range
@@ -818,19 +814,17 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.get_edges(fixture.out_of_range_vertex, vd_2)),
-            std::out_of_range
+            discard_result(sut.get_edges(fixture.out_of_range_vertex, vd_2)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.get_edges(vd_1, fixture.out_of_range_vertex)),
-            std::out_of_range
+            discard_result(sut.get_edges(vd_1, fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
     SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            func::discard_result(sut.adjacent_edges(constants::out_of_range_element_idx)),
+            discard_result(sut.adjacent_edges(constants::out_of_range_element_idx)),
             std::out_of_range
         );
     }
@@ -850,7 +844,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.adjacent_edges(fixture.out_of_range_vertex)), std::out_of_range
+            discard_result(sut.adjacent_edges(fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -949,7 +943,7 @@ TEST_CASE_TEMPLATE_DEFINE("properties getter tests", TraitsType, property_graph_
     }
 
     CHECK_THROWS_AS(
-        func::discard_result(sut.get_vertex_properties(constants::out_of_range_element_idx)),
+        discard_result(sut.get_vertex_properties(constants::out_of_range_element_idx)),
         std::out_of_range
     );
 
@@ -962,7 +956,7 @@ TEST_CASE_TEMPLATE_DEFINE("properties getter tests", TraitsType, property_graph_
     }
 
     CHECK_THROWS_AS(
-        func::discard_result(sut.get_edge_properties(constants::out_of_range_element_idx)),
+        discard_result(sut.get_edge_properties(constants::out_of_range_element_idx)),
         std::out_of_range
     );
 }

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -88,7 +88,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph file io tests", SutType, directional_tag_sut_te
         gl::io::save(fixture.sut_out, fixture.path);
         const auto sut_in = gl::io::load<sut_type>(fixture.path);
 
-        io_common::verify_graph_structure(sut_in, fixture.sut_out);
+        verify_graph_structure(sut_in, fixture.sut_out);
     }
 
     SUBCASE("file io should properly save and load a graph in a gsf format with vertex properties"
@@ -96,16 +96,16 @@ TEST_CASE_TEMPLATE_DEFINE("graph file io tests", SutType, directional_tag_sut_te
         gl::io::save(fixture.sut_out, fixture.path, {gl::io::with_vertex_properties});
         const auto sut_in = gl::io::load<sut_type>(fixture.path);
 
-        io_common::verify_graph_structure(sut_in, fixture.sut_out);
-        io_common::verify_vertex_properties(sut_in, fixture.sut_out);
+        verify_graph_structure(sut_in, fixture.sut_out);
+        verify_vertex_properties(sut_in, fixture.sut_out);
     }
 
     SUBCASE("file io should properly save and load a graph in a gsf format with edge properties") {
         gl::io::save(fixture.sut_out, fixture.path, {gl::io::with_edge_properties});
         const auto sut_in = gl::io::load<sut_type>(fixture.path);
 
-        io_common::verify_graph_structure(sut_in, fixture.sut_out);
-        io_common::verify_edge_properties(sut_in, fixture.sut_out);
+        verify_graph_structure(sut_in, fixture.sut_out);
+        verify_edge_properties(sut_in, fixture.sut_out);
     }
 
     SUBCASE("file io should properly save and load a graph in a gsf format with vertex and edge "
@@ -113,9 +113,9 @@ TEST_CASE_TEMPLATE_DEFINE("graph file io tests", SutType, directional_tag_sut_te
         gl::io::save(fixture.sut_out, fixture.path, {gl::io::with_properties});
         const auto sut_in = gl::io::load<sut_type>(fixture.path);
 
-        io_common::verify_graph_structure(sut_in, fixture.sut_out);
-        io_common::verify_vertex_properties(sut_in, fixture.sut_out);
-        io_common::verify_edge_properties(sut_in, fixture.sut_out);
+        verify_graph_structure(sut_in, fixture.sut_out);
+        verify_vertex_properties(sut_in, fixture.sut_out);
+        verify_edge_properties(sut_in, fixture.sut_out);
     }
 }
 

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -36,8 +36,7 @@ TEST_SUITE_BEGIN("test_graph_file_io");
 // Tests covering only the io functionality with the graph specification format enabled
 
 struct test_graph_file_io {
-    using traits_type =
-        gl::graph_traits<gl::directed_t, gl::types::name_property, gl::types::name_property>;
+    using traits_type = gl::graph_traits<gl::directed_t, gl::name_property, gl::name_property>;
     using sut_type = gl::graph<traits_type>;
 
     test_graph_file_io() {

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -56,7 +56,7 @@ struct test_graph_file_io {
         fs::remove(path);
     }
 
-    const gl::types::size_type n_vertices = 5ull;
+    const gl::size_type n_vertices = 5ull;
     sut_type sut_out;
 
     fs::path path{"test_directed_graph_file_io.gsf"};

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -79,7 +79,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph file io tests", SutType, directional_tag_sut_te
 
     SUBCASE("load shoul throw if a file does not exist") {
         GL_REQUIRE_THROWS_FS_ERROR(
-            func::discard_result(gl::io::load<SutType>(fixture.path)),
+            discard_result(gl::io::load<SutType>(fixture.path)),
             std::errc::no_such_file_or_directory
         );
     }

--- a/tests/source/gl/test_graph_incidence.cpp
+++ b/tests/source/gl/test_graph_incidence.cpp
@@ -17,15 +17,15 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
     const auto vd_1 = sut.get_vertex(constants::v1_id);
     const auto vd_2 = sut.get_vertex(constants::v2_id);
     const auto vd_3 = sut.get_vertex(constants::v3_id);
-    vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
+    vertex_type out_of_range_vertex{constants::out_of_rng_idx};
 
     SUBCASE("are_incident(vertex_id, vertex_id) should throw for out of range vertex ids") {
         CHECK_THROWS_AS(
-            discard_result(sut.are_incident(constants::out_of_range_element_idx, constants::v2_id)),
+            discard_result(sut.are_incident(constants::out_of_rng_idx, constants::v2_id)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.are_incident(constants::v1_id, constants::out_of_range_element_idx)),
+            discard_result(sut.are_incident(constants::v1_id, constants::out_of_rng_idx)),
             std::out_of_range
         );
     }

--- a/tests/source/gl/test_graph_incidence.cpp
+++ b/tests/source/gl/test_graph_incidence.cpp
@@ -21,13 +21,13 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
 
     SUBCASE("are_incident(vertex_id, vertex_id) should throw for out of range vertex ids") {
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 sut.are_incident(constants::out_of_range_element_idx, constants::vertex_id_2)
             ),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(
+            discard_result(
                 sut.are_incident(constants::vertex_id_1, constants::out_of_range_element_idx)
             ),
             std::out_of_range
@@ -55,14 +55,14 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
     SUBCASE("are_incident(vertex, vertex) should throw if at least one of the vertices is invalid"
     ) {
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(out_of_range_vertex, out_of_range_vertex)),
+            discard_result(sut.are_incident(out_of_range_vertex, out_of_range_vertex)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(out_of_range_vertex, vd_2)), std::out_of_range
+            discard_result(sut.are_incident(out_of_range_vertex, vd_2)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, out_of_range_vertex)), std::out_of_range
+            discard_result(sut.are_incident(vd_1, out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -87,17 +87,17 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const auto edge = sut.add_edge(vd_1, vd_2);
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
+            discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
+            discard_result(sut.are_incident(out_of_range_vertex, edge)), std::out_of_range
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
+            discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
+            discard_result(sut.are_incident(edge, out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -105,17 +105,17 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const typename SutType::edge_type invalid_edge{constants::invalid_id, vd_1.id(), vd_2.id()};
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
+            discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
+            discard_result(sut.are_incident(vd_1, invalid_edge)), std::invalid_argument
         );
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
+            discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
+            discard_result(sut.are_incident(invalid_edge, vd_2)), std::invalid_argument
         );
     }
 
@@ -135,10 +135,10 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
         const typename SutType::edge_type invalid_edge{constants::invalid_id, vd_1.id(), vd_2.id()};
 
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(edge, invalid_edge)), std::invalid_argument
+            discard_result(sut.are_incident(edge, invalid_edge)), std::invalid_argument
         );
         CHECK_THROWS_AS(
-            func::discard_result(sut.are_incident(invalid_edge, edge)), std::invalid_argument
+            discard_result(sut.are_incident(invalid_edge, edge)), std::invalid_argument
         );
     }
 

--- a/tests/source/gl/test_graph_incidence.cpp
+++ b/tests/source/gl/test_graph_incidence.cpp
@@ -14,22 +14,18 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
 
     SutType sut{constants::n_elements};
 
-    const auto vd_1 = sut.get_vertex(constants::vertex_id_1);
-    const auto vd_2 = sut.get_vertex(constants::vertex_id_2);
-    const auto vd_3 = sut.get_vertex(constants::vertex_id_3);
+    const auto vd_1 = sut.get_vertex(constants::v1_id);
+    const auto vd_2 = sut.get_vertex(constants::v2_id);
+    const auto vd_3 = sut.get_vertex(constants::v3_id);
     vertex_type out_of_range_vertex{constants::out_of_range_element_idx};
 
     SUBCASE("are_incident(vertex_id, vertex_id) should throw for out of range vertex ids") {
         CHECK_THROWS_AS(
-            discard_result(
-                sut.are_incident(constants::out_of_range_element_idx, constants::vertex_id_2)
-            ),
+            discard_result(sut.are_incident(constants::out_of_range_element_idx, constants::v2_id)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(
-                sut.are_incident(constants::vertex_id_1, constants::out_of_range_element_idx)
-            ),
+            discard_result(sut.are_incident(constants::v1_id, constants::out_of_range_element_idx)),
             std::out_of_range
         );
     }
@@ -45,11 +41,11 @@ TEST_CASE_TEMPLATE_DEFINE("incidence functions tests", SutType, graph_type_templ
             "the given vertices") {
         sut.add_edge(vd_1, vd_2);
 
-        CHECK(sut.are_incident(constants::vertex_id_1, constants::vertex_id_2));
-        CHECK(sut.are_incident(constants::vertex_id_2, constants::vertex_id_1));
+        CHECK(sut.are_incident(constants::v1_id, constants::v2_id));
+        CHECK(sut.are_incident(constants::v2_id, constants::v1_id));
 
-        CHECK_FALSE(sut.are_incident(constants::vertex_id_1, constants::vertex_id_3));
-        CHECK_FALSE(sut.are_incident(constants::vertex_id_2, constants::vertex_id_3));
+        CHECK_FALSE(sut.are_incident(constants::v1_id, constants::v3_id));
+        CHECK_FALSE(sut.are_incident(constants::v2_id, constants::v3_id));
     }
 
     SUBCASE("are_incident(vertex, vertex) should throw if at least one of the vertices is invalid"

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -16,8 +16,7 @@ TEST_SUITE_BEGIN("test_graph_io");
 // Tests covering only the io functionality with the graph specification format enabled
 
 struct test_directed_graph_io {
-    using traits_type =
-        gl::graph_traits<gl::directed_t, gl::types::name_property, gl::types::name_property>;
+    using traits_type = gl::graph_traits<gl::directed_t, gl::name_property, gl::name_property>;
     using sut_type = gl::graph<traits_type>;
 
     test_directed_graph_io() {
@@ -60,7 +59,7 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << sut_out;
 
     using not_readable_vp_traits =
-        gl::graph_traits<gl::directed_t, std::monostate, gl::types::name_property>;
+        gl::graph_traits<gl::directed_t, std::monostate, gl::name_property>;
     gl::graph<not_readable_vp_traits> invalid_sut_in;
 
     CHECK_THROWS_AS(ss >> invalid_sut_in, std::ios_base::failure);
@@ -73,7 +72,7 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_edge_properties << sut_out;
 
     using not_readable_vp_traits =
-        gl::graph_traits<gl::directed_t, gl::types::name_property, std::monostate>;
+        gl::graph_traits<gl::directed_t, gl::name_property, std::monostate>;
     gl::graph<not_readable_vp_traits> invalid_sut_in;
 
     CHECK_THROWS_AS(ss >> invalid_sut_in, std::ios_base::failure);
@@ -126,8 +125,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_graph_io {
-    using traits_type =
-        gl::graph_traits<gl::undirected_t, gl::types::name_property, gl::types::name_property>;
+    using traits_type = gl::graph_traits<gl::undirected_t, gl::name_property, gl::name_property>;
     using sut_type = gl::graph<traits_type>;
 
     test_undirected_graph_io() {
@@ -171,7 +169,7 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << sut_out;
 
     using not_readable_vp_traits =
-        gl::graph_traits<gl::undirected_t, std::monostate, gl::types::name_property>;
+        gl::graph_traits<gl::undirected_t, std::monostate, gl::name_property>;
     gl::graph<not_readable_vp_traits> invalid_sut_in;
 
     CHECK_THROWS_AS(ss >> invalid_sut_in, std::ios_base::failure);
@@ -184,7 +182,7 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_edge_properties << sut_out;
 
     using not_readable_vp_traits =
-        gl::graph_traits<gl::undirected_t, gl::types::name_property, std::monostate>;
+        gl::graph_traits<gl::undirected_t, gl::name_property, std::monostate>;
     gl::graph<not_readable_vp_traits> invalid_sut_in;
 
     CHECK_THROWS_AS(ss >> invalid_sut_in, std::ios_base::failure);

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -86,7 +86,7 @@ TEST_CASE_FIXTURE(
     ss << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -96,8 +96,8 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_vertex_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_vertex_properties(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -107,8 +107,8 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_edge_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_edge_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_edge_properties(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -119,9 +119,9 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << gl::io::with_edge_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_vertex_properties(sut_in, sut_out);
-    io_common::verify_edge_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_vertex_properties(sut_in, sut_out);
+    verify_edge_properties(sut_in, sut_out);
 }
 
 struct test_undirected_graph_io {
@@ -196,7 +196,7 @@ TEST_CASE_FIXTURE(
     ss << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -206,8 +206,8 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_vertex_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_vertex_properties(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -217,8 +217,8 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_edge_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_edge_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_edge_properties(sut_in, sut_out);
 }
 
 TEST_CASE_FIXTURE(
@@ -229,9 +229,9 @@ TEST_CASE_FIXTURE(
     ss << gl::io::with_vertex_properties << gl::io::with_edge_properties << sut_out;
     ss >> sut_in;
 
-    io_common::verify_graph_structure(sut_in, sut_out);
-    io_common::verify_vertex_properties(sut_in, sut_out);
-    io_common::verify_edge_properties(sut_in, sut_out);
+    verify_graph_structure(sut_in, sut_out);
+    verify_vertex_properties(sut_in, sut_out);
+    verify_edge_properties(sut_in, sut_out);
 }
 
 TEST_SUITE_END(); // test_graph_io

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -34,7 +34,7 @@ struct test_directed_graph_io {
         }
     }
 
-    const gl::types::size_type n_vertices = 5ull;
+    const gl::size_type n_vertices = 5ull;
     sut_type sut_out;
     sut_type sut_in;
 
@@ -145,7 +145,7 @@ struct test_undirected_graph_io {
         }
     }
 
-    const gl::types::size_type n_vertices = 5ull;
+    const gl::size_type n_vertices = 5ull;
     sut_type sut_out;
     sut_type sut_in;
 

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -79,8 +79,7 @@ template <gl::traits::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_next_only(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
-        const auto next_vertex =
-            graph.get_vertex((source.id() + constants::one_element) % graph.order());
+        const auto next_vertex = graph.get_vertex((source.id() + 1uz) % graph.order());
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == next_vertex) == graph.has_edge(source, vertex);
@@ -92,9 +91,8 @@ template <gl::traits::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_prev_only(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
-        const auto prev_vertex = graph.get_vertex(
-            (source.id() + graph.order() - constants::one_element) % graph.order()
-        );
+        const auto prev_vertex =
+            graph.get_vertex((source.id() + graph.order() - 1uz) % graph.order());
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex) == graph.has_edge(source, vertex);
@@ -106,12 +104,10 @@ template <gl::traits::c_graph GraphType>
 [[nodiscard]] auto is_vertex_connected_to_id_adjacent(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
-        const auto next_vertex =
-            graph.get_vertex((source.id() + constants::one_element) % graph.order());
+        const auto next_vertex = graph.get_vertex((source.id() + 1uz) % graph.order());
 
-        const auto prev_vertex = graph.get_vertex(
-            (source.id() + graph.order() - constants::one_element) % graph.order()
-        );
+        const auto prev_vertex =
+            graph.get_vertex((source.id() + graph.order() - 1uz) % graph.order());
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex or vertex == next_vertex)
@@ -184,7 +180,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto clique = gl::topology::clique<graph_type>(constants::n_elements_top);
 
         const auto expected_n_connections =
-            constants::n_elements_top * (constants::n_elements_top - constants::one_element);
+            constants::n_elements_top * (constants::n_elements_top - 1uz);
         verify_bidir_graph_size(clique, constants::n_elements_top, expected_n_connections);
 
         CHECK(std::ranges::all_of(clique.vertices(), predicate::is_vertex_fully_connected(clique)));
@@ -281,7 +277,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("path(n_vertices) should build a one-way path graph of size n_vertices") {
         const auto path = gl::topology::path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.order() - constants::one_element;
+        const auto n_source_vertices = path.order() - 1uz;
 
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
 
@@ -294,14 +290,14 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("bidirectional_path(n_vertices) should build a two-way path graph of size n_vertices") {
         const auto path = gl::topology::bidirectional_path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.order() - constants::one_element;
+        const auto n_source_vertices = path.order() - 1uz;
 
         verify_graph_size(path, constants::n_elements_top, 2uz * n_source_vertices);
 
         const auto vertices = path.vertices();
 
         REQUIRE(std::ranges::all_of(
-            std::ranges::next(vertices.begin(), constants::one_element),
+            std::ranges::next(vertices.begin(), 1uz),
             std::ranges::next(vertices.begin(), n_source_vertices),
             predicate::is_vertex_connected_to_id_adjacent(path)
         ));
@@ -385,13 +381,13 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CAPTURE(path);
 
-        const auto n_source_vertices = path.order() - constants::one_element;
+        const auto n_source_vertices = path.order() - 1uz;
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
 
         const auto vertices = path.vertices();
 
         REQUIRE(std::ranges::all_of(
-            std::ranges::next(vertices.begin(), constants::one_element),
+            std::ranges::next(vertices.begin(), 1uz),
             std::ranges::next(vertices.begin(), n_source_vertices),
             predicate::is_vertex_connected_to_id_adjacent(path)
         ));

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -11,9 +11,7 @@ TEST_SUITE_BEGIN("test_graph_topology_builders");
 namespace {
 
 template <gl::traits::c_graph GraphType>
-[[nodiscard]] gl::types::size_type n_unique_edges_for_bidir_topology(
-    const gl::types::size_type n_connections
-) {
+[[nodiscard]] gl::size_type n_unique_edges_for_bidir_topology(const gl::size_type n_connections) {
     if constexpr (gl::traits::c_directed_graph<GraphType>)
         return n_connections;
     else
@@ -23,8 +21,8 @@ template <gl::traits::c_graph GraphType>
 template <gl::traits::c_graph GraphType>
 void verify_graph_size(
     const GraphType& graph,
-    const gl::types::size_type expected_n_vertices,
-    const gl::types::size_type expected_n_connections
+    const gl::size_type expected_n_vertices,
+    const gl::size_type expected_n_connections
 ) {
     REQUIRE_EQ(graph.order(), expected_n_vertices);
     REQUIRE_EQ(graph.size(), expected_n_connections);
@@ -33,8 +31,8 @@ void verify_graph_size(
 template <gl::traits::c_graph GraphType>
 void verify_bidir_graph_size(
     const GraphType& graph,
-    const gl::types::size_type expected_n_vertices,
-    const gl::types::size_type expected_n_connections
+    const gl::size_type expected_n_vertices,
+    const gl::size_type expected_n_connections
 ) {
     REQUIRE_EQ(graph.order(), expected_n_vertices);
     REQUIRE_EQ(graph.size(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections));
@@ -146,9 +144,9 @@ template <gl::traits::c_graph GraphType>
 template <gl::traits::c_graph GraphType>
 [[nodiscard]] auto is_biconnected_to_binary_chlidren(const GraphType& graph) {
     using vertex_type = typename GraphType::vertex_type;
-    return [&graph](const gl::types::id_type source_id) {
+    return [&graph](const gl::id_type source_id) {
         const auto target_ids = gl::topology::detail::get_binary_target_ids(source_id);
-        const gl::types::id_type parent_id =
+        const gl::id_type parent_id =
             source_id == constants::zero
                 ? constants::zero
                 : (source_id - constants::one) / constants::two;

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -152,7 +152,7 @@ template <gl::traits::c_graph GraphType>
             // no need to check second as second = first + 1
             auto adjacent_edges = graph.adjacent_edges(source_id);
 
-            return gl::util::range_size(adjacent_edges) == constants::one
+            return gl::util::range_size(adjacent_edges) == 1uz
                and (*std::ranges::begin(adjacent_edges)).incident_vertex(source_id) == parent_id;
         }
 
@@ -318,7 +318,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto bin_tree = gl::topology::regular_binary_tree<graph_type>(constants::depth);
 
         const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
-        const auto expected_n_connections = expected_n_vertices - constants::one;
+        const auto expected_n_connections = expected_n_vertices - 1uz;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(
@@ -332,7 +332,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             gl::topology::bidirectional_regular_binary_tree<graph_type>(constants::depth);
 
         const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
-        const auto expected_n_connections = (expected_n_vertices - constants::one) * constants::two;
+        const auto expected_n_connections = (expected_n_vertices - 1uz) * constants::two;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(
@@ -418,7 +418,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         CAPTURE(bin_tree);
 
         const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
-        const auto expected_n_connections = expected_n_vertices - constants::one;
+        const auto expected_n_connections = expected_n_vertices - 1uz;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -15,7 +15,7 @@ template <gl::traits::c_graph GraphType>
     if constexpr (gl::traits::c_directed_graph<GraphType>)
         return n_connections;
     else
-        return n_connections / constants::two;
+        return n_connections / 2uz;
 }
 
 template <gl::traits::c_graph GraphType>
@@ -197,8 +197,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto expected_n_vertices = constants::n_elements_top + constants::n_elements;
         // `2x` is required to account for adding edges both ways
-        const auto expected_n_connections =
-            constants::two * constants::n_elements_top * constants::n_elements;
+        const auto expected_n_connections = 2uz * constants::n_elements_top * constants::n_elements;
         verify_bidir_graph_size(biclique, expected_n_vertices, expected_n_connections);
 
         const auto vertices = biclique.vertices();
@@ -273,9 +272,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("bidirectional_cycle(n_vertices) should build a two-way cycle graph of size n_vertices"
     ) {
         const auto cycle = gl::topology::bidirectional_cycle<graph_type>(constants::n_elements_top);
-        verify_graph_size(
-            cycle, constants::n_elements_top, constants::two * constants::n_elements_top
-        );
+        verify_graph_size(cycle, constants::n_elements_top, 2uz * constants::n_elements_top);
 
         CHECK(std::ranges::all_of(
             cycle.vertices(), predicate::is_vertex_connected_to_id_adjacent(cycle)
@@ -299,7 +296,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto path = gl::topology::bidirectional_path<graph_type>(constants::n_elements_top);
         const auto n_source_vertices = path.order() - constants::one_element;
 
-        verify_graph_size(path, constants::n_elements_top, constants::two * n_source_vertices);
+        verify_graph_size(path, constants::n_elements_top, 2uz * n_source_vertices);
 
         const auto vertices = path.vertices();
 
@@ -332,7 +329,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             gl::topology::bidirectional_regular_binary_tree<graph_type>(constants::depth);
 
         const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
-        const auto expected_n_connections = (expected_n_vertices - 1uz) * constants::two;
+        const auto expected_n_connections = (expected_n_vertices - 1uz) * 2uz;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
         CHECK(std::ranges::all_of(

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -128,7 +128,7 @@ template <gl::traits::c_graph GraphType>
 
         if (target_ids.first >= graph.order())
             // no need to check second as second = first + 1
-            return gl::util::range_size(graph.adjacent_edges(source)) == constants::zero;
+            return gl::util::range_size(graph.adjacent_edges(source)) == 0uz;
 
         const auto target_1 = graph.get_vertex(target_ids.first);
         const auto target_2 = graph.get_vertex(target_ids.second);
@@ -146,10 +146,7 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const gl::id_type source_id) {
         const auto target_ids = gl::topology::detail::get_binary_target_ids(source_id);
-        const gl::id_type parent_id =
-            source_id == constants::zero
-                ? constants::zero
-                : (source_id - constants::one) / constants::two;
+        const gl::id_type parent_id = source_id == 0uz ? 0uz : (source_id - 1uz) / 2uz;
 
         if (target_ids.first >= graph.order()) {
             // no need to check second as second = first + 1
@@ -166,7 +163,7 @@ template <gl::traits::c_graph GraphType>
             if (vertex_id == target_1 or vertex_id == target_2)
                 return graph.has_edge(source_id, vertex_id);
 
-            if (vertex_id == parent_id and source_id != constants::zero)
+            if (vertex_id == parent_id and source_id != 0uz)
                 return graph.has_edge(source_id, vertex_id);
 
             return not graph.has_edge(source_id, vertex_id);
@@ -234,17 +231,15 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("regular_binary_tree(depth) should return a regular binay tree with the given depth") {
         SUBCASE("depth = 0 : empty graph") {
-            const auto complete_bin_tree =
-                gl::topology::regular_binary_tree<graph_type>(constants::zero);
-            REQUIRE_EQ(complete_bin_tree.order(), constants::zero_elements);
-            REQUIRE_EQ(complete_bin_tree.size(), constants::zero_elements);
+            const auto complete_bin_tree = gl::topology::regular_binary_tree<graph_type>(0uz);
+            REQUIRE_EQ(complete_bin_tree.order(), 0uz);
+            REQUIRE_EQ(complete_bin_tree.size(), 0uz);
         }
 
         SUBCASE("depth = 1 : graph with one vertex and no edges") {
-            const auto complete_bin_tree =
-                gl::topology::regular_binary_tree<graph_type>(constants::one);
-            REQUIRE_EQ(complete_bin_tree.order(), constants::one_element);
-            REQUIRE_EQ(complete_bin_tree.size(), constants::zero_elements);
+            const auto complete_bin_tree = gl::topology::regular_binary_tree<graph_type>(1uz);
+            REQUIRE_EQ(complete_bin_tree.order(), 1uz);
+            REQUIRE_EQ(complete_bin_tree.size(), 0uz);
         }
     }
 }
@@ -322,8 +317,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             "given depth") {
         const auto bin_tree = gl::topology::regular_binary_tree<graph_type>(constants::depth);
 
-        const auto expected_n_vertices =
-            gl::util::upow_sum(constants::two, constants::zero, constants::depth - constants::one);
+        const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
         const auto expected_n_connections = expected_n_vertices - constants::one;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
@@ -337,8 +331,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto bin_tree =
             gl::topology::bidirectional_regular_binary_tree<graph_type>(constants::depth);
 
-        const auto expected_n_vertices =
-            gl::util::upow_sum(constants::two, constants::zero, constants::depth - constants::one);
+        const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
         const auto expected_n_connections = (expected_n_vertices - constants::one) * constants::two;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 
@@ -424,8 +417,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CAPTURE(bin_tree);
 
-        const auto expected_n_vertices =
-            gl::util::upow_sum(constants::two, constants::zero, constants::depth - constants::one);
+        const auto expected_n_vertices = gl::util::upow_sum(2uz, 0uz, constants::depth - 1uz);
         const auto expected_n_connections = expected_n_vertices - constants::one;
         verify_graph_size(bin_tree, expected_n_vertices, expected_n_connections);
 

--- a/tests/source/gl/test_properties.cpp
+++ b/tests/source/gl/test_properties.cpp
@@ -91,12 +91,12 @@ TEST_CASE_FIXTURE(test_dynamic_properties, "is_present should return true for a 
 }
 
 TEST_CASE_FIXTURE(test_dynamic_properties, "get should throw for a not present key") {
-    CHECK_THROWS_AS(func::discard_result(sut.get<int>(not_present_key)), std::out_of_range);
+    CHECK_THROWS_AS(discard_result(sut.get<int>(not_present_key)), std::out_of_range);
 }
 
 TEST_CASE_FIXTURE(test_dynamic_properties, "get should throw for an invalid value type") {
     sut.underlying()[key] = std::any{value};
-    CHECK_THROWS_AS(func::discard_result(sut.get<double>(key)), std::bad_any_cast);
+    CHECK_THROWS_AS(discard_result(sut.get<double>(key)), std::bad_any_cast);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/gl/test_properties.cpp
+++ b/tests/source/gl/test_properties.cpp
@@ -14,21 +14,14 @@ TEST_SUITE_BEGIN("test_properties");
 
 struct test_name_property {
     using sut_type = gl::types::name_property;
-    using value_type = typename sut_type::value_type;
 
     static_assert(gl::traits::c_properties<sut_type>);
 
-    const value_type value = "element name";
+    std::string value = "element name";
     sut_type sut{value};
 
     std::stringstream ss;
 };
-
-TEST_CASE_FIXTURE(
-    test_name_property, "name() should return the name the porperty was initialized with"
-) {
-    CHECK_EQ(sut.name(), value);
-}
 
 TEST_CASE_FIXTURE(
     test_name_property, "operator<< should insert a quoted string to the output stream"
@@ -50,7 +43,7 @@ TEST_CASE_FIXTURE(
     ss << input_name;
 
     ss >> sut;
-    CHECK_EQ(sut.name(), first_word);
+    CHECK_EQ(sut, first_word);
 }
 
 TEST_CASE_FIXTURE(
@@ -60,7 +53,7 @@ TEST_CASE_FIXTURE(
     ss << std::quoted(input_name);
 
     ss >> sut;
-    CHECK_EQ(sut.name(), input_name);
+    CHECK_EQ(sut, input_name);
 }
 
 struct test_dynamic_properties {

--- a/tests/source/gl/test_properties.cpp
+++ b/tests/source/gl/test_properties.cpp
@@ -13,7 +13,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_properties");
 
 struct test_name_property {
-    using sut_type = gl::types::name_property;
+    using sut_type = gl::name_property;
 
     static_assert(gl::traits::c_properties<sut_type>);
 
@@ -57,7 +57,7 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_dynamic_properties {
-    using sut_type = gl::types::dynamic_properties;
+    using sut_type = gl::dynamic_properties;
     using key_type = typename sut_type::key_type;
 
     static_assert(gl::traits::c_properties<sut_type>);
@@ -157,7 +157,7 @@ TEST_CASE_FIXTURE(test_dynamic_properties, "remove should properly erase the key
 }
 
 struct test_binary_color {
-    using sut_type = gl::types::binary_color;
+    using sut_type = gl::binary_color;
     using color = sut_type::value;
 
     static constexpr color out_of_bounds_color =
@@ -205,8 +205,8 @@ TEST_CASE_FIXTURE(
 }
 
 // assertions for not tested property types
-static_assert(gl::traits::c_properties<gl::types::binary_color_property>);
-static_assert(gl::traits::c_properties<gl::types::weight_property<>>);
+static_assert(gl::traits::c_properties<gl::binary_color_property>);
+static_assert(gl::traits::c_properties<gl::weight_property<>>);
 
 TEST_SUITE_END(); // test_properties
 

--- a/tests/source/gl/test_stream_options_manipulator.cpp
+++ b/tests/source/gl/test_stream_options_manipulator.cpp
@@ -19,7 +19,7 @@ struct test_stream_options_manipulator {
     std::stringstream ss1;
     std::stringstream ss2;
 
-    static constexpr gl::io::bit_position_type bit_position_1 = constants::first_element_idx;
+    static constexpr gl::io::bit_position_type bit_position_1 = constants::first_elem_idx;
     static constexpr gl::io::bit_position_type bit_position_2 = bit_position_1 + constants::one;
     static constexpr gl::io::iword_type options_bitmask =
         (gl::io::iword_bit << bit_position_1) | (gl::io::iword_bit << bit_position_2);

--- a/tests/source/gl/test_stream_options_manipulator.cpp
+++ b/tests/source/gl/test_stream_options_manipulator.cpp
@@ -19,8 +19,8 @@ struct test_stream_options_manipulator {
     std::stringstream ss1;
     std::stringstream ss2;
 
-    static constexpr gl::io::bit_position_type bit_position_1 = constants::first_elem_idx;
-    static constexpr gl::io::bit_position_type bit_position_2 = bit_position_1 + constants::one;
+    static constexpr gl::io::bit_position_type bit_position_1 = 0uz;
+    static constexpr gl::io::bit_position_type bit_position_2 = 1uz;
     static constexpr gl::io::iword_type options_bitmask =
         (gl::io::iword_bit << bit_position_1) | (gl::io::iword_bit << bit_position_2);
 };

--- a/tests/source/gl/test_util.cpp
+++ b/tests/source/gl/test_util.cpp
@@ -7,7 +7,7 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_util");
 
 TEST_CASE("upow should return the `base ^ exponent` operation result") {
-    gl::types::size_type base, exponent, expected_result;
+    gl::size_type base, exponent, expected_result;
 
     // clang-format off
 
@@ -28,7 +28,7 @@ TEST_CASE("upow should return the `base ^ exponent` operation result") {
 }
 
 TEST_CASE("upow_sum function test") {
-    gl::types::size_type base, i_begin, i_end, expected_result;
+    gl::size_type base, i_begin, i_end, expected_result;
 
     // clang-format off
 

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -32,7 +32,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique with an additional loop") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        sut.add_edge(constants::first_element_idx, constants::first_element_idx);
+        sut.add_edge(constants::first_elem_idx, constants::first_elem_idx);
 
         expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
         expected_in_deg_list.front()++;
@@ -49,13 +49,11 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("path") {
         sut = gl::topology::path<sut_type>(n_vertices);
 
-        expected_in_deg_list =
-            std::deque<gl::size_type>(n_vertices - constants::one, constants::one);
-        expected_in_deg_list.push_front(constants::zero);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices - 1uz, 1uz);
+        expected_in_deg_list.push_front(0uz);
 
-        expected_out_deg_list =
-            std::deque<gl::size_type>(n_vertices - constants::one, constants::one);
-        expected_out_deg_list.push_back(constants::zero);
+        expected_out_deg_list = std::deque<gl::size_type>(n_vertices - 1uz, 1uz);
+        expected_out_deg_list.push_back(0uz);
     }
 
     CAPTURE(sut);
@@ -70,7 +68,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         std::plus<gl::size_type>{}
     );
 
-    gl::size_type i = constants::zero;
+    gl::size_type i = 0uz;
     CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
         const bool result =
             sut.in_degree(vertex) == expected_in_deg_list[i]
@@ -80,7 +78,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         return result;
     }));
 
-    i = constants::zero;
+    i = 0uz;
     CHECK(std::ranges::all_of(
         sut.vertices(),
         [&](const gl::id_type vertex_id) {
@@ -115,34 +113,34 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
     }
 
     SUBCASE("clique with an additional loop") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        sut.add_edge(constants::first_element_idx, constants::first_element_idx);
+        sut.add_edge(constants::first_elem_idx, constants::first_elem_idx);
 
-        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
-        expected_deg_list.front() += constants::two; // loops counted twice
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
+        expected_deg_list.front() += 2uz; // loops counted twice
     }
 
     SUBCASE("cycle") {
         sut = gl::topology::cycle<sut_type>(n_vertices);
-        expected_deg_list = std::deque<gl::size_type>(n_vertices, constants::two);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, 2uz);
     }
 
     SUBCASE("path") {
         sut = gl::topology::path<sut_type>(n_vertices);
 
-        expected_deg_list = std::deque<gl::size_type>(n_vertices - constants::two, constants::two);
-        expected_deg_list.push_front(constants::one);
-        expected_deg_list.push_back(constants::one);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices - 2uz, 2uz);
+        expected_deg_list.push_front(1uz);
+        expected_deg_list.push_back(1uz);
     }
 
     CAPTURE(sut);
     CAPTURE(expected_deg_list);
 
-    gl::size_type i = constants::zero;
+    gl::size_type i = 0uz;
     CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
         const auto expected_deg = expected_deg_list[i];
         const bool result =
@@ -152,7 +150,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         return result;
     }));
 
-    i = constants::zero;
+    i = 0uz;
     CHECK(std::ranges::all_of(
         sut.vertices(),
         [&](const gl::id_type vertex_id) {

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -26,7 +26,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
         expected_out_deg_list = expected_in_deg_list;
     }
 
@@ -34,7 +34,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut = gl::topology::clique<sut_type>(n_vertices);
         sut.add_edge(constants::first_elem_idx, constants::first_elem_idx);
 
-        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
         expected_in_deg_list.front()++;
 
         expected_out_deg_list = expected_in_deg_list;
@@ -42,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("cycle") {
         sut = gl::topology::cycle<sut_type>(n_vertices);
-        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, 1uz);
         expected_out_deg_list = expected_in_deg_list;
     }
 

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -32,7 +32,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique with an additional loop") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        sut.add_edge(constants::first_elem_idx, constants::first_elem_idx);
+        sut.add_edge(0uz, 0uz);
 
         expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
         expected_in_deg_list.front()++;
@@ -118,7 +118,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("clique with an additional loop") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        sut.add_edge(constants::first_elem_idx, constants::first_elem_idx);
+        sut.add_edge(0uz, 0uz);
 
         expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - 1uz);
         expected_deg_list.front() += 2uz; // loops counted twice

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -11,7 +11,7 @@ namespace gl_testing {
 
 TEST_SUITE_BEGIN("test_vertex_degree_getters");
 
-inline constexpr auto get_id = [](auto&& element) -> gl::types::id_type { return element.id(); };
+inline constexpr auto get_id = [](auto&& element) -> gl::id_type { return element.id(); };
 
 TEST_CASE_TEMPLATE_DEFINE(
     "vertex degree getter tests for directed graphs", TraitsType, directed_graph_traits_template
@@ -22,12 +22,11 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto n_vertices = constants::n_elements_top;
 
     sut_type sut;
-    std::deque<gl::types::size_type> expected_in_deg_list, expected_out_deg_list;
+    std::deque<gl::size_type> expected_in_deg_list, expected_out_deg_list;
 
     SUBCASE("clique") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        expected_in_deg_list =
-            std::deque<gl::types::size_type>(n_vertices, n_vertices - constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
         expected_out_deg_list = expected_in_deg_list;
     }
 
@@ -35,8 +34,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut = gl::topology::clique<sut_type>(n_vertices);
         sut.add_edge(constants::first_element_idx, constants::first_element_idx);
 
-        expected_in_deg_list =
-            std::deque<gl::types::size_type>(n_vertices, n_vertices - constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
         expected_in_deg_list.front()++;
 
         expected_out_deg_list = expected_in_deg_list;
@@ -44,7 +42,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("cycle") {
         sut = gl::topology::cycle<sut_type>(n_vertices);
-        expected_in_deg_list = std::deque<gl::types::size_type>(n_vertices, constants::one);
+        expected_in_deg_list = std::deque<gl::size_type>(n_vertices, constants::one);
         expected_out_deg_list = expected_in_deg_list;
     }
 
@@ -52,11 +50,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut = gl::topology::path<sut_type>(n_vertices);
 
         expected_in_deg_list =
-            std::deque<gl::types::size_type>(n_vertices - constants::one, constants::one);
+            std::deque<gl::size_type>(n_vertices - constants::one, constants::one);
         expected_in_deg_list.push_front(constants::zero);
 
         expected_out_deg_list =
-            std::deque<gl::types::size_type>(n_vertices - constants::one, constants::one);
+            std::deque<gl::size_type>(n_vertices - constants::one, constants::one);
         expected_out_deg_list.push_back(constants::zero);
     }
 
@@ -64,15 +62,15 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(expected_in_deg_list);
     CAPTURE(expected_out_deg_list);
 
-    std::deque<gl::types::size_type> expected_deg_list(n_vertices);
+    std::deque<gl::size_type> expected_deg_list(n_vertices);
     std::ranges::transform(
         expected_in_deg_list,
         expected_out_deg_list,
         expected_deg_list.begin(),
-        std::plus<gl::types::size_type>{}
+        std::plus<gl::size_type>{}
     );
 
-    gl::types::size_type i = constants::zero;
+    gl::size_type i = constants::zero;
     CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
         const bool result =
             sut.in_degree(vertex) == expected_in_deg_list[i]
@@ -85,7 +83,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     i = constants::zero;
     CHECK(std::ranges::all_of(
         sut.vertices(),
-        [&](const gl::types::id_type vertex_id) {
+        [&](const gl::id_type vertex_id) {
             const bool result =
                 sut.in_degree(vertex_id) == expected_in_deg_list[i]
                 and sut.out_degree(vertex_id) == expected_out_deg_list[i]
@@ -113,33 +111,30 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto n_vertices = constants::n_elements_top;
 
     sut_type sut;
-    std::deque<gl::types::size_type> expected_deg_list;
+    std::deque<gl::size_type> expected_deg_list;
 
     SUBCASE("clique") {
         sut = gl::topology::clique<sut_type>(n_vertices);
-        expected_deg_list =
-            std::deque<gl::types::size_type>(n_vertices, n_vertices - constants::one);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
     }
 
     SUBCASE("clique with an additional loop") {
         sut = gl::topology::clique<sut_type>(n_vertices);
         sut.add_edge(constants::first_element_idx, constants::first_element_idx);
 
-        expected_deg_list =
-            std::deque<gl::types::size_type>(n_vertices, n_vertices - constants::one);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, n_vertices - constants::one);
         expected_deg_list.front() += constants::two; // loops counted twice
     }
 
     SUBCASE("cycle") {
         sut = gl::topology::cycle<sut_type>(n_vertices);
-        expected_deg_list = std::deque<gl::types::size_type>(n_vertices, constants::two);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices, constants::two);
     }
 
     SUBCASE("path") {
         sut = gl::topology::path<sut_type>(n_vertices);
 
-        expected_deg_list =
-            std::deque<gl::types::size_type>(n_vertices - constants::two, constants::two);
+        expected_deg_list = std::deque<gl::size_type>(n_vertices - constants::two, constants::two);
         expected_deg_list.push_front(constants::one);
         expected_deg_list.push_back(constants::one);
     }
@@ -147,7 +142,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(sut);
     CAPTURE(expected_deg_list);
 
-    gl::types::size_type i = constants::zero;
+    gl::size_type i = constants::zero;
     CHECK(std::ranges::all_of(sut.vertices(), [&](const auto& vertex) {
         const auto expected_deg = expected_deg_list[i];
         const bool result =
@@ -160,7 +155,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     i = constants::zero;
     CHECK(std::ranges::all_of(
         sut.vertices(),
-        [&](const gl::types::id_type vertex_id) {
+        [&](const gl::id_type vertex_id) {
             const auto expected_deg = expected_deg_list[i];
             const bool result =
                 sut.in_degree(vertex_id) == expected_deg

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -40,15 +40,15 @@ TEST_CASE("vertex_descriptor should be valid only if it has a valid id") {
 }
 
 TEST_CASE("properties should be properly initialized") {
-    types::visited_property property{constants::visited};
+    visited_property property{constants::visited};
 
-    const gl::vertex_descriptor<types::visited_property> sut{constants::vertex_id_1, property};
+    const gl::vertex_descriptor<visited_property> sut{constants::vertex_id_1, property};
     CHECK_EQ(&sut.properties(), &property);
 }
 
 TEST_CASE("accessing properties should throw for an invalid vertex") {
-    using sut_type = gl::vertex_descriptor<types::visited_property>;
-    types::visited_property property{constants::visited};
+    using sut_type = gl::vertex_descriptor<visited_property>;
+    visited_property property{constants::visited};
 
     CHECK_THROWS_AS(func::discard_result(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -11,13 +11,13 @@ namespace gl_testing {
 TEST_SUITE_BEGIN("test_vertex_descriptor");
 
 TEST_CASE("id() should return the correct vertex id") {
-    const gl::vertex_descriptor sut{constants::vertex_id_1};
-    CHECK_EQ(sut.id(), constants::vertex_id_1);
+    const gl::vertex_descriptor sut{constants::v1_id};
+    CHECK_EQ(sut.id(), constants::v1_id);
 }
 
 TEST_CASE("vertex_descriptor objects should be compared by id") {
-    const gl::vertex_descriptor vd_1{constants::vertex_id_1};
-    const gl::vertex_descriptor vd_2{constants::vertex_id_2};
+    const gl::vertex_descriptor vd_1{constants::v1_id};
+    const gl::vertex_descriptor vd_2{constants::v2_id};
 
     REQUIRE_NE(vd_1, vd_2);
     CHECK_EQ(vd_1, vd_1);
@@ -33,7 +33,7 @@ TEST_CASE("vertex_descriptor objects should be compared by id") {
 }
 
 TEST_CASE("vertex_descriptor should be valid only if it has a valid id") {
-    CHECK(gl::vertex_descriptor{constants::vertex_id_1}.is_valid());
+    CHECK(gl::vertex_descriptor{constants::v1_id}.is_valid());
 
     CHECK_FALSE(gl::vertex_descriptor<>::invalid().is_valid());
     CHECK_FALSE(gl::vertex_descriptor{constants::invalid_id}.is_valid());
@@ -42,7 +42,7 @@ TEST_CASE("vertex_descriptor should be valid only if it has a valid id") {
 TEST_CASE("properties should be properly initialized") {
     visited_property property{constants::visited};
 
-    const gl::vertex_descriptor<visited_property> sut{constants::vertex_id_1, property};
+    const gl::vertex_descriptor<visited_property> sut{constants::v1_id, property};
     CHECK_EQ(&sut.properties(), &property);
 }
 

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -50,10 +50,9 @@ TEST_CASE("accessing properties should throw for an invalid vertex") {
     using sut_type = gl::vertex_descriptor<visited_property>;
     visited_property property{constants::visited};
 
-    CHECK_THROWS_AS(func::discard_result(sut_type::invalid().properties()), std::logic_error);
+    CHECK_THROWS_AS(discard_result(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(
-        func::discard_result(sut_type{constants::invalid_id, property}.properties()),
-        std::logic_error
+        discard_result(sut_type{constants::invalid_id, property}.properties()), std::logic_error
     );
 }
 

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -418,18 +418,12 @@ TEST_CASE_TEMPLATE_DEFINE(
     using sut_type = hgl::hypergraph<HypergraphTraits>;
 
     // Define the three target graph models
-    using list_graph = gl::graph<gl::directed_graph_traits<
-        gl::types::empty_properties,
-        gl::types::empty_properties,
-        gl::impl::list_t>>;
-    using flat_list_graph = gl::graph<gl::directed_graph_traits<
-        gl::types::empty_properties,
-        gl::types::empty_properties,
-        gl::impl::flat_list_t>>;
-    using matrix_graph = gl::graph<gl::directed_graph_traits<
-        gl::types::empty_properties,
-        gl::types::empty_properties,
-        gl::impl::matrix_t>>;
+    using list_graph = gl::graph<
+        gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::list_t>>;
+    using flat_list_graph = gl::graph<
+        gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::flat_list_t>>;
+    using matrix_graph = gl::graph<
+        gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::matrix_t>>;
 
     SUBCASE("projection should produce directed edges from tails to heads for each hyperedge") {
         sut_type sut{4ull, 2ull};

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -19,7 +19,7 @@ namespace hgl_testing {
 TEST_SUITE_BEGIN("test_converters");
 
 struct test_hypergraph_conversion {
-    using property_type = hgl::types::name_property;
+    using property_type = hgl::name_property;
 
     template <hgl::traits::c_undirected_hypergraph HypergraphType>
     [[nodiscard]] HypergraphType create_test_hypergraph() {
@@ -237,36 +237,36 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hypergraph_params_template,
     std::tuple<
         hgl::undirected_t,
-        hgl::types::empty_properties,
-        hgl::types::empty_properties>, // undirected, no properties
+        hgl::empty_properties,
+        hgl::empty_properties>, // undirected, no properties
     std::tuple<
         hgl::bf_directed_t,
-        hgl::types::empty_properties,
-        hgl::types::empty_properties>, // bf-directed, no properties
+        hgl::empty_properties,
+        hgl::empty_properties>, // bf-directed, no properties
     std::tuple<
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::empty_properties>, // undirected, vertex properties
+        hgl::name_property,
+        hgl::empty_properties>, // undirected, vertex properties
     std::tuple<
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::empty_properties>, // bf-directed, vertex properties
+        hgl::name_property,
+        hgl::empty_properties>, // bf-directed, vertex properties
     std::tuple<
         hgl::undirected_t,
-        hgl::types::empty_properties,
-        hgl::types::name_property>, // undirected, hyperedge properties
+        hgl::empty_properties,
+        hgl::name_property>, // undirected, hyperedge properties
     std::tuple<
         hgl::bf_directed_t,
-        hgl::types::empty_properties,
-        hgl::types::name_property>, // bf-directed, hyperedge properties
+        hgl::empty_properties,
+        hgl::name_property>, // bf-directed, hyperedge properties
     std::tuple<
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected, all properties
+        hgl::name_property,
+        hgl::name_property>, // undirected, all properties
     std::tuple<
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property> // bf-directed, all properties
+        hgl::name_property,
+        hgl::name_property> // bf-directed, all properties
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -300,7 +300,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         // e3 = {0} (should not add any edge)
         sut.bind(0ull, 3ull);
 
-        const std::vector<std::pair<hgl::types::id_type, hgl::types::id_type>> expected_edges{
+        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0: (0,1), (0,2), (1,2)
             {0ull, 1ull},
             {0ull, 2ull},
@@ -349,7 +349,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind(0ull, 3ull);
 
         // Expected edges: vertices 0-3, hyperedges 4-7
-        const std::vector<std::pair<hgl::types::id_type, hgl::types::id_type>> expected_edges{
+        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0 (4): {0,1,2}
             {0ull, 4ull},
             {1ull, 4ull},
@@ -439,7 +439,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind_head(0ull, 1ull);
         sut.bind_head(1ull, 1ull);
 
-        const std::vector<std::pair<hgl::types::id_type, hgl::types::id_type>> expected_edges{
+        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0: 0->2, 0->3, 1->2, 1->3
             {0ull, 2ull},
             {0ull, 3ull},
@@ -482,7 +482,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind_head(1ull, 1ull);
 
         // Expected directed edges: vertices 0-3, hyperedges 4-5
-        const std::vector<std::pair<hgl::types::id_type, hgl::types::id_type>> expected_edges{
+        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // Tails to hyperedges: 0->4, 1->4, 2->5
             {0ull, 4ull},
             {1ull, 4ull},

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -284,31 +284,31 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{4ull, 4ull};
 
         // e0 = {0,1,2}
-        sut.bind(0ull, 0ull);
-        sut.bind(1ull, 0ull);
-        sut.bind(2ull, 0ull);
+        sut.bind(0uz, 0uz);
+        sut.bind(1uz, 0uz);
+        sut.bind(2uz, 0uz);
 
         // e1 = {1,2,3}
-        sut.bind(1ull, 1ull);
-        sut.bind(2ull, 1ull);
-        sut.bind(3ull, 1ull);
+        sut.bind(1uz, 1uz);
+        sut.bind(2uz, 1uz);
+        sut.bind(3uz, 1uz);
 
         // e2 = {0,3}
-        sut.bind(0ull, 2ull);
-        sut.bind(3ull, 2ull);
+        sut.bind(0uz, 2uz);
+        sut.bind(3uz, 2uz);
 
         // e3 = {0} (should not add any edge)
-        sut.bind(0ull, 3ull);
+        sut.bind(0uz, 3uz);
 
         const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0: (0,1), (0,2), (1,2)
-            {0ull, 1ull},
-            {0ull, 2ull},
-            {1ull, 2ull},
-            {1ull, 3ull},
+            {0uz, 1uz},
+            {0uz, 2uz},
+            {1uz, 2uz},
+            {1uz, 3uz},
             // e1: (1,2) - exists, (1,3), (2,3)
-            {2ull, 3ull},
-            {0ull, 3ull},
+            {2uz, 3uz},
+            {0uz, 3uz},
             // e3: none
         };
 
@@ -332,37 +332,37 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{4ull, 4ull};
 
         // e0 = {0,1,2}
-        sut.bind(0ull, 0ull);
-        sut.bind(1ull, 0ull);
-        sut.bind(2ull, 0ull);
+        sut.bind(0uz, 0uz);
+        sut.bind(1uz, 0uz);
+        sut.bind(2uz, 0uz);
 
         // e1 = {1,2,3}
-        sut.bind(1ull, 1ull);
-        sut.bind(2ull, 1ull);
-        sut.bind(3ull, 1ull);
+        sut.bind(1uz, 1uz);
+        sut.bind(2uz, 1uz);
+        sut.bind(3uz, 1uz);
 
         // e2 = {0,3}
-        sut.bind(0ull, 2ull);
-        sut.bind(3ull, 2ull);
+        sut.bind(0uz, 2uz);
+        sut.bind(3uz, 2uz);
 
         // e3 = {0}
-        sut.bind(0ull, 3ull);
+        sut.bind(0uz, 3uz);
 
         // Expected edges: vertices 0-3, hyperedges 4-7
         const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0 (4): {0,1,2}
-            {0ull, 4ull},
-            {1ull, 4ull},
-            {2ull, 4ull},
+            {0uz, 4ull},
+            {1uz, 4ull},
+            {2uz, 4ull},
             // e1 (5): {1,2,3}
-            {1ull, 5ull},
-            {2ull, 5ull},
-            {3ull, 5ull},
+            {1uz, 5ull},
+            {2uz, 5ull},
+            {3uz, 5ull},
             // e2 (6): {0,3}
-            {0ull, 6ull},
-            {3ull, 6ull},
+            {0uz, 6ull},
+            {3uz, 6ull},
             // e3 (7): {0}
-            {0ull, 7ull}
+            {0uz, 7ull}
         };
 
         auto test_conversion_for =
@@ -426,28 +426,28 @@ TEST_CASE_TEMPLATE_DEFINE(
         gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::matrix_t>>;
 
     SUBCASE("projection should produce directed edges from tails to heads for each hyperedge") {
-        sut_type sut{4ull, 2ull};
+        sut_type sut{4ull, 2uz};
 
         // e0: T={0,1} -> H={2,3}
-        sut.bind_tail(0ull, 0ull);
-        sut.bind_tail(1ull, 0ull);
-        sut.bind_head(2ull, 0ull);
-        sut.bind_head(3ull, 0ull);
+        sut.bind_tail(0uz, 0uz);
+        sut.bind_tail(1uz, 0uz);
+        sut.bind_head(2uz, 0uz);
+        sut.bind_head(3uz, 0uz);
 
         // e1: T={2} -> H={0,1}
-        sut.bind_tail(2ull, 1ull);
-        sut.bind_head(0ull, 1ull);
-        sut.bind_head(1ull, 1ull);
+        sut.bind_tail(2uz, 1uz);
+        sut.bind_head(0uz, 1uz);
+        sut.bind_head(1uz, 1uz);
 
         const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // e0: 0->2, 0->3, 1->2, 1->3
-            {0ull, 2ull},
-            {0ull, 3ull},
-            {1ull, 2ull},
-            {1ull, 3ull},
+            {0uz, 2uz},
+            {0uz, 3uz},
+            {1uz, 2uz},
+            {1uz, 3uz},
             // e1: 2->0, 2->1
-            {2ull, 0ull},
-            {2ull, 1ull}
+            {2uz, 0uz},
+            {2uz, 1uz}
         };
 
         auto test_conversion_for =
@@ -468,30 +468,30 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("incidence_graph should produce a directed bipartite graph connecting tails to "
             "hyperedges and hyperedges to heads") {
-        sut_type sut{4ull, 2ull};
+        sut_type sut{4ull, 2uz};
 
         // e0: T={0,1} -> H={2,3}
-        sut.bind_tail(0ull, 0ull);
-        sut.bind_tail(1ull, 0ull);
-        sut.bind_head(2ull, 0ull);
-        sut.bind_head(3ull, 0ull);
+        sut.bind_tail(0uz, 0uz);
+        sut.bind_tail(1uz, 0uz);
+        sut.bind_head(2uz, 0uz);
+        sut.bind_head(3uz, 0uz);
 
         // e1: T={2} -> H={0,1}
-        sut.bind_tail(2ull, 1ull);
-        sut.bind_head(0ull, 1ull);
-        sut.bind_head(1ull, 1ull);
+        sut.bind_tail(2uz, 1uz);
+        sut.bind_head(0uz, 1uz);
+        sut.bind_head(1uz, 1uz);
 
         // Expected directed edges: vertices 0-3, hyperedges 4-5
         const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
             // Tails to hyperedges: 0->4, 1->4, 2->5
-            {0ull, 4ull},
-            {1ull, 4ull},
-            {2ull, 5ull},
+            { 0uz, 4ull},
+            { 1uz, 4ull},
+            { 2uz, 5ull},
             // Hyperedges to heads: 4->2, 4->3, 5->0, 5->1
-            {4ull, 2ull},
-            {4ull, 3ull},
-            {5ull, 0ull},
-            {5ull, 1ull}
+            {4ull,  2uz},
+            {4ull,  3uz},
+            {5ull,  0uz},
+            {5ull,  1uz}
         };
 
         // Generic runner for the target models

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -276,7 +276,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
@@ -554,7 +554,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
@@ -1009,7 +1009,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));
@@ -1492,7 +1492,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -167,15 +167,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly unbind (if necessary) the given hyperedge and align ids "
     "> hyperedge_id"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 4uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 4uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_heid;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_heid;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_heid = constants::id1;
@@ -454,15 +454,15 @@ TEST_CASE_FIXTURE(
     test_undirected_hyperedge_major_flat_incidence_list,
     "remove_vertex should properly unbind (if necessary) the given vertex and align ids > vertex_id"
 ) {
-    constexpr hgl::types::size_type n_vertices = 4uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 4uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -599,9 +599,9 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_flat_incidence_list : public test_flat_incidence_list {
     auto altbind_to_vertex(
-        auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges
+        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -618,9 +618,9 @@ struct test_bf_directed_flat_incidence_list : public test_flat_incidence_list {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices
+        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -684,16 +684,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_flat_incidence_list,
     "remove_vertex should properly remove the major entry and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -794,16 +794,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_flat_incidence_list,
     "remove_hyperedge should properly remove the minor entries and shift the hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -955,7 +955,7 @@ TEST_CASE_FIXTURE(
     "unbind should erase the hyperedge id from a proper vertex entry"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::types::id_type> expected_storage;
+    std::vector<hgl::id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);
@@ -1162,16 +1162,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_flat_incidence_list,
     "remove_vertex should properly remove the minor entries and shift the vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1273,16 +1273,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_flat_incidence_list,
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1438,7 +1438,7 @@ TEST_CASE_FIXTURE(
     "unbind should clear the corresponding bit"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::types::id_type> expected_storage;
+    std::vector<hgl::id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -786,19 +786,19 @@ TEST_CASE_TEMPLATE_DEFINE(
         constexpr auto n_elements = 5ull;
         sut_type sut{n_elements, n_elements};
 
-        constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+        constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
         REQUIRE(std::ranges::all_of(sut.degree_map(), is_zero));
         REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(), is_zero));
 
         if constexpr (std::same_as<directional_tag, hgl::undirected_t>) {
-            for (std::size_t i = 0uz; i < n_elements; i++)
-                for (std::size_t j = 0uz; j <= i; j++)
+            for (auto i = 0uz; i < n_elements; i++)
+                for (auto j = 0uz; j <= i; j++)
                     sut.bind(i, j);
 
             const auto deg_map = sut.degree_map();
             const auto esize_map = sut.hyperedge_size_map();
 
-            for (std::size_t i = 0uz; i < n_elements; i++) {
+            for (auto i = 0uz; i < n_elements; i++) {
                 CHECK_EQ(deg_map[i], i + 1uz);
                 CHECK_EQ(esize_map[i], n_elements - i);
             }
@@ -810,8 +810,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             REQUIRE(std::ranges::all_of(sut.tail_size_map(), is_zero));
             REQUIRE(std::ranges::all_of(sut.head_size_map(), is_zero));
 
-            for (std::size_t i = 0uz; i < n_elements; i++) {
-                for (std::size_t j = 0uz; j <= i; j++) {
+            for (auto i = 0uz; i < n_elements; i++) {
+                for (auto j = 0uz; j <= i; j++) {
                     if (i == j)
                         sut.bind_tail(i, j);
                     else
@@ -826,7 +826,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const auto tsize_map = sut.tail_size_map();
             const auto hsize_map = sut.head_size_map();
 
-            for (std::size_t k = 0uz; k < n_elements; k++) {
+            for (auto k = 0uz; k < n_elements; k++) {
                 CHECK_EQ(deg_map[k], k + 1uz);
                 CHECK_EQ(out_deg_map[k], 1uz);
                 CHECK_EQ(in_deg_map[k], k);

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -46,7 +46,7 @@ using add_properties = hgl::hypergraph_traits<
     Properties,
     typename HypergraphTraits::implementation_tag>;
 
-inline constexpr auto get_id = [](auto&& element) -> hgl::types::id_type { return element.id(); };
+inline constexpr auto get_id = [](auto&& element) -> hgl::id_type { return element.id(); };
 
 TEST_CASE_TEMPLATE_DEFINE(
     "hypergraph structure tests", HypergraphTraits, hypergraph_traits_template
@@ -105,7 +105,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("add_vertex should return a vertex_descriptor with an incremented id") {
         sut_type sut;
 
-        for (hgl::types::id_type v_id = 0uz; v_id < constants::n_vertices; v_id++) {
+        for (hgl::id_type v_id = 0uz; v_id < constants::n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
             CHECK_EQ(sut.order(), v_id + 1uz);
@@ -222,7 +222,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{n_vertices};
         sut.remove_vertices_from(
-            std::vector<hgl::types::id_type>{constants::id1, constants::id3, constants::id1}
+            std::vector<hgl::id_type>{constants::id1, constants::id3, constants::id1}
         );
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
@@ -247,7 +247,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("add_hyperedge should return a hyperedge_descriptor with an incremented id") {
         sut_type sut;
 
-        for (hgl::types::id_type e_id = 0uz; e_id < constants::n_hyperedges; e_id++) {
+        for (hgl::id_type e_id = 0uz; e_id < constants::n_hyperedges; e_id++) {
             const auto hyperedge = sut.add_hyperedge();
             CHECK_EQ(hyperedge.id(), e_id);
             CHECK_EQ(sut.size(), e_id + 1uz);
@@ -366,7 +366,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{0uz, n_hyperedges};
         sut.remove_hyperedges_from(
-            std::vector<hgl::types::id_type>{constants::id1, constants::id3, constants::id1}
+            std::vector<hgl::id_type>{constants::id1, constants::id3, constants::id1}
         );
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
@@ -552,7 +552,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("sequential hyperedges") {
             if constexpr (std::same_as<directional_tag, hgl::undirected_t>) {
-                std::vector<hgl::types::id_type> expected_hyperedges{};
+                std::vector<hgl::id_type> expected_hyperedges{};
                 for (const auto eid : sut.hyperedge_ids()) {
                     sut.bind(vertex_id, eid);
                     expected_hyperedges.push_back(eid);
@@ -568,8 +568,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             }
 
             if constexpr (std::same_as<directional_tag, hgl::bf_directed_t>) {
-                std::vector<hgl::types::id_type> expected_hyperedges;
-                std::vector<hgl::types::id_type> expected_in_hyperedges, expected_out_hyperedges;
+                std::vector<hgl::id_type> expected_hyperedges;
+                std::vector<hgl::id_type> expected_in_hyperedges, expected_out_hyperedges;
                 for (const auto eid : sut.hyperedge_ids()) {
                     if (eid % 2 == 0) {
                         sut.bind_head(vertex_id, eid);
@@ -612,7 +612,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.incident_hyperedges(vertex_id),
-                    std::vector<hgl::types::id_type>{constants::id2, constants::id4},
+                    std::vector<hgl::id_type>{constants::id2, constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -625,7 +625,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_hyperedges(vertex_id),
-                    std::vector<hgl::types::id_type>{constants::id2, constants::id4},
+                    std::vector<hgl::id_type>{constants::id2, constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -633,7 +633,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.in_hyperedges(vertex_id),
-                    std::vector<hgl::types::id_type>{constants::id2},
+                    std::vector<hgl::id_type>{constants::id2},
                     std::equal_to{},
                     get_id
                 ));
@@ -641,7 +641,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.out_hyperedges(vertex_id),
-                    std::vector<hgl::types::id_type>{constants::id4},
+                    std::vector<hgl::id_type>{constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -681,7 +681,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("sequential vertices") {
             if constexpr (std::same_as<directional_tag, hgl::undirected_t>) {
-                std::vector<hgl::types::id_type> expected_vertices{};
+                std::vector<hgl::id_type> expected_vertices{};
                 for (const auto vid : sut.vertex_ids()) {
                     sut.bind(vid, hyperedge_id);
                     expected_vertices.push_back(vid);
@@ -697,8 +697,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             }
 
             if constexpr (std::same_as<directional_tag, hgl::bf_directed_t>) {
-                std::vector<hgl::types::id_type> expected_vertices;
-                std::vector<hgl::types::id_type> expected_head_vertices, expected_tail_vertices;
+                std::vector<hgl::id_type> expected_vertices;
+                std::vector<hgl::id_type> expected_head_vertices, expected_tail_vertices;
                 for (const auto vid : sut.vertex_ids()) {
                     if (vid % 2 == 0) {
                         sut.bind_head(vid, hyperedge_id);
@@ -744,7 +744,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.incident_vertices(hyperedge_id),
-                    std::vector<hgl::types::id_type>{constants::id1, constants::id3},
+                    std::vector<hgl::id_type>{constants::id1, constants::id3},
                     std::equal_to{},
                     get_id
                 ));
@@ -757,7 +757,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_vertices(hyperedge_id),
-                    std::vector<hgl::types::id_type>{constants::id1, constants::id3},
+                    std::vector<hgl::id_type>{constants::id1, constants::id3},
                     std::equal_to{},
                     get_id
                 ));
@@ -765,7 +765,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.head_vertices(hyperedge_id),
-                    std::vector<hgl::types::id_type>{constants::id1},
+                    std::vector<hgl::id_type>{constants::id1},
                     std::equal_to{},
                     get_id
                 ));
@@ -773,7 +773,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.tail_vertices(hyperedge_id),
-                    std::vector<hgl::types::id_type>{constants::id3},
+                    std::vector<hgl::id_type>{constants::id3},
                     std::equal_to{},
                     get_id
                 ));
@@ -848,7 +848,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             hyperedge.properties() = std::format("hyperedge_{}", hyperedge.id());
     };
 
-    using p_hypergraph_traits = add_properties<HypergraphTraits, hgl::types::name_property>;
+    using p_hypergraph_traits = add_properties<HypergraphTraits, hgl::name_property>;
     using p_sut_type = hgl::hypergraph<p_hypergraph_traits>;
 
     const auto create_test_p_hypergraph = [&set_properties]() {
@@ -1084,43 +1084,43 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected bidirectional incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected hyperedge-major incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected hyperedge-major incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected vertex-major incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected vertex-major incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected bidirectional flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected bidirectional flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected hyperedge-major flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected hyperedge-major flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected vertex-major flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // undirected vertex-major flat incidence list
     hgl::matrix_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // undirected hyperedge-major incidence matrix
+        hgl::name_property,
+        hgl::name_property>, // undirected hyperedge-major incidence matrix
     hgl::matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::undirected_t,
-        hgl::types::name_property,
-        hgl::types::name_property> // undirected vertex-major incidence matrix
+        hgl::name_property,
+        hgl::name_property> // undirected vertex-major incidence matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -1320,43 +1320,43 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed bidirectional incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed hyperedge-major incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed hyperedge-major incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed vertex-major incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed vertex-major incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed bidirectional flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed bidirectional flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed hyperedge-major flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed hyperedge-major flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed vertex-major flat incidence list
+        hgl::name_property,
+        hgl::name_property>, // bf-directed vertex-major flat incidence list
     hgl::matrix_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property>, // bf-directed hyperedge-major incidence matrix
+        hgl::name_property,
+        hgl::name_property>, // bf-directed hyperedge-major incidence matrix
     hgl::matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
         hgl::bf_directed_t,
-        hgl::types::name_property,
-        hgl::types::name_property> // bf-directed vertex-major incidence matrix
+        hgl::name_property,
+        hgl::name_property> // bf-directed vertex-major incidence matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -116,8 +116,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
-        using properties_traits_type =
-            add_vertex_property<HypergraphTraits, types::boolean_property>;
+        using properties_traits_type = add_vertex_property<HypergraphTraits, boolean_property>;
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::p_true);
@@ -138,11 +137,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("add_vertices_with should add new vertices to the hypergraph with the given properties"
     ) {
-        using properties_traits_type =
-            add_vertex_property<HypergraphTraits, types::boolean_property>;
+        using properties_traits_type = add_vertex_property<HypergraphTraits, boolean_property>;
         hgl::hypergraph<properties_traits_type> sut;
 
-        const std::vector<types::boolean_property> properties_list{
+        const std::vector<boolean_property> properties_list{
             constants::p_true, constants::p_false, constants::p_true
         };
         const auto expected_n_vertices = properties_list.size();
@@ -260,8 +258,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("add_hyperedge_with should initialize a new hyperedge with the input properties "
             "structure") {
-        using properties_traits_type =
-            add_hyperedge_property<HypergraphTraits, types::boolean_property>;
+        using properties_traits_type = add_hyperedge_property<HypergraphTraits, boolean_property>;
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto hyperedge = sut.add_hyperedge_with(constants::p_true);
@@ -281,11 +278,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("add_hyperedges_with should add new hyperedges to the hypergraph with the given "
             "properties") {
-        using properties_traits_type =
-            add_hyperedge_property<HypergraphTraits, types::boolean_property>;
+        using properties_traits_type = add_hyperedge_property<HypergraphTraits, boolean_property>;
         hgl::hypergraph<properties_traits_type> sut;
 
-        const std::vector<types::boolean_property> properties_list{
+        const std::vector<boolean_property> properties_list{
             constants::p_true, constants::p_false, constants::p_true, constants::p_false
         };
         const auto expected_n_hyperedges = properties_list.size();

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -13,8 +13,8 @@ static_assert(std::same_as<hgl::vertex_descriptor<>, gl::vertex_descriptor<>>);
 struct test_hyperedge_descriptor {
     using sut_type = hgl::hyperedge_descriptor<>;
 
-    static constexpr hgl::types::id_type id1 = 0ull;
-    static constexpr hgl::types::id_type id2 = 1ull;
+    static constexpr hgl::id_type id1 = 0ull;
+    static constexpr hgl::id_type id2 = 1ull;
 
     sut_type he1{id1};
     sut_type he2{id2};

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -13,8 +13,8 @@ static_assert(std::same_as<hgl::vertex_descriptor<>, gl::vertex_descriptor<>>);
 struct test_hyperedge_descriptor {
     using sut_type = hgl::hyperedge_descriptor<>;
 
-    static constexpr hgl::id_type id1 = 0ull;
-    static constexpr hgl::id_type id2 = 1ull;
+    static constexpr hgl::id_type id1 = 0uz;
+    static constexpr hgl::id_type id2 = 1uz;
 
     sut_type he1{id1};
     sut_type he2{id2};

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -44,15 +44,15 @@ TEST_CASE_FIXTURE(test_hyperedge_descriptor, "hyperedge descriptors should be in
 }
 
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "properties should be properly initialized") {
-    types::boolean_property property{constants::p_true};
+    boolean_property property{constants::p_true};
 
-    const hgl::hyperedge<types::boolean_property> sut{id1, property};
+    const hgl::hyperedge<boolean_property> sut{id1, property};
     CHECK_EQ(&sut.properties(), &property);
 }
 
 TEST_CASE("accessing properties should throw for an invalid hyperedge") {
-    using sut_type = hgl::hyperedge<types::boolean_property>;
-    types::boolean_property property{constants::p_true};
+    using sut_type = hgl::hyperedge<boolean_property>;
+    boolean_property property{constants::p_true};
 
     CHECK_THROWS_AS(static_cast<void>(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -162,15 +162,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly unbind (if necessary) the given hyperedge and align ids "
     "> hyperedge_id"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 4uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 4uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_heid;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_heid;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_heid = constants::id1;
@@ -443,15 +443,15 @@ TEST_CASE_FIXTURE(
     test_undirected_hyperedge_major_incidence_list,
     "remove_vertex should properly unbind (if necessary) the given vertex and align ids > vertex_id"
 ) {
-    constexpr hgl::types::size_type n_vertices = 4uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 4uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -588,9 +588,9 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_incidence_list : public test_incidence_list {
     auto altbind_to_vertex(
-        auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges
+        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -607,9 +607,9 @@ struct test_bf_directed_incidence_list : public test_incidence_list {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices
+        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -671,16 +671,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_list,
     "remove_vertex should properly remove the major entry and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -779,16 +779,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_list,
     "remove_hyperedge should properly remove the minor entries and shift the hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -940,7 +940,7 @@ TEST_CASE_FIXTURE(
     "unbind should erase the hyperedge id from a proper vertex entry"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::types::id_type> expected_storage;
+    std::vector<hgl::id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);
@@ -1144,16 +1144,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list,
     "remove_vertex should properly remove the minor entries and shift the vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1255,16 +1255,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list,
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1419,7 +1419,7 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list, "unbind should clear the corresponding bit"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::types::id_type> expected_storage;
+    std::vector<hgl::id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -266,20 +266,20 @@ TEST_CASE_FIXTURE(
     test_undirected_vertex_major_incidence_list,
     "element size map getters should return maps of properly calculated element sizes"
 ) {
-    constexpr auto n_elements = 5ull;
+    constexpr auto n_elements = 5uz;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
-    for (std::size_t i = 0uz; i < n_elements; i++)
-        for (std::size_t j = 0uz; j <= i; j++)
+    for (auto i = 0uz; i < n_elements; i++)
+        for (auto j = 0uz; j <= i; j++)
             sut.bind(i, j);
 
     const auto deg_map = sut.degree_map(n_elements);
     const auto esize_map = sut.hyperedge_size_map(n_elements);
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(esize_map[i], n_elements - i);
     }
@@ -543,17 +543,17 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
-    for (std::size_t i = 0uz; i < n_elements; i++)
-        for (std::size_t j = 0uz; j <= i; j++)
+    for (auto i = 0uz; i < n_elements; i++)
+        for (auto j = 0uz; j <= i; j++)
             sut.bind(i, j);
 
     const auto deg_map = sut.degree_map(n_elements);
     const auto esize_map = sut.hyperedge_size_map(n_elements);
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(esize_map[i], n_elements - i);
     }
@@ -592,7 +592,7 @@ struct test_bf_directed_incidence_list : public test_incidence_list {
     ) {
         std::vector<hgl::id_type> tail_bound, head_bound;
 
-        for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
+        for (auto i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
                 sut.bind_tail(vertex_id, i);
                 tail_bound.push_back(i);
@@ -611,7 +611,7 @@ struct test_bf_directed_incidence_list : public test_incidence_list {
     ) {
         std::vector<hgl::id_type> tail_bound, head_bound;
 
-        for (std::size_t i = 0uz; i < n_vertices; ++i) {
+        for (auto i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
                 sut.bind_tail(i, hyperedge_id);
                 tail_bound.push_back(i);
@@ -994,7 +994,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));
@@ -1003,15 +1003,15 @@ TEST_CASE_FIXTURE(
     REQUIRE(std::ranges::all_of(sut.head_size_map(n_elements), is_zero));
 
     SUBCASE("tail bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_tail(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto out_deg_map = sut.out_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto tsize_map = sut.tail_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(out_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1022,15 +1022,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("head bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_head(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto in_deg_map = sut.in_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto hsize_map = sut.head_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(in_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1041,8 +1041,8 @@ TEST_CASE_FIXTURE(
     }
 
     // diagonal = tail, everything else is head
-    for (std::size_t i = 0uz; i < n_elements; i++) {
-        for (std::size_t j = 0uz; j <= i; j++) {
+    for (auto i = 0uz; i < n_elements; i++) {
+        for (auto j = 0uz; j <= i; j++) {
             if (i == j)
                 sut.bind_tail(i, j);
             else
@@ -1058,7 +1058,7 @@ TEST_CASE_FIXTURE(
     const auto tsize_map = sut.tail_size_map(n_elements);
     const auto hsize_map = sut.head_size_map(n_elements);
 
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(out_deg_map[i], 1uz);
         CHECK_EQ(in_deg_map[i], i);
@@ -1473,7 +1473,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));
@@ -1482,15 +1482,15 @@ TEST_CASE_FIXTURE(
     REQUIRE(std::ranges::all_of(sut.head_size_map(n_elements), is_zero));
 
     SUBCASE("tail bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_tail(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto out_deg_map = sut.out_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto tsize_map = sut.tail_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(out_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1501,15 +1501,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("head bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_head(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto in_deg_map = sut.in_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto hsize_map = sut.head_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(in_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1520,8 +1520,8 @@ TEST_CASE_FIXTURE(
     }
 
     // diagonal = tail, everything else is head
-    for (std::size_t i = 0uz; i < n_elements; i++) {
-        for (std::size_t j = 0uz; j <= i; j++) {
+    for (auto i = 0uz; i < n_elements; i++) {
+        for (auto j = 0uz; j <= i; j++) {
             if (i == j)
                 sut.bind_tail(i, j);
             else
@@ -1537,7 +1537,7 @@ TEST_CASE_FIXTURE(
     const auto tsize_map = sut.tail_size_map(n_elements);
     const auto hsize_map = sut.head_size_map(n_elements);
 
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(out_deg_map[i], 1uz);
         CHECK_EQ(in_deg_map[i], i);

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -72,16 +72,16 @@ TEST_CASE_FIXTURE(
     test_undirected_vertex_major_incidence_matrix,
     "remove_vertex should properly remove the row and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -185,16 +185,16 @@ TEST_CASE_FIXTURE(
     test_undirected_vertex_major_incidence_matrix,
     "remove_hyperedge should properly remove the column and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -413,16 +413,16 @@ TEST_CASE_FIXTURE(
     test_undirected_hyperedge_major_incidence_matrix,
     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -512,16 +512,16 @@ TEST_CASE_FIXTURE(
     test_undirected_hyperedge_major_incidence_matrix,
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -691,9 +691,9 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     }
 
     auto altbind_to_vertex(
-        auto& sut, const hgl::types::id_type vertex_id, const hgl::types::size_type n_hyperedges
+        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -710,9 +710,9 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::types::id_type hyperedge_id, const hgl::types::size_type n_vertices
+        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::types::id_type> tail_bound, head_bound;
+        std::vector<hgl::id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -773,16 +773,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
     "remove_vertex should properly remove the row and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -894,16 +894,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
     "remove_hyperedge should properly remove the column and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1239,16 +1239,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_matrix,
     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::types::id_type hyperedge_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
+    constexpr hgl::id_type hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::types::id_type rem_vid;
-    hgl::types::size_type expected_hyperedge_size;
-    std::vector<hgl::types::id_type> expected_vertices;
+    hgl::id_type rem_vid;
+    hgl::size_type expected_hyperedge_size;
+    std::vector<hgl::id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1347,16 +1347,16 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_matrix,
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
-    constexpr hgl::types::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::types::id_type vertex_id = constants::id1;
+    constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
+    constexpr hgl::id_type vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::types::id_type rem_eid;
-    hgl::types::size_type expected_vertex_degree;
-    std::vector<hgl::types::id_type> expected_hyperedges;
+    hgl::id_type rem_eid;
+    hgl::size_type expected_vertex_degree;
+    std::vector<hgl::id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -313,17 +313,17 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
-    for (std::size_t i = 0uz; i < n_elements; i++)
-        for (std::size_t j = 0uz; j <= i; j++)
+    for (auto i = 0uz; i < n_elements; i++)
+        for (auto j = 0uz; j <= i; j++)
             sut.bind(i, j);
 
     const auto deg_map = sut.degree_map(n_elements);
     const auto esize_map = sut.hyperedge_size_map(n_elements);
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(esize_map[i], n_elements - i);
     }
@@ -640,17 +640,17 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.hyperedge_size_map(n_elements), is_zero));
 
-    for (std::size_t i = 0uz; i < n_elements; i++)
-        for (std::size_t j = 0uz; j <= i; j++)
+    for (auto i = 0uz; i < n_elements; i++)
+        for (auto j = 0uz; j <= i; j++)
             sut.bind(i, j);
 
     const auto deg_map = sut.degree_map(n_elements);
     const auto esize_map = sut.hyperedge_size_map(n_elements);
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(esize_map[i], n_elements - i);
     }
@@ -695,7 +695,7 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     ) {
         std::vector<hgl::id_type> tail_bound, head_bound;
 
-        for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
+        for (auto i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
                 sut.bind_tail(vertex_id, i);
                 tail_bound.push_back(i);
@@ -714,7 +714,7 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     ) {
         std::vector<hgl::id_type> tail_bound, head_bound;
 
-        for (std::size_t i = 0uz; i < n_vertices; ++i) {
+        for (auto i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
                 sut.bind_tail(i, hyperedge_id);
                 tail_bound.push_back(i);
@@ -1071,7 +1071,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));
@@ -1080,15 +1080,15 @@ TEST_CASE_FIXTURE(
     REQUIRE(std::ranges::all_of(sut.head_size_map(n_elements), is_zero));
 
     SUBCASE("tail bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_tail(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto out_deg_map = sut.out_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto tsize_map = sut.tail_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(out_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1099,15 +1099,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("head bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_head(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto in_deg_map = sut.in_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto hsize_map = sut.head_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(in_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1118,8 +1118,8 @@ TEST_CASE_FIXTURE(
     }
 
     // diagonal = tail, everything else is head
-    for (std::size_t i = 0uz; i < n_elements; i++) {
-        for (std::size_t j = 0uz; j <= i; j++) {
+    for (auto i = 0uz; i < n_elements; i++) {
+        for (auto j = 0uz; j <= i; j++) {
             if (i == j)
                 sut.bind_tail(i, j);
             else
@@ -1135,7 +1135,7 @@ TEST_CASE_FIXTURE(
     const auto tsize_map = sut.tail_size_map(n_elements);
     const auto hsize_map = sut.head_size_map(n_elements);
 
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(out_deg_map[i], 1uz);
         CHECK_EQ(in_deg_map[i], i);
@@ -1524,7 +1524,7 @@ TEST_CASE_FIXTURE(
     constexpr auto n_elements = 5ull;
     sut_type sut{n_elements, n_elements};
 
-    constexpr auto is_zero = [](const auto& size) { return size == 0ull; };
+    constexpr auto is_zero = [](const auto& size) { return size == 0uz; };
     REQUIRE(std::ranges::all_of(sut.degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.out_degree_map(n_elements), is_zero));
     REQUIRE(std::ranges::all_of(sut.in_degree_map(n_elements), is_zero));
@@ -1533,15 +1533,15 @@ TEST_CASE_FIXTURE(
     REQUIRE(std::ranges::all_of(sut.head_size_map(n_elements), is_zero));
 
     SUBCASE("tail bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_tail(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto out_deg_map = sut.out_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto tsize_map = sut.tail_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(out_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1552,15 +1552,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("head bind") {
-        for (std::size_t i = 0uz; i < n_elements; i++)
-            for (std::size_t j = 0uz; j <= i; j++)
+        for (auto i = 0uz; i < n_elements; i++)
+            for (auto j = 0uz; j <= i; j++)
                 sut.bind_head(i, j);
 
         const auto deg_map = sut.degree_map(n_elements);
         const auto in_deg_map = sut.in_degree_map(n_elements);
         const auto esize_map = sut.hyperedge_size_map(n_elements);
         const auto hsize_map = sut.head_size_map(n_elements);
-        for (std::size_t i = 0uz; i < n_elements; i++) {
+        for (auto i = 0uz; i < n_elements; i++) {
             CHECK_EQ(deg_map[i], i + 1uz);
             CHECK_EQ(in_deg_map[i], i + 1uz);
             CHECK_EQ(esize_map[i], n_elements - i);
@@ -1571,8 +1571,8 @@ TEST_CASE_FIXTURE(
     }
 
     // diagonal = tail, everything else is head
-    for (std::size_t i = 0uz; i < n_elements; i++) {
-        for (std::size_t j = 0uz; j <= i; j++) {
+    for (auto i = 0uz; i < n_elements; i++) {
+        for (auto j = 0uz; j <= i; j++) {
             if (i == j)
                 sut.bind_tail(i, j);
             else
@@ -1588,7 +1588,7 @@ TEST_CASE_FIXTURE(
     const auto tsize_map = sut.tail_size_map(n_elements);
     const auto hsize_map = sut.head_size_map(n_elements);
 
-    for (std::size_t i = 0uz; i < n_elements; i++) {
+    for (auto i = 0uz; i < n_elements; i++) {
         CHECK_EQ(deg_map[i], i + 1uz);
         CHECK_EQ(out_deg_map[i], 1uz);
         CHECK_EQ(in_deg_map[i], i);

--- a/todo.txt
+++ b/todo.txt
@@ -3,6 +3,7 @@ TODO - GL:
 3. Align property type docs
 4. Remove the gl_attr_force_inline attribute and macro
 5. Remove dummy testing constants
+6. Change the id_type and size_type to std::size_t (ull -> uz)
 
 TODO - HGL:
 1. Remove the types namespace

--- a/todo.txt
+++ b/todo.txt
@@ -1,8 +1,8 @@
 TODO - GL:
-1. Remove the types namespace
 2. Remove gl_testing::* namespaces
 3. Align property type docs
 4. Remove the gl_attr_force_inline attribute and macro
+5. Remove dummy testing constants
 
 TODO - HGL:
 1. Remove the types namespace

--- a/todo.txt
+++ b/todo.txt
@@ -5,4 +5,3 @@ TODO - GL:
 
 TODO - HGL:
 1. Remove the types namespace
-2. Remove hgl_testing::* namespaces

--- a/todo.txt
+++ b/todo.txt
@@ -1,8 +1,6 @@
 TODO - GL:
-2. Remove gl_testing::* namespaces (other then constants)
 3. Align property type docs
 4. Remove the gl_attr_force_inline attribute and macro
-5. Remove dummy testing constants
 6. Change the id_type and size_type to std::size_t (ull -> uz)
 
 TODO - HGL:

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,9 @@
+TODO - GL:
+1. Remove the types namespace
+2. Remove gl_testing::* namespaces
+3. Align property type docs
+4. Remove the gl_attr_force_inline attribute and macro
+
+TODO - HGL:
+1. Remove the types namespace
+2. Remove hgl_testing::* namespaces

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,5 @@
 TODO - GL:
-2. Remove gl_testing::* namespaces
+2. Remove gl_testing::* namespaces (other then constants)
 3. Align property type docs
 4. Remove the gl_attr_force_inline attribute and macro
 5. Remove dummy testing constants

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,0 @@
-TODO - GL:
-3. Align property type docs
-6. Change the id_type and size_type to std::size_t (ull -> uz)
-
-TODO - HGL:
-1. Remove the types namespace

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,5 @@
 TODO - GL:
 3. Align property type docs
-4. Remove the gl_attr_force_inline attribute and macro
 6. Change the id_type and size_type to std::size_t (ull -> uz)
 
 TODO - HGL:


### PR DESCRIPTION
- Removed the `gl::types` and `hgl::types` namespaces. All elements that were previously defined in these namespaces are now directly in `gl::` and/or `hgl::` namespaces
- Removed the `GL_CONFIG_PROPERTY_TYPES_NOT_FINAL` macro usage. All property types are now final
- Simplified the `name_property` type
- Removed redundant testing constants and namespaces