### PR TITLE
YT-CPPHGL-33: Replace the concrete id_type with a configurable hypergraph trait

### DIFF
--- a/include/gl/decl/graph_traits.hpp
+++ b/include/gl/decl/graph_traits.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/decl/impl_tags.hpp"
+#include "gl/directional_tags.hpp"
 #include "gl/traits.hpp"
 
 namespace gl {

--- a/include/gl/decl/impl_tags.hpp
+++ b/include/gl/decl/impl_tags.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "gl/directional_tags.hpp"
 #include "gl/traits.hpp"
 
 namespace gl {

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -204,6 +204,7 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
+// TODO: remove ???
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
     traits::c_properties Properties = empty_properties,

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -204,7 +204,6 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
-// TODO: remove ???
 template <
     traits::c_graph_directional_tag DirectionalTag = directed_t,
     traits::c_properties Properties = empty_properties,

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -134,6 +134,7 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
+// TODO: remove ???
 template <
     traits::c_properties Properties = empty_properties,
     traits::c_id_type IdType = default_id_type>

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -134,7 +134,6 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
-// TODO: remove ???
 template <
     traits::c_properties Properties = empty_properties,
     traits::c_id_type IdType = default_id_type>

--- a/include/hgl/constants.hpp
+++ b/include/hgl/constants.hpp
@@ -12,9 +12,6 @@ namespace hgl {
 namespace constants {
 
 template <traits::c_id_type IdType>
-inline constexpr IdType initial_id{0};
-
-template <traits::c_id_type IdType>
 inline constexpr IdType invalid_id{std::numeric_limits<IdType>::max()};
 
 } // namespace constants

--- a/include/hgl/constants.hpp
+++ b/include/hgl/constants.hpp
@@ -9,13 +9,6 @@
 
 namespace hgl {
 
-namespace constants {
-
-template <traits::c_id_type IdType>
-inline constexpr IdType invalid_id{std::numeric_limits<IdType>::max()};
-
-} // namespace constants
-
 using gl::initial_id;
 using gl::initial_id_t;
 using gl::initial_id_v;

--- a/include/hgl/constants.hpp
+++ b/include/hgl/constants.hpp
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include "gl/constants.hpp"
 #include "hgl/traits.hpp"
 
-namespace hgl::constants {
+namespace hgl {
+
+namespace constants {
 
 template <traits::c_id_type IdType>
 inline constexpr IdType initial_id{0};
@@ -14,4 +17,14 @@ inline constexpr IdType initial_id{0};
 template <traits::c_id_type IdType>
 inline constexpr IdType invalid_id{std::numeric_limits<IdType>::max()};
 
-} // namespace hgl::constants
+} // namespace constants
+
+using gl::initial_id;
+using gl::initial_id_t;
+using gl::initial_id_v;
+
+using gl::invalid_id;
+using gl::invalid_id_t;
+using gl::invalid_id_v;
+
+} // namespace hgl

--- a/include/hgl/conversion.hpp
+++ b/include/hgl/conversion.hpp
@@ -10,6 +10,7 @@
 #include "gl/types/core.hpp"
 #include "hgl/directional_tags.hpp"
 #include "hgl/hypergraph.hpp"
+#include "hgl/types.hpp"
 
 #include <algorithm>
 #include <ranges>
@@ -230,7 +231,7 @@ template <traits::c_hypergraph_impl_tag TargetImplTag, traits::c_hypergraph Hype
 
 template <gl::traits::c_undirected_graph G>
 [[nodiscard]] G projection(const traits::c_undirected_hypergraph auto& h) {
-    using edge_vertices = std::pair<id_type, id_type>;
+    using edge_vertices = hgl::homogeneous_pair<typename G::id_type>;
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {
@@ -262,7 +263,7 @@ requires std::same_as<typename G::traits_type::implementation_tag, gl::impl::fla
 
 template <gl::traits::c_directed_graph G>
 [[nodiscard]] G projection(const traits::c_bf_directed_hypergraph auto& h) {
-    using edge_vertices = std::pair<id_type, id_type>;
+    using edge_vertices = hgl::homogeneous_pair<typename G::id_type>;
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {

--- a/include/hgl/conversion.hpp
+++ b/include/hgl/conversion.hpp
@@ -236,8 +236,8 @@ template <gl::traits::c_undirected_graph G>
 
     for (const auto eid : h.hyperedge_ids()) {
         const auto clique_vertices = h.incident_vertex_ids(eid) | std::ranges::to<std::vector>();
-        for (std::size_t i = 0uz; i < clique_vertices.size(); i++) {
-            for (std::size_t j = 0uz; j < i; j++) {
+        for (auto i = 0uz; i < clique_vertices.size(); i++) {
+            for (auto j = 0uz; j < i; j++) {
                 const auto [u, v] = std::minmax(clique_vertices[i], clique_vertices[j]);
                 edges.emplace_back(u, v);
             }

--- a/include/hgl/decl/impl_tags.hpp
+++ b/include/hgl/decl/impl_tags.hpp
@@ -11,16 +11,18 @@ namespace hgl {
 
 namespace impl {
 
-// TODO: add default LayoutTag values
-
-template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType = default_id_type>
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = bidirectional_t,
+    traits::c_id_type IdType = default_id_type>
 struct list_t;
 
-template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType = default_id_type>
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = bidirectional_t,
+    traits::c_id_type IdType = default_id_type>
 struct flat_list_t;
 
 template <
-    traits::c_hypergraph_asymmetric_layout_tag LayoutTag,
+    traits::c_hypergraph_asymmetric_layout_tag LayoutTag = hyperedge_major_t,
     traits::c_id_type IdType = default_id_type>
 struct matrix_t;
 

--- a/include/hgl/decl/impl_tags.hpp
+++ b/include/hgl/decl/impl_tags.hpp
@@ -5,18 +5,23 @@
 #pragma once
 
 #include "hgl/impl/layout_tags.hpp"
+#include "hgl/types.hpp"
 
 namespace hgl {
 
 namespace impl {
 
-template <traits::c_hypergraph_layout_tag LayoutTag>
+// TODO: add default LayoutTag values
+
+template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType = default_id_type>
 struct list_t;
 
-template <traits::c_hypergraph_layout_tag LayoutTag>
+template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType = default_id_type>
 struct flat_list_t;
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
+template <
+    traits::c_hypergraph_asymmetric_layout_tag LayoutTag,
+    traits::c_id_type IdType = default_id_type>
 struct matrix_t;
 
 } // namespace impl

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -80,6 +80,7 @@ public:
     using implementation_tag = typename traits_type::implementation_tag;
     using implementation_type =
         typename implementation_tag::template implementation_type<directional_tag>;
+    using id_type = typename traits_type::id_type;
 
     using vertex_type = typename traits_type::vertex_type;
     using vertex_properties_type = typename traits_type::vertex_properties_type;

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -136,7 +136,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline auto vertex_ids() const noexcept {
-        return std::views::iota(constants::initial_id<id_type>, this->_n_vertices);
+        return std::views::iota(initial_id_v<id_type>, this->_n_vertices);
     }
 
     [[nodiscard]] vertex_type get_vertex(const id_type vertex_id) const {
@@ -263,7 +263,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline auto hyperedge_ids() const noexcept {
-        return std::views::iota(constants::initial_id<id_type>, this->_n_hyperedges);
+        return std::views::iota(initial_id_v<id_type>, this->_n_hyperedges);
     }
 
     [[nodiscard]] hyperedge_type get_hyperedge(const id_type hyperedge_id) const {

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -316,7 +316,7 @@ public:
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
             const auto old_size = this->_hyperedge_properties.size();
             this->_hyperedge_properties.reserve(this->_n_hyperedges);
-            for (size_type i = old_size; i < this->_n_hyperedges; ++i)
+            for (auto i = old_size; i < this->_n_hyperedges; ++i)
                 this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
                 );
         }
@@ -826,7 +826,7 @@ private:
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
         return [&pmap = this->_vertex_properties](const id_type id) {
-            return vertex_type{id, *pmap[id]};
+            return vertex_type{id, *pmap[to_idx(id)]};
         };
     }
 
@@ -840,7 +840,7 @@ private:
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
         return [&pmap = this->_hyperedge_properties](const id_type id) {
-            return hyperedge_type{id, *pmap[id]};
+            return hyperedge_type{id, *pmap[to_idx(id)]};
         };
     }
 

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -49,14 +49,14 @@ public:
     [[nodiscard]] gl_attr_force_inline static hyperedge_descriptor invalid() noexcept
     requires(traits::c_empty_properties<properties_type>)
     {
-        return hyperedge_descriptor(constants::invalid_id<id_type>);
+        return hyperedge_descriptor(invalid_id);
     }
 
     [[nodiscard]] gl_attr_force_inline static hyperedge_descriptor invalid() noexcept
     requires(traits::c_non_empty_properties<properties_type>)
     {
         static properties_type invalid_properties{};
-        return hyperedge_descriptor(constants::invalid_id<id_type>, invalid_properties);
+        return hyperedge_descriptor(invalid_id, invalid_properties);
     }
 
     hyperedge_descriptor(const hyperedge_descriptor&) = default;
@@ -82,7 +82,7 @@ public:
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_valid() const noexcept {
-        return this->_id != constants::invalid_id<id_type>;
+        return this->_id != invalid_id;
     }
 
     [[nodiscard]] gl_attr_force_inline id_type id() const noexcept {

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -14,10 +14,7 @@ namespace hgl {
 
 // hypergraph vertex descriptor
 
-template <
-    traits::c_properties Properties = empty_properties,
-    traits::c_id_type IdType = default_id_type>
-using vertex_descriptor = gl::vertex_descriptor<Properties, IdType>;
+using gl::vertex_descriptor;
 
 // hyperedge descriptor
 
@@ -103,9 +100,5 @@ private:
         empty_properties,
         std::reference_wrapper<properties_type>> _properties;
 };
-
-// TODO: remove
-template <traits::c_properties Properties = empty_properties>
-using hyperedge = hyperedge_descriptor<Properties>;
 
 } // namespace hgl

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -14,15 +14,20 @@ namespace hgl {
 
 // hypergraph vertex descriptor
 
-template <traits::c_properties Properties = empty_properties>
-using vertex_descriptor = gl::vertex_descriptor<Properties, id_type>;
+template <
+    traits::c_properties Properties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using vertex_descriptor = gl::vertex_descriptor<Properties, IdType>;
 
 // hyperedge descriptor
 
-template <traits::c_properties Properties = empty_properties>
+template <
+    traits::c_properties Properties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
 class hyperedge_descriptor final {
 public:
     using type = hyperedge_descriptor<Properties>;
+    using id_type = IdType;
     using properties_type = Properties;
     using properties_ref_type = std::conditional_t<
         traits::c_empty_properties<properties_type>,
@@ -99,6 +104,7 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
+// TODO: remove
 template <traits::c_properties Properties = empty_properties>
 using hyperedge = hyperedge_descriptor<Properties>;
 

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/types/core.hpp"
 #include "hgl/directional_tags.hpp"
 #include "hgl/hypergraph_elements.hpp"
 #include "hgl/impl/impl_tags.hpp"
@@ -15,13 +16,12 @@ template <
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
-    traits::c_id_type IdType = default_id_type>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
 struct hypergraph_traits {
     using directional_tag = DirectionalTag;
     using implementation_tag = ImplTag;
     using layout_tag = typename implementation_tag::layout_tag;
-    using id_type = IdType;
+    using id_type = typename implementation_tag::id_type;
 
     using vertex_type = vertex_descriptor<VertexProperties, id_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
@@ -40,8 +40,7 @@ using list_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
     HyperedgeProperties,
-    impl::list_t<LayoutTag>,
-    IdType>;
+    impl::list_t<LayoutTag, IdType>>;
 
 template <
     traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
@@ -53,8 +52,7 @@ using flat_list_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
     HyperedgeProperties,
-    impl::flat_list_t<LayoutTag>,
-    IdType>;
+    impl::flat_list_t<LayoutTag, IdType>>;
 
 template <
     traits::c_hypergraph_asymmetric_layout_tag LayoutTag = impl::hyperedge_major_t,
@@ -66,24 +64,21 @@ using matrix_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
     HyperedgeProperties,
-    impl::matrix_t<LayoutTag>,
-    IdType>;
+    impl::matrix_t<LayoutTag, IdType>>;
 
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
-    traits::c_id_type IdType = default_id_type>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
 using undirected_hypergraph_traits =
-    hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag, IdType>;
+    hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
-    traits::c_id_type IdType = default_id_type>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
 using bf_directed_hypergraph_traits =
-    hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag, IdType>;
+    hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 namespace traits {
 

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -16,7 +16,7 @@ template <
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<>>
 struct hypergraph_traits {
     using directional_tag = DirectionalTag;
     using implementation_tag = ImplTag;
@@ -31,7 +31,7 @@ struct hypergraph_traits {
 };
 
 template <
-    traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
@@ -43,7 +43,7 @@ using list_hypergraph_traits = hypergraph_traits<
     impl::list_t<LayoutTag, IdType>>;
 
 template <
-    traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
@@ -69,14 +69,14 @@ using matrix_hypergraph_traits = hypergraph_traits<
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<>>
 using undirected_hypergraph_traits =
     hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag>;
 
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t, default_id_type>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<>>
 using bf_directed_hypergraph_traits =
     hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag>;
 

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -15,15 +15,18 @@ template <
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
+    traits::c_id_type IdType = default_id_type>
 struct hypergraph_traits {
     using directional_tag = DirectionalTag;
     using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = IdType;
 
-    using vertex_type = vertex_descriptor<VertexProperties>;
+    using vertex_type = vertex_descriptor<VertexProperties, id_type>;
     using vertex_properties_type = typename vertex_type::properties_type;
 
-    using hyperedge_type = hyperedge_descriptor<HyperedgeProperties>;
+    using hyperedge_type = hyperedge_descriptor<HyperedgeProperties, id_type>;
     using hyperedge_properties_type = typename hyperedge_type::properties_type;
 };
 
@@ -31,45 +34,56 @@ template <
     traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
-    traits::c_properties HyperedgeProperties = empty_properties>
-using list_hypergraph_traits =
-    hypergraph_traits<DirectionalTag, VertexProperties, HyperedgeProperties, impl::list_t<LayoutTag>>;
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using list_hypergraph_traits = hypergraph_traits<
+    DirectionalTag,
+    VertexProperties,
+    HyperedgeProperties,
+    impl::list_t<LayoutTag>,
+    IdType>;
 
 template <
     traits::c_hypergraph_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
-    traits::c_properties HyperedgeProperties = empty_properties>
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
 using flat_list_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
     HyperedgeProperties,
-    impl::flat_list_t<LayoutTag>>;
+    impl::flat_list_t<LayoutTag>,
+    IdType>;
 
 template <
     traits::c_hypergraph_asymmetric_layout_tag LayoutTag = impl::hyperedge_major_t,
     traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
     traits::c_properties VertexProperties = empty_properties,
-    traits::c_properties HyperedgeProperties = empty_properties>
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
 using matrix_hypergraph_traits = hypergraph_traits<
     DirectionalTag,
     VertexProperties,
     HyperedgeProperties,
-    impl::matrix_t<LayoutTag>>;
+    impl::matrix_t<LayoutTag>,
+    IdType>;
 
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
+    traits::c_id_type IdType = default_id_type>
 using undirected_hypergraph_traits =
-    hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag>;
+    hypergraph_traits<undirected_t, VertexProperties, HyperedgeProperties, ImplTag, IdType>;
 
 template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties HyperedgeProperties = empty_properties,
-    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>>
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<impl::hyperedge_major_t>,
+    traits::c_id_type IdType = default_id_type>
 using bf_directed_hypergraph_traits =
-    hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag>;
+    hypergraph_traits<bf_directed_t, VertexProperties, HyperedgeProperties, ImplTag, IdType>;
 
 namespace traits {
 

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -53,11 +53,12 @@ template <traits::c_id_type IdType>
 inline void unique_insert(
     flat_list_storage_type<IdType>& storage, const IdType major_id, const IdType minor_id
 ) noexcept {
-    const auto segment = storage[major_id];
+    const auto major_idx = to_idx(major_id);
+    const auto segment = storage[major_idx];
     const auto insert_it = std::ranges::lower_bound(segment, minor_id);
     if (insert_it == segment.end() or *insert_it != minor_id) {
         const auto pos = static_cast<size_type>(std::distance(segment.begin(), insert_it));
-        storage.insert(major_id, pos, minor_id);
+        storage.insert(major_idx, pos, minor_id);
     }
 }
 
@@ -176,12 +177,13 @@ public:
 
     gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
+        const auto major_idx = to_idx(major_id);
 
-        const auto segment = this->_storage[major_id];
+        const auto segment = this->_storage[major_idx];
         const auto minor_it = std::ranges::lower_bound(segment, minor_id);
         if (minor_it != segment.end() and *minor_it == minor_id) {
             const auto pos = static_cast<size_type>(std::distance(segment.begin(), minor_it));
-            this->_storage.erase(major_id, pos);
+            this->_storage.erase(major_idx, pos);
         }
     }
 
@@ -189,7 +191,7 @@ public:
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         return detail::contains(
-            this->_storage[layout_tag::major(vertex_id, hyperedge_id)],
+            this->_storage[to_idx(layout_tag::major(vertex_id, hyperedge_id))],
             layout_tag::minor(vertex_id, hyperedge_id)
         );
     }
@@ -224,7 +226,7 @@ private:
     template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) // remove major
-            this->_storage.erase(id);
+            this->_storage.erase(to_idx(id));
         else // remove minor
             detail::remove_minor(this->_storage, id);
     }
@@ -232,11 +234,11 @@ private:
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
-            return this->_storage[id];
+            return this->_storage[to_idx(id)];
         }
         else { // incident with minor
             return std::views::iota(initial_id_v<size_type>, this->_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                 | std::views::filter([this, minor_id = id](size_type major_idx) {
                        return detail::contains(this->_storage[major_idx], minor_id);
                    });
         }
@@ -245,7 +247,7 @@ private:
     template <element_type Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return this->_storage[id].size();
+            return this->_storage[to_idx(id)].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -271,7 +273,7 @@ private:
         else { // size minor
             std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto minor_id : this->_storage.data_view())
-                ++size_map[static_cast<std::size_t>(minor_id)];
+                ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }
@@ -492,16 +494,17 @@ private:
     [[nodiscard]] gl_attr_force_inline auto _storage_view(
         const id_type id, const Projection storage_proj
     ) const noexcept {
+        const auto idx = to_idx(id);
         if constexpr (std::same_as<Projection, std::identity>) {
             // TODO: use std::views::concat (C++26)
             // NOTE: This is safe because the range operator | creates an owning view over the array
-            return std::array<storage_const_segment_type, 2>{
-                       this->_tail_storage[id], this->_head_storage[id]
+            return std::array<storage_const_segment_type, 2uz>{
+                       this->_tail_storage[idx], this->_head_storage[idx]
                    }
                  | std::views::join;
         }
         else {
-            return std::invoke(storage_proj, this)[id];
+            return std::invoke(storage_proj, this)[idx];
         }
     }
 
@@ -516,8 +519,9 @@ private:
     template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) {
-            this->_tail_storage.erase(id);
-            this->_head_storage.erase(id);
+            const auto idx = to_idx(id);
+            this->_tail_storage.erase(idx);
+            this->_head_storage.erase(idx);
         }
         else {
             detail::remove_minor(this->_tail_storage, id);
@@ -528,25 +532,27 @@ private:
     void _remove_no_align(
         storage_type& storage, const id_type major_id, const id_type minor_id
     ) noexcept {
-        const auto segment = storage[major_id];
+        const auto major_idx = to_idx(major_id);
+        const auto segment = storage[major_idx];
         const auto minor_it = std::ranges::lower_bound(segment, minor_id);
         if (minor_it != segment.end() and *minor_it == minor_id) {
             const auto pos = static_cast<size_type>(std::distance(segment.begin(), minor_it));
-            storage.erase(major_id, pos);
+            storage.erase(major_idx, pos);
         }
     }
 
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
-            return std::array<storage_const_segment_type, 2>{
-                       this->_tail_storage[id], this->_head_storage[id]
+            const auto idx = to_idx(id);
+            return std::array<storage_const_segment_type, 2uz>{
+                       this->_tail_storage[idx], this->_head_storage[idx]
                    }
                  | std::views::join;
         }
         else { // get minor
             return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                 | std::views::filter([this, minor_id = id](size_type major_idx) {
                        return detail::contains(this->_tail_storage[major_idx], minor_id)
                            or detail::contains(this->_head_storage[major_idx], minor_id);
                    });
@@ -557,23 +563,23 @@ private:
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const auto&& storage_proj)
         const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
-            return std::invoke(storage_proj, this)[id];
+            return std::invoke(storage_proj, this)[to_idx(id)];
         }
         else { // get minor
             return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](const size_type major_idx
-                                      ) {
-                       return detail::contains(
-                           std::invoke(storage_proj, this)[major_idx], minor_id
-                       );
-                   });
+                 | std::views::filter(
+                       [this, &storage = std::invoke(storage_proj, this), minor_id = id](
+                           size_type major_idx
+                       ) { return detail::contains(storage[major_idx], minor_id); }
+                 );
         }
     }
 
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return this->_tail_storage[id].size() + this->_head_storage[id].size();
+            const auto idx = to_idx(id);
+            return this->_tail_storage[idx].size() + this->_head_storage[idx].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -591,7 +597,7 @@ private:
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const auto&& storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return std::invoke(storage_proj, this)[id].size();
+            return std::invoke(storage_proj, this)[to_idx(id)].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -619,9 +625,9 @@ private:
         else { // size minor
             std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto minor_id : this->_tail_storage.data_view())
-                ++size_map[static_cast<std::size_t>(minor_id)];
+                ++size_map[to_idx(minor_id)];
             for (const auto minor_id : this->_head_storage.data_view())
-                ++size_map[static_cast<std::size_t>(minor_id)];
+                ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }
@@ -630,11 +636,12 @@ private:
     [[nodiscard]] std::vector<size_type> _size_map(
         const size_type n_elements, const auto&& storage_proj
     ) const noexcept {
+        const auto& storage = std::invoke(storage_proj, this);
         if constexpr (Element == layout_tag::major_element) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
 
-            const auto n_segments = std::invoke(storage_proj, this).size();
-            const auto offsets = std::invoke(storage_proj, this).offsets_view();
+            const auto n_segments = storage.size();
+            const auto offsets = storage.offsets_view();
 
             for (auto i = 0uz; i < n_segments; ++i)
                 size_map[i] = offsets[i + 1uz] - offsets[i];
@@ -642,8 +649,8 @@ private:
         }
         else { // size minor
             std::vector<size_type> size_map(n_elements, 0uz);
-            for (const auto minor_id : std::invoke(storage_proj, this).data_view())
-                ++size_map[static_cast<std::size_t>(minor_id)];
+            for (const auto minor_id : storage.data_view())
+                ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -235,9 +235,9 @@ private:
             return this->_storage[id];
         }
         else { // incident with minor
-            return std::views::iota(constants::initial_id<id_type>, this->_storage.size())
-                 | std::views::filter([this, minor_id = id](const id_type major_id) {
-                       return detail::contains(this->_storage[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_storage.size())
+                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                       return detail::contains(this->_storage[major_idx], minor_id);
                    });
         }
     }
@@ -545,10 +545,10 @@ private:
                  | std::views::join;
         }
         else { // get minor
-            return std::views::iota(constants::initial_id<id_type>, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](id_type major_id) {
-                       return detail::contains(this->_tail_storage[major_id], minor_id)
-                           or detail::contains(this->_head_storage[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
+                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                       return detail::contains(this->_tail_storage[major_idx], minor_id)
+                           or detail::contains(this->_head_storage[major_idx], minor_id);
                    });
         }
     }
@@ -560,9 +560,12 @@ private:
             return std::invoke(storage_proj, this)[id];
         }
         else { // get minor
-            return std::views::iota(constants::initial_id<id_type>, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](id_type major_id) {
-                       return detail::contains(std::invoke(storage_proj, this)[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
+                 | std::views::filter([this, storage_proj, minor_id = id](const size_type major_idx
+                                      ) {
+                       return detail::contains(
+                           std::invoke(storage_proj, this)[major_idx], minor_id
+                       );
                    });
         }
     }

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -7,6 +7,7 @@
 #include "hgl/constants.hpp"
 #include "hgl/decl/impl_tags.hpp"
 #include "hgl/directional_tags.hpp"
+#include "hgl/impl/impl_tags.hpp"
 #include "hgl/impl/layout_tags.hpp"
 #include "hgl/types.hpp"
 
@@ -36,17 +37,21 @@ namespace impl {
 
 namespace detail {
 
-using flat_list_storage_type = flat_jagged_vector<id_type>;
+template <traits::c_id_type IdType>
+using flat_list_storage_type = flat_jagged_vector<IdType>;
 
+template <traits::c_id_type IdType>
 [[nodiscard]] inline bool contains(
-    const flat_list_storage_type::const_segment_type& segment, const id_type minor_id
+    const typename flat_list_storage_type<IdType>::const_segment_type& segment,
+    const IdType minor_id
 ) noexcept {
     const auto minor_it = std::ranges::lower_bound(segment, minor_id);
     return minor_it != segment.end() and *minor_it == minor_id;
 }
 
+template <traits::c_id_type IdType>
 inline void unique_insert(
-    flat_list_storage_type& storage, const id_type major_id, const id_type minor_id
+    flat_list_storage_type<IdType>& storage, const IdType major_id, const IdType minor_id
 ) noexcept {
     const auto segment = storage[major_id];
     const auto insert_it = std::ranges::lower_bound(segment, minor_id);
@@ -56,7 +61,8 @@ inline void unique_insert(
     }
 }
 
-inline void remove_minor(flat_list_storage_type& storage, const id_type id) noexcept {
+template <traits::c_id_type IdType>
+inline void remove_minor(flat_list_storage_type<IdType>& storage, const IdType id) noexcept {
     auto& data = storage.data_storage();
     auto& offsets = storage.offsets_storage();
 
@@ -86,14 +92,17 @@ inline void remove_minor(flat_list_storage_type& storage, const id_type id) noex
 
 template <
     traits::c_hypergraph_directional_tag DirectionalTag,
-    traits::c_hypergraph_layout_tag LayoutTag>
+    traits::c_hypergraph_flat_list_impl ImplTag>
 class flat_incidence_list;
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class flat_incidence_list<hgl::undirected_t, LayoutTag> final {
+template <traits::c_hypergraph_flat_list_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class flat_incidence_list<hgl::undirected_t, ImplTag> final {
 public:
     using directional_tag = hgl::undirected_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     flat_incidence_list() = default;
 
@@ -202,8 +211,7 @@ public:
 #endif
 
 private:
-    using element_type = id_type;
-    using storage_type = flat_jagged_vector<element_type>;
+    using storage_type = flat_jagged_vector<id_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
@@ -271,11 +279,14 @@ private:
     storage_type _storage;
 };
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class flat_incidence_list<hgl::bf_directed_t, LayoutTag> final {
+template <traits::c_hypergraph_flat_list_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class flat_incidence_list<hgl::bf_directed_t, ImplTag> final {
 public:
     using directional_tag = hgl::bf_directed_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     flat_incidence_list() = default;
 
@@ -481,8 +492,7 @@ public:
 #endif
 
 private:
-    using element_type = id_type;
-    using storage_type = flat_jagged_vector<element_type>;
+    using storage_type = flat_jagged_vector<id_type>;
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
@@ -647,11 +657,16 @@ private:
     storage_type _head_storage;
 };
 
-template <traits::c_hypergraph_directional_tag DirectionalTag>
-class flat_incidence_list<DirectionalTag, bidirectional_t> final {
+template <
+    traits::c_hypergraph_directional_tag DirectionalTag,
+    traits::c_hypergraph_flat_list_impl ImplTag>
+requires std::same_as<typename ImplTag::layout_tag, bidirectional_t>
+class flat_incidence_list<DirectionalTag, ImplTag> final {
 public:
     using directional_tag = DirectionalTag;
-    using layout_tag = bidirectional_t;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     flat_incidence_list() = default;
 
@@ -872,8 +887,10 @@ public:
 #endif
 
 private:
-    using vertex_major_list = flat_incidence_list<DirectionalTag, vertex_major_t>;
-    using hyperedge_major_list = flat_incidence_list<DirectionalTag, hyperedge_major_t>;
+    using vertex_major_list =
+        flat_incidence_list<DirectionalTag, impl::flat_list_t<impl::vertex_major_t, id_type>>;
+    using hyperedge_major_list =
+        flat_incidence_list<DirectionalTag, impl::flat_list_t<impl::hyperedge_major_t, id_type>>;
 
     vertex_major_list _v_list;
     hyperedge_major_list _e_list;

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "gl/types/core.hpp"
 #include "hgl/constants.hpp"
 #include "hgl/decl/impl_tags.hpp"
 #include "hgl/directional_tags.hpp"
-#include "hgl/impl/impl_tags.hpp"
 #include "hgl/impl/layout_tags.hpp"
 #include "hgl/types.hpp"
 
@@ -17,6 +17,8 @@
 #include <functional>
 #include <ranges>
 #include <vector>
+
+// TODO: remove impl::
 
 #ifdef HGL_TESTING
 namespace hgl_testing {
@@ -888,9 +890,9 @@ public:
 
 private:
     using vertex_major_list =
-        flat_incidence_list<DirectionalTag, impl::flat_list_t<impl::vertex_major_t, id_type>>;
+        flat_incidence_list<DirectionalTag, flat_list_t<vertex_major_t, id_type>>;
     using hyperedge_major_list =
-        flat_incidence_list<DirectionalTag, impl::flat_list_t<impl::hyperedge_major_t, id_type>>;
+        flat_incidence_list<DirectionalTag, flat_list_t<hyperedge_major_t, id_type>>;
 
     vertex_major_list _v_list;
     hyperedge_major_list _e_list;

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -18,8 +18,6 @@
 #include <ranges>
 #include <vector>
 
-// TODO: remove impl::
-
 #ifdef HGL_TESTING
 namespace hgl_testing {
 struct test_flat_incidence_list;
@@ -122,51 +120,51 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::vertex>(vertex_id);
+        return this->_incident_with<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id);
+        return this->_size<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(n_vertices);
+        return this->_size_map<element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_size<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
         const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -217,13 +215,13 @@ private:
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) // add major
             this->_storage.resize(this->_storage.size() + n);
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) // remove major
             this->_storage.erase(id);
@@ -231,7 +229,7 @@ private:
             detail::remove_minor(this->_storage, id);
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return this->_storage[id];
@@ -244,7 +242,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_storage[id].size();
@@ -258,7 +256,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
@@ -307,60 +305,52 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_get<impl::element_type::vertex>(vertex_id);
+        return this->_get<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id);
+        return this->_size<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(n_vertices);
+        return this->_size_map<element_type::vertex>(n_vertices);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<impl::element_type::vertex>(
-            vertex_id, &flat_incidence_list::_tail_storage
-        );
+        return this->_get<element_type::vertex>(vertex_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(
-            vertex_id, &flat_incidence_list::_tail_storage
-        );
+        return this->_size<element_type::vertex>(vertex_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(
+        return this->_size_map<element_type::vertex>(
             n_vertices, &flat_incidence_list::_tail_storage
         );
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<impl::element_type::vertex>(
-            vertex_id, &flat_incidence_list::_head_storage
-        );
+        return this->_get<element_type::vertex>(vertex_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(
-            vertex_id, &flat_incidence_list::_head_storage
-        );
+        return this->_size<element_type::vertex>(vertex_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(
+        return this->_size_map<element_type::vertex>(
             n_vertices, &flat_incidence_list::_head_storage
         );
     }
@@ -368,65 +358,65 @@ public:
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_get<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_size<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(
+        return this->_get<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_tail_storage
         );
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(
+        return this->_size<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_tail_storage
         );
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(
+        return this->_size_map<element_type::hyperedge>(
             n_hyperedges, &flat_incidence_list::_tail_storage
         );
     }
 
     [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(
+        return this->_get<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_head_storage
         );
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(
+        return this->_size<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_head_storage
         );
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(
+        return this->_size_map<element_type::hyperedge>(
             n_hyperedges, &flat_incidence_list::_head_storage
         );
     }
@@ -515,7 +505,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) {
             this->_tail_storage.resize(this->_tail_storage.size() + n);
@@ -523,7 +513,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) {
             this->_tail_storage.erase(id);
@@ -546,7 +536,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::array<storage_const_segment_type, 2>{
@@ -563,7 +553,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const auto&& storage_proj)
         const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
@@ -577,7 +567,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_tail_storage[id].size() + this->_head_storage[id].size();
@@ -594,7 +584,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const auto&& storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
@@ -609,7 +599,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
@@ -633,7 +623,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(
         const size_type n_elements, const auto&& storage_proj
     ) const noexcept {

--- a/include/hgl/impl/impl_tags.hpp
+++ b/include/hgl/impl/impl_tags.hpp
@@ -5,38 +5,44 @@
 #pragma once
 
 #include "hgl/decl/impl_tags.hpp"
-#include "hgl/directional_tags.hpp"
 #include "hgl/impl/flat_incidence_list.hpp"
 #include "hgl/impl/incidence_list.hpp"
 #include "hgl/impl/incidence_matrix.hpp"
 #include "hgl/impl/layout_tags.hpp"
-#include "hgl/traits.hpp"
-#include "hgl/types.hpp"
 
 namespace hgl::impl {
 
-template <traits::c_hypergraph_layout_tag LayoutTag>
+template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType>
 struct list_t {
+    using type = list_t<LayoutTag, IdType>;
+
     using layout_tag = LayoutTag;
+    using id_type = IdType;
 
     template <traits::c_hypergraph_directional_tag DirectionalTag>
-    using implementation_type = incidence_list<DirectionalTag, LayoutTag>;
+    using implementation_type = incidence_list<DirectionalTag, type>;
 };
 
-template <traits::c_hypergraph_layout_tag LayoutTag>
+template <traits::c_hypergraph_layout_tag LayoutTag, traits::c_id_type IdType>
 struct flat_list_t {
+    using type = flat_list_t<LayoutTag, IdType>;
+
     using layout_tag = LayoutTag;
+    using id_type = IdType;
 
     template <traits::c_hypergraph_directional_tag DirectionalTag>
-    using implementation_type = flat_incidence_list<DirectionalTag, LayoutTag>;
+    using implementation_type = flat_incidence_list<DirectionalTag, type>;
 };
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
+template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag, traits::c_id_type IdType>
 struct matrix_t {
+    using type = matrix_t<LayoutTag, IdType>;
+
     using layout_tag = LayoutTag;
+    using id_type = IdType;
 
     template <traits::c_hypergraph_directional_tag DirectionalTag>
-    using implementation_type = incidence_matrix<DirectionalTag, LayoutTag>;
+    using implementation_type = incidence_matrix<DirectionalTag, type>;
 };
 
 } // namespace hgl::impl

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -190,9 +190,9 @@ private:
             return std::views::all(this->_major_storage[id]);
         }
         else { // incident with minor
-            return std::views::iota(constants::initial_id<size_type>, this->_major_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_id) {
-                       return this->_contains(this->_major_storage[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_major_storage.size())
+                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                       return this->_contains(this->_major_storage[major_idx], minor_id);
                    });
         }
     }
@@ -482,10 +482,10 @@ private:
                  | std::views::join;
         }
         else { // get minor
-            return std::views::iota(constants::initial_id<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_id) {
-                       return this->_contains(this->_tail_storage[major_id], minor_id)
-                           or this->_contains(this->_head_storage[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
+                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                       return this->_contains(this->_tail_storage[major_idx], minor_id)
+                           or this->_contains(this->_head_storage[major_idx], minor_id);
                    });
         }
     }
@@ -497,9 +497,10 @@ private:
             return std::views::all(std::invoke(storage_proj, this)[id]);
         }
         else { // get minor
-            return std::views::iota(constants::initial_id<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](const size_type major_id) {
-                       return this->_contains(std::invoke(storage_proj, this)[major_id], minor_id);
+            return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
+                 | std::views::filter([this, storage_proj, minor_id = id](const size_type major_idx
+                                      ) {
+                       return this->_contains(std::invoke(storage_proj, this)[major_idx], minor_id);
                    });
         }
     }

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -114,7 +114,7 @@ public:
 
     gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        auto& minor_storage = this->_major_storage[major_id];
+        auto& minor_storage = this->_major_storage[to_idx(major_id)];
 
         // insert the id at the correct position to keep the minor-id collection sorted
         const auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);
@@ -124,7 +124,7 @@ public:
 
     gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        auto& minor_storage = this->_major_storage[major_id];
+        auto& minor_storage = this->_major_storage[to_idx(major_id)];
         const auto minor_it = std::ranges::lower_bound(minor_storage, minor_id);
         if (minor_it != minor_storage.end() and *minor_it == minor_id)
             minor_storage.erase(minor_it);
@@ -134,7 +134,7 @@ public:
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         return this->_contains(
-            this->_major_storage[layout_tag::major(vertex_id, hyperedge_id)],
+            this->_major_storage[to_idx(layout_tag::major(vertex_id, hyperedge_id))],
             layout_tag::minor(vertex_id, hyperedge_id)
         );
     }
@@ -187,11 +187,11 @@ private:
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
-            return std::views::all(this->_major_storage[id]);
+            return std::views::all(this->_major_storage[to_idx(id)]);
         }
         else { // incident with minor
             return std::views::iota(initial_id_v<size_type>, this->_major_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                 | std::views::filter([this, minor_id = id](size_type major_idx) {
                        return this->_contains(this->_major_storage[major_idx], minor_id);
                    });
         }
@@ -200,7 +200,7 @@ private:
     template <element_type Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return this->_major_storage[id].size();
+            return this->_major_storage[to_idx(id)].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -222,8 +222,8 @@ private:
         else { // size minor
             std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& major_entry : this->_major_storage)
-                for (const auto& minor_id : major_entry)
-                    ++size_map[static_cast<std::size_t>(minor_id)];
+                for (const auto minor_id : major_entry)
+                    ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }
@@ -374,44 +374,48 @@ public:
         const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_remove_no_align(this->_head_storage[major_id], minor_id);
-        this->_unique_insert(this->_tail_storage[major_id], minor_id);
+        const auto major_idx = to_idx(major_id);
+        this->_remove_no_align(this->_head_storage[major_idx], minor_id);
+        this->_unique_insert(this->_tail_storage[major_idx], minor_id);
     }
 
     gl_attr_force_inline void bind_head(
         const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_remove_no_align(this->_tail_storage[major_id], minor_id);
-        this->_unique_insert(this->_head_storage[major_id], minor_id);
+        const auto major_idx = to_idx(major_id);
+        this->_remove_no_align(this->_tail_storage[major_idx], minor_id);
+        this->_unique_insert(this->_head_storage[major_idx], minor_id);
     }
 
     gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_remove_no_align(this->_tail_storage[major_id], minor_id);
-        this->_remove_no_align(this->_head_storage[major_id], minor_id);
+        const auto major_idx = to_idx(major_id);
+        this->_remove_no_align(this->_tail_storage[major_idx], minor_id);
+        this->_remove_no_align(this->_head_storage[major_idx], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_contains(this->_tail_storage[major_id], minor_id)
-            or this->_contains(this->_head_storage[major_id], minor_id);
+        const auto major_idx = to_idx(major_id);
+        return this->_contains(this->_tail_storage[major_idx], minor_id)
+            or this->_contains(this->_head_storage[major_idx], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_contains(this->_tail_storage[major_id], minor_id);
+        return this->_contains(this->_tail_storage[to_idx(major_id)], minor_id);
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_contains(this->_head_storage[major_id], minor_id);
+        return this->_contains(this->_head_storage[to_idx(major_id)], minor_id);
     }
 
     // --- comparison ---
@@ -476,14 +480,15 @@ private:
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
+            const auto idx = to_idx(id);
             return std::array<std::span<const minor_element_type>, 2>{
-                       this->_tail_storage[id], this->_head_storage[id]
+                       this->_tail_storage[idx], this->_head_storage[idx]
                    }
                  | std::views::join;
         }
         else { // get minor
             return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_idx) {
+                 | std::views::filter([this, minor_id = id](size_type major_idx) {
                        return this->_contains(this->_tail_storage[major_idx], minor_id)
                            or this->_contains(this->_head_storage[major_idx], minor_id);
                    });
@@ -494,21 +499,23 @@ private:
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const Projection storage_proj)
         const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
-            return std::views::all(std::invoke(storage_proj, this)[id]);
+            return std::views::all(std::invoke(storage_proj, this)[to_idx(id)]);
         }
         else { // get minor
             return std::views::iota(initial_id_v<size_type>, this->_tail_storage.size())
-                 | std::views::filter([this, storage_proj, minor_id = id](const size_type major_idx
-                                      ) {
-                       return this->_contains(std::invoke(storage_proj, this)[major_idx], minor_id);
-                   });
+                 | std::views::filter(
+                       [this, &storage = std::invoke(storage_proj, this), minor_id = id](
+                           size_type major_idx
+                       ) { return this->_contains(storage[major_idx], minor_id); }
+                 );
         }
     }
 
     template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return this->_tail_storage[id].size() + this->_head_storage[id].size();
+            const auto idx = to_idx(id);
+            return this->_tail_storage[idx].size() + this->_head_storage[idx].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -526,7 +533,7 @@ private:
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const Projection storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
-            return std::invoke(storage_proj, this)[id].size();
+            return std::invoke(storage_proj, this)[to_idx(id)].size();
         }
         else { // size minor
             size_type size = 0uz;
@@ -550,10 +557,10 @@ private:
             std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& minor_storage : this->_tail_storage)
                 for (const auto minor_id : minor_storage)
-                    ++size_map[static_cast<std::size_t>(minor_id)];
+                    ++size_map[to_idx(minor_id)];
             for (const auto& minor_storage : this->_head_storage)
                 for (const auto minor_id : minor_storage)
-                    ++size_map[static_cast<std::size_t>(minor_id)];
+                    ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }
@@ -574,7 +581,7 @@ private:
             std::vector<size_type> size_map(n_elements, 0uz);
             for (const auto& minor_storage : std::invoke(storage_proj, this))
                 for (const auto minor_id : minor_storage)
-                    ++size_map[static_cast<std::size_t>(minor_id)];
+                    ++size_map[to_idx(minor_id)];
             return size_map;
         }
     }

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -18,8 +18,6 @@
 #include <ranges>
 #include <vector>
 
-// TODO: remove impl::
-
 #ifdef HGL_TESTING
 namespace hgl_testing {
 struct test_incidence_list;
@@ -65,51 +63,51 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::vertex>(vertex_id);
+        return this->_incident_with<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id);
+        return this->_size<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(n_vertices);
+        return this->_size_map<element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_size<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
         const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -162,13 +160,13 @@ private:
     using major_element_type = minor_storage_type;
     using major_storage_type = std::vector<major_element_type>;
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) // add major
             this->_major_storage.resize(this->_major_storage.size() + n);
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_major_storage.erase(
@@ -186,7 +184,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return std::views::all(this->_major_storage[id]);
@@ -199,7 +197,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_major_storage[id].size();
@@ -213,7 +211,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             auto size_map = this->_major_storage | std::views::transform(&major_element_type::size)
@@ -266,118 +264,106 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_get<impl::element_type::vertex>(vertex_id);
+        return this->_get<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id);
+        return this->_size<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(n_vertices);
+        return this->_size_map<element_type::vertex>(n_vertices);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<impl::element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
+        return this->_get<element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
+        return this->_size<element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(
-            n_vertices, &incidence_list::_tail_storage
-        );
+        return this->_size_map<element_type::vertex>(n_vertices, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<impl::element_type::vertex>(vertex_id, &incidence_list::_head_storage);
+        return this->_get<element_type::vertex>(vertex_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_size<impl::element_type::vertex>(vertex_id, &incidence_list::_head_storage);
+        return this->_size<element_type::vertex>(vertex_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<impl::element_type::vertex>(
-            n_vertices, &incidence_list::_head_storage
-        );
+        return this->_size_map<element_type::vertex>(n_vertices, &incidence_list::_head_storage);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_get<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_size<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(
-            hyperedge_id, &incidence_list::_tail_storage
-        );
+        return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(
-            hyperedge_id, &incidence_list::_tail_storage
-        );
+        return this->_size<element_type::hyperedge>(hyperedge_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(
+        return this->_size_map<element_type::hyperedge>(
             n_hyperedges, &incidence_list::_tail_storage
         );
     }
 
     [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<impl::element_type::hyperedge>(
-            hyperedge_id, &incidence_list::_head_storage
-        );
+        return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<impl::element_type::hyperedge>(
-            hyperedge_id, &incidence_list::_head_storage
-        );
+        return this->_size<element_type::hyperedge>(hyperedge_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<impl::element_type::hyperedge>(
+        return this->_size_map<element_type::hyperedge>(
             n_hyperedges, &incidence_list::_head_storage
         );
     }
@@ -448,7 +434,7 @@ private:
     using minor_storage_type = std::vector<minor_element_type>;
     using major_storage_type = std::vector<minor_storage_type>;
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_tail_storage.resize(this->_tail_storage.size() + n);
@@ -456,7 +442,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_tail_storage.erase(
@@ -487,7 +473,7 @@ private:
         return minor_it;
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
             return std::array<std::span<const minor_element_type>, 2>{
@@ -504,7 +490,7 @@ private:
         }
     }
 
-    template <impl::element_type Element, typename Projection = std::identity>
+    template <element_type Element, typename Projection = std::identity>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const Projection storage_proj)
         const noexcept {
         if constexpr (Element == layout_tag::major_element) { // get major
@@ -518,7 +504,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             return this->_tail_storage[id].size() + this->_head_storage[id].size();
@@ -535,7 +521,7 @@ private:
         }
     }
 
-    template <impl::element_type Element, typename Projection = std::identity>
+    template <element_type Element, typename Projection = std::identity>
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const Projection storage_proj) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
@@ -550,7 +536,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
@@ -571,7 +557,7 @@ private:
         }
     }
 
-    template <impl::element_type Element, typename Projection = std::identity>
+    template <element_type Element, typename Projection = std::identity>
     [[nodiscard]] std::vector<size_type> _size_map(
         const size_type n_elements, const Projection storage_proj
     ) const noexcept {

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -8,7 +8,6 @@
 #include "hgl/constants.hpp"
 #include "hgl/decl/impl_tags.hpp"
 #include "hgl/directional_tags.hpp"
-#include "hgl/impl/impl_tags.hpp"
 #include "hgl/impl/layout_tags.hpp"
 #include "hgl/types.hpp"
 
@@ -18,6 +17,8 @@
 #include <functional>
 #include <ranges>
 #include <vector>
+
+// TODO: remove impl::
 
 #ifdef HGL_TESTING
 namespace hgl_testing {
@@ -835,10 +836,8 @@ public:
 #endif
 
 private:
-    using vertex_major_list =
-        flat_incidence_list<DirectionalTag, impl::list_t<impl::vertex_major_t, id_type>>;
-    using hyperedge_major_list =
-        flat_incidence_list<DirectionalTag, impl::list_t<impl::hyperedge_major_t, id_type>>;
+    using vertex_major_list = incidence_list<DirectionalTag, list_t<vertex_major_t, id_type>>;
+    using hyperedge_major_list = incidence_list<DirectionalTag, list_t<hyperedge_major_t, id_type>>;
 
     vertex_major_list _v_list;
     hyperedge_major_list _e_list;

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -8,6 +8,7 @@
 #include "hgl/constants.hpp"
 #include "hgl/decl/impl_tags.hpp"
 #include "hgl/directional_tags.hpp"
+#include "hgl/impl/impl_tags.hpp"
 #include "hgl/impl/layout_tags.hpp"
 #include "hgl/types.hpp"
 
@@ -35,16 +36,17 @@ struct to_impl;
 
 namespace impl {
 
-template <
-    traits::c_hypergraph_directional_tag DirectionalTag,
-    traits::c_hypergraph_layout_tag LayoutTag>
+template <traits::c_hypergraph_directional_tag DirectionalTag, traits::c_hypergraph_list_impl ImplTag>
 class incidence_list;
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class incidence_list<hgl::undirected_t, LayoutTag> final {
+template <traits::c_hypergraph_list_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class incidence_list<hgl::undirected_t, ImplTag> final {
 public:
     using directional_tag = hgl::undirected_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     incidence_list() = default;
 
@@ -236,11 +238,15 @@ private:
     major_storage_type _major_storage;
 };
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class incidence_list<hgl::bf_directed_t, LayoutTag> final {
+template <traits::c_hypergraph_list_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class incidence_list<hgl::bf_directed_t, ImplTag> final {
 public:
     using directional_tag = hgl::bf_directed_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
+
 
     incidence_list() = default;
 
@@ -601,11 +607,15 @@ private:
     major_storage_type _head_storage;
 };
 
-template <traits::c_hypergraph_directional_tag DirectionalTag>
-class incidence_list<DirectionalTag, bidirectional_t> final {
+template <traits::c_hypergraph_directional_tag DirectionalTag, traits::c_hypergraph_list_impl ImplTag>
+requires std::same_as<typename ImplTag::layout_tag, bidirectional_t>
+class incidence_list<DirectionalTag, ImplTag> final {
 public:
     using directional_tag = DirectionalTag;
-    using layout_tag = bidirectional_t;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
+
 
     incidence_list() = default;
 
@@ -825,8 +835,10 @@ public:
 #endif
 
 private:
-    using vertex_major_list = incidence_list<DirectionalTag, vertex_major_t>;
-    using hyperedge_major_list = incidence_list<DirectionalTag, hyperedge_major_t>;
+    using vertex_major_list =
+        flat_incidence_list<DirectionalTag, impl::list_t<impl::vertex_major_t, id_type>>;
+    using hyperedge_major_list =
+        flat_incidence_list<DirectionalTag, impl::list_t<impl::hyperedge_major_t, id_type>>;
 
     vertex_major_list _v_list;
     hyperedge_major_list _e_list;

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -35,14 +35,17 @@ namespace impl {
 
 template <
     traits::c_hypergraph_directional_tag DirectionalTag,
-    traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
+    traits::c_hypergraph_matrix_impl ImplTag>
 class incidence_matrix;
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class incidence_matrix<hgl::undirected_t, LayoutTag> final {
+template <traits::c_hypergraph_matrix_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class incidence_matrix<hgl::undirected_t, ImplTag> final {
 public:
     using directional_tag = hgl::undirected_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     incidence_matrix() = default;
 
@@ -232,11 +235,14 @@ private:
     hypergraph_storage_type _matrix;
 };
 
-template <traits::c_hypergraph_asymmetric_layout_tag LayoutTag>
-class incidence_matrix<hgl::bf_directed_t, LayoutTag> final {
+template <traits::c_hypergraph_matrix_impl ImplTag>
+requires traits::c_hypergraph_asymmetric_layout_tag<typename ImplTag::layout_tag>
+class incidence_matrix<hgl::bf_directed_t, ImplTag> final {
 public:
     using directional_tag = hgl::bf_directed_t;
-    using layout_tag = LayoutTag;
+    using implementation_tag = ImplTag;
+    using layout_tag = typename implementation_tag::layout_tag;
+    using id_type = typename implementation_tag::id_type;
 
     incidence_matrix() = default;
 

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -114,19 +114,19 @@ public:
 
     gl_attr_force_inline void bind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = true;
+        this->_matrix[to_idx(major_id)][to_idx(minor_id)] = true;
     }
 
     gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = false;
+        this->_matrix[to_idx(major_id)][to_idx(minor_id)] = false;
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_matrix[major_id][minor_id];
+        return this->_matrix[to_idx(major_id)][to_idx(minor_id)];
     }
 
     // --- comparison ---
@@ -169,7 +169,7 @@ private:
             this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
         }
         else { // remove minor
-            if (this->_matrix_row_size == 0)
+            if (this->_matrix_row_size == 0uz)
                 return;
             this->_matrix_row_size--;
             for (auto& row : this->_matrix) {
@@ -197,12 +197,13 @@ private:
     [[nodiscard]] gl_attr_force_inline size_type _count(const id_type id) const noexcept {
         size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
-            for (const bool bit : this->_matrix[id])
+            for (const bool bit : this->_matrix[to_idx(id)])
                 count += static_cast<size_type>(bit);
         }
         else { // count minor
+            const auto idx = to_idx(id);
             for (const auto& row : this->_matrix)
-                count += static_cast<size_type>(row[id]);
+                count += static_cast<size_type>(row[idx]);
         }
         return count;
     }
@@ -219,13 +220,10 @@ private:
         }
         else { // count map minor
             const size_type limit = std::min(n_elements, this->_matrix_row_size);
-            for (const auto& row : this->_matrix) {
-                for (auto j = 0uz; j < limit; ++j) {
-                    if (row[j]) {
+            for (const auto& row : this->_matrix)
+                for (auto j = 0uz; j < limit; ++j)
+                    if (row[j])
                         ++size_map[j];
-                    }
-                }
-            }
         }
         return size_map;
     }
@@ -369,40 +367,40 @@ public:
         const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = incidence_type::backward;
+        this->_matrix[to_idx(major_id)][to_idx(minor_id)] = incidence_type::backward;
     }
 
     gl_attr_force_inline void bind_head(
         const id_type vertex_id, const id_type hyperedge_id
     ) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = incidence_type::forward;
+        this->_matrix[to_idx(major_id)][to_idx(minor_id)] = incidence_type::forward;
     }
 
     gl_attr_force_inline void unbind(const id_type vertex_id, const id_type hyperedge_id) noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        this->_matrix[major_id][minor_id] = incidence_type::none;
+        this->_matrix[to_idx(major_id)][to_idx(minor_id)] = incidence_type::none;
     }
 
     [[nodiscard]] gl_attr_force_inline bool are_bound(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_matrix[major_id][minor_id] != incidence_type::none;
+        return this->_matrix[to_idx(major_id)][to_idx(minor_id)] != incidence_type::none;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_tail(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_matrix[major_id][minor_id] == incidence_type::backward;
+        return this->_matrix[to_idx(major_id)][to_idx(minor_id)] == incidence_type::backward;
     }
 
     [[nodiscard]] gl_attr_force_inline bool is_head(
         const id_type vertex_id, const id_type hyperedge_id
     ) const noexcept {
         const auto [major_id, minor_id] = layout_tag::majmin(vertex_id, hyperedge_id);
-        return this->_matrix[major_id][minor_id] == incidence_type::forward;
+        return this->_matrix[to_idx(major_id)][to_idx(minor_id)] == incidence_type::forward;
     }
 
     // --- comparison ---
@@ -499,12 +497,13 @@ private:
     _count(const id_type id, std::predicate<incidence_type> auto&& pred) const noexcept {
         size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
-            for (const incidence_type t : this->_matrix[id])
+            for (const incidence_type t : this->_matrix[to_idx(id)])
                 count += static_cast<size_type>(pred(t));
         }
         else { // count minor
+            const auto idx = to_idx(id);
             for (const auto& row : this->_matrix)
-                count += static_cast<size_type>(pred(row[id]));
+                count += static_cast<size_type>(pred(row[idx]));
         }
         return count;
     }

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -181,15 +181,14 @@ private:
     template <element_type Element>
     gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
-            return std::views::iota(constants::initial_id<size_type>, this->_matrix_row_size)
-                 | std::views::filter([&row = this->_matrix[id]](const size_type minor_id) {
-                       return row[minor_id];
-                   });
+            return std::views::iota(initial_id_v<size_type>, this->_matrix_row_size)
+                 | std::views::filter([&row = this->_matrix[to_idx(id)]](const size_type minor_idx
+                                      ) { return row[minor_idx]; });
         }
         else { // incident with minor
-            return std::views::iota(constants::initial_id<size_type>, this->_matrix.size())
-                 | std::views::filter([this, minor_id = id](const size_type major_id) {
-                       return this->_matrix[major_id][minor_id];
+            return std::views::iota(initial_id_v<size_type>, this->_matrix.size())
+                 | std::views::filter([this, minor_idx = to_idx(id)](const size_type major_idx) {
+                       return this->_matrix[major_idx][minor_idx];
                    });
         }
     }
@@ -482,16 +481,16 @@ private:
         const id_type id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // query major
-            return std::views::iota(constants::initial_id<size_type>, this->_matrix_row_size)
-                 | std::views::filter([&row = this->_matrix[id], pred](const size_type minor_id) {
-                       return pred(row[minor_id]);
+            return std::views::iota(initial_id_v<size_type>, this->_matrix_row_size)
+                 | std::views::filter([&row = this->_matrix[to_idx(id)],
+                                       pred](const size_type minor_idx) {
+                       return pred(row[minor_idx]);
                    });
         }
         else { // query minor
-            return std::views::iota(constants::initial_id<size_type>, this->_matrix.size())
-                 | std::views::filter([this, minor_id = id, pred](const size_type major_id) {
-                       return pred(this->_matrix[major_id][minor_id]);
-                   });
+            return std::views::iota(initial_id_v<size_type>, this->_matrix.size())
+                 | std::views::filter([this, minor_idx = to_idx(id), pred](const size_type major_idx
+                                      ) { return pred(this->_matrix[major_idx][minor_idx]); });
         }
     }
 

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -16,6 +16,8 @@
 #include <ranges>
 #include <vector>
 
+// TODO: remove impl::
+
 #ifdef HGL_TESTING
 namespace hgl_testing {
 struct test_incidence_matrix;

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -16,8 +16,6 @@
 #include <ranges>
 #include <vector>
 
-// TODO: remove impl::
-
 #ifdef HGL_TESTING
 namespace hgl_testing {
 struct test_incidence_matrix;
@@ -68,48 +66,48 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::vertex>(vertex_id);
+        return this->_incident_with<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<impl::element_type::vertex>(vertex_id);
+        return this->_count<element_type::vertex>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<impl::element_type::vertex>(n_vertices);
+        return this->_count_map<element_type::vertex>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<impl::element_type::hyperedge>(hyperedge_id);
+        return this->_count<element_type::hyperedge>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<impl::element_type::hyperedge>(n_hyperedges);
+        return this->_count_map<element_type::hyperedge>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -151,7 +149,7 @@ private:
     using matrix_row_type = std::vector<bool>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_matrix.resize(
@@ -165,7 +163,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
@@ -180,7 +178,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
         if constexpr (Element == layout_tag::major_element) { // incident with major
             return std::views::iota(constants::initial_id<size_type>, this->_matrix_row_size)
@@ -196,7 +194,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type _count(const id_type id) const noexcept {
         size_type count = 0uz;
         if constexpr (Element == layout_tag::major_element) { // count major
@@ -210,7 +208,7 @@ private:
         return count;
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _count_map(const size_type n_elements) const noexcept {
         std::vector<size_type> size_map(n_elements, 0uz);
 
@@ -266,104 +264,104 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<impl::element_type::vertex>(n);
+        this->_add<element_type::vertex>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<impl::element_type::vertex>(vertex_id);
+        this->_remove<element_type::vertex>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_query<impl::element_type::vertex>(vertex_id, _is_incident);
+        return this->_query<element_type::vertex>(vertex_id, _is_incident);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<impl::element_type::vertex>(vertex_id, _is_incident);
+        return this->_count<element_type::vertex>(vertex_id, _is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<impl::element_type::vertex>(n_vertices, _is_incident);
+        return this->_count_map<element_type::vertex>(n_vertices, _is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<impl::element_type::vertex>(vertex_id, _is_tail);
+        return this->_query<element_type::vertex>(vertex_id, _is_tail);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_count<impl::element_type::vertex>(vertex_id, _is_tail);
+        return this->_count<element_type::vertex>(vertex_id, _is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<impl::element_type::vertex>(n_vertices, _is_tail);
+        return this->_count_map<element_type::vertex>(n_vertices, _is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<impl::element_type::vertex>(vertex_id, _is_head);
+        return this->_query<element_type::vertex>(vertex_id, _is_head);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_count<impl::element_type::vertex>(vertex_id, _is_head);
+        return this->_count<element_type::vertex>(vertex_id, _is_head);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<impl::element_type::vertex>(n_vertices, _is_head);
+        return this->_count_map<element_type::vertex>(n_vertices, _is_head);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<impl::element_type::hyperedge>(n);
+        this->_add<element_type::hyperedge>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<impl::element_type::hyperedge>(hyperedge_id);
+        this->_remove<element_type::hyperedge>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
+        return this->_query<element_type::hyperedge>(hyperedge_id, _is_incident);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_incident);
+        return this->_count<element_type::hyperedge>(hyperedge_id, _is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_incident);
+        return this->_count_map<element_type::hyperedge>(n_hyperedges, _is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
+        return this->_query<element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_tail);
+        return this->_count<element_type::hyperedge>(hyperedge_id, _is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_tail);
+        return this->_count_map<element_type::hyperedge>(n_hyperedges, _is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_query<impl::element_type::hyperedge>(hyperedge_id, _is_head);
+        return this->_query<element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<impl::element_type::hyperedge>(hyperedge_id, _is_head);
+        return this->_count<element_type::hyperedge>(hyperedge_id, _is_head);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<impl::element_type::hyperedge>(n_hyperedges, _is_head);
+        return this->_count_map<element_type::hyperedge>(n_hyperedges, _is_head);
     }
 
     // --- binding methods ---
@@ -450,7 +448,7 @@ private:
     using matrix_row_type = std::vector<incidence_type>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _add(const size_type n) noexcept {
         if constexpr (Element == layout_tag::major_element) { // add major
             this->_matrix.resize(
@@ -465,7 +463,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     void _remove(const id_type id) noexcept {
         if constexpr (Element == layout_tag::major_element) { // remove major
             this->_matrix.erase(this->_matrix.begin() + static_cast<std::ptrdiff_t>(id));
@@ -479,7 +477,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline auto _query(
         const id_type id, std::predicate<incidence_type> auto&& pred
     ) const noexcept {
@@ -497,7 +495,7 @@ private:
         }
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] gl_attr_force_inline size_type
     _count(const id_type id, std::predicate<incidence_type> auto&& pred) const noexcept {
         size_type count = 0uz;
@@ -512,7 +510,7 @@ private:
         return count;
     }
 
-    template <impl::element_type Element>
+    template <element_type Element>
     [[nodiscard]] std::vector<size_type> _count_map(
         const size_type n_elements, std::predicate<incidence_type> auto&& pred
     ) const noexcept {

--- a/include/hgl/traits.hpp
+++ b/include/hgl/traits.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gl/traits.hpp"
+#include "hgl/types.hpp"
 
 namespace hgl::traits {
 

--- a/include/hgl/types.hpp
+++ b/include/hgl/types.hpp
@@ -14,8 +14,8 @@ namespace hgl {
 
 using gl::default_id_type;
 using gl::size_type;
-using id_type = size_type;
 
+// TODO: use for all indexing
 using gl::to_idx;
 
 // --- generic data structures ---

--- a/include/hgl/types.hpp
+++ b/include/hgl/types.hpp
@@ -12,8 +12,11 @@ namespace hgl {
 
 // --- core types ---
 
+using gl::default_id_type;
 using gl::size_type;
 using id_type = size_type;
+
+using gl::to_idx;
 
 // --- generic data structures ---
 

--- a/include/hgl/types.hpp
+++ b/include/hgl/types.hpp
@@ -15,7 +15,6 @@ namespace hgl {
 using gl::default_id_type;
 using gl::size_type;
 
-// TODO: use for all indexing
 using gl::to_idx;
 
 // --- generic data structures ---

--- a/tests/include/testing/hgl/constants.hpp
+++ b/tests/include/testing/hgl/constants.hpp
@@ -12,7 +12,7 @@ namespace hgl_testing::constants {
 IC hgl::size_type n_vertices = 3uz;
 IC hgl::size_type n_hyperedges = 4uz;
 
-IC hgl::default_id_type id1 = hgl::initial_id_v<hgl::default_id_type>;
+IC hgl::default_id_type id1 = hgl::initial_id;
 IC hgl::default_id_type id2 = id1 + 1uz;
 IC hgl::default_id_type id3 = id2 + 1uz;
 IC hgl::default_id_type id4 = id3 + 1uz;

--- a/tests/include/testing/hgl/constants.hpp
+++ b/tests/include/testing/hgl/constants.hpp
@@ -12,17 +12,16 @@ namespace hgl_testing::constants {
 IC hgl::size_type n_vertices = 3uz;
 IC hgl::size_type n_hyperedges = 4uz;
 
-IC hgl::default_id_type id1 = hgl::constants::initial_id<hgl::default_id_type>;
+IC hgl::default_id_type id1 = hgl::initial_id_v<hgl::default_id_type>;
 IC hgl::default_id_type id2 = id1 + 1uz;
 IC hgl::default_id_type id3 = id2 + 1uz;
 IC hgl::default_id_type id4 = id3 + 1uz;
 IC hgl::default_id_type out_of_rng_vid = n_vertices;
 IC hgl::default_id_type out_of_rng_eid = n_hyperedges;
 
-IC auto vertex_ids_view =
-    std::views::iota(hgl::constants::initial_id<hgl::default_id_type>, n_vertices);
+IC auto vertex_ids_view = std::views::iota(hgl::initial_id_v<hgl::default_id_type>, n_vertices);
 IC auto hyperedge_ids_view =
-    std::views::iota(hgl::constants::initial_id<hgl::default_id_type>, n_hyperedges);
+    std::views::iota(hgl::initial_id_v<hgl::default_id_type>, n_hyperedges);
 
 IC boolean_property p_true{true};
 IC boolean_property p_false{false};

--- a/tests/include/testing/hgl/constants.hpp
+++ b/tests/include/testing/hgl/constants.hpp
@@ -12,16 +12,17 @@ namespace hgl_testing::constants {
 IC hgl::size_type n_vertices = 3uz;
 IC hgl::size_type n_hyperedges = 4uz;
 
-IC hgl::id_type id1 = hgl::constants::initial_id<hgl::id_type>;
-IC hgl::id_type id2 = id1 + 1uz;
-IC hgl::id_type id3 = id2 + 1uz;
-IC hgl::id_type id4 = id3 + 1uz;
-IC hgl::id_type out_of_rng_vid = n_vertices;
-IC hgl::id_type out_of_rng_eid = n_hyperedges;
+IC hgl::default_id_type id1 = hgl::constants::initial_id<hgl::default_id_type>;
+IC hgl::default_id_type id2 = id1 + 1uz;
+IC hgl::default_id_type id3 = id2 + 1uz;
+IC hgl::default_id_type id4 = id3 + 1uz;
+IC hgl::default_id_type out_of_rng_vid = n_vertices;
+IC hgl::default_id_type out_of_rng_eid = n_hyperedges;
 
-IC auto vertex_ids_view = std::views::iota(hgl::constants::initial_id<hgl::id_type>, n_vertices);
+IC auto vertex_ids_view =
+    std::views::iota(hgl::constants::initial_id<hgl::default_id_type>, n_vertices);
 IC auto hyperedge_ids_view =
-    std::views::iota(hgl::constants::initial_id<hgl::id_type>, n_hyperedges);
+    std::views::iota(hgl::constants::initial_id<hgl::default_id_type>, n_hyperedges);
 
 IC boolean_property p_true{true};
 IC boolean_property p_false{false};

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -4,6 +4,7 @@
 #include "hgl/hypergraph.hpp"
 #include "hgl/hypergraph_traits.hpp"
 #include "hgl/impl/layout_tags.hpp"
+#include "hgl/types.hpp"
 
 #include <doctest.h>
 
@@ -300,7 +301,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         // e3 = {0} (should not add any edge)
         sut.bind(0uz, 3uz);
 
-        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
+        const std::vector<hgl::homogeneous_pair<hgl::default_id_type>> expected_edges{
             // e0: (0,1), (0,2), (1,2)
             {0uz, 1uz},
             {0uz, 2uz},
@@ -349,7 +350,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind(0uz, 3uz);
 
         // Expected edges: vertices 0-3, hyperedges 4-7
-        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
+        const std::vector<hgl::homogeneous_pair<hgl::default_id_type>> expected_edges{
             // e0 (4): {0,1,2}
             {0uz, 4ull},
             {1uz, 4ull},
@@ -439,7 +440,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind_head(0uz, 1uz);
         sut.bind_head(1uz, 1uz);
 
-        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
+        const std::vector<hgl::homogeneous_pair<hgl::default_id_type>> expected_edges{
             // e0: 0->2, 0->3, 1->2, 1->3
             {0uz, 2uz},
             {0uz, 3uz},
@@ -482,7 +483,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.bind_head(1uz, 1uz);
 
         // Expected directed edges: vertices 0-3, hyperedges 4-5
-        const std::vector<std::pair<hgl::id_type, hgl::id_type>> expected_edges{
+        const std::vector<hgl::homogeneous_pair<hgl::default_id_type>> expected_edges{
             // Tails to hyperedges: 0->4, 1->4, 2->5
             { 0uz, 4ull},
             { 1uz, 4ull},

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -1,9 +1,10 @@
-#include "hgl/directional_tags.hpp"
-#include "hgl/impl/layout_tags.hpp"
 #include "testing/hgl/constants.hpp"
 
 #include <doctest.h>
+#include <hgl/directional_tags.hpp>
 #include <hgl/impl/flat_incidence_list.hpp>
+#include <hgl/impl/impl_tags.hpp>
+#include <hgl/impl/layout_tags.hpp>
 
 #include <algorithm>
 #include <ranges>
@@ -323,8 +324,8 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_hyperedge_major_flat_incidence_list : public test_flat_incidence_list {
-    using sut_type =
-        hgl::impl::flat_incidence_list<hgl::undirected_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::flat_list_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::flat_incidence_list<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -644,7 +645,8 @@ constexpr auto is_empty_pred = [](const auto& rng) { return rng.empty(); };
 
 struct test_bf_directed_vertex_major_flat_incidence_list
 : public test_bf_directed_flat_incidence_list {
-    using sut_type = hgl::impl::flat_incidence_list<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::flat_list_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::flat_incidence_list<hgl::bf_directed_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -958,7 +960,7 @@ TEST_CASE_FIXTURE(
     "unbind should erase the hyperedge id from a proper vertex entry"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::id_type> expected_storage;
+    std::vector<hgl::default_id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);
@@ -1123,8 +1125,8 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_hyperedge_major_flat_incidence_list
 : public test_bf_directed_flat_incidence_list {
-    using sut_type =
-        hgl::impl::flat_incidence_list<hgl::bf_directed_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::flat_list_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::flat_incidence_list<hgl::bf_directed_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -1441,7 +1443,7 @@ TEST_CASE_FIXTURE(
     "unbind should clear the corresponding bit"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::id_type> expected_storage;
+    std::vector<hgl::default_id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -172,14 +172,14 @@ TEST_CASE_FIXTURE(
     "> hyperedge_id"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 4uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::id_type rem_heid;
-    std::vector<hgl::id_type> expected_hyperedges;
+    hgl::default_id_type rem_heid;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_heid = constants::id1;
@@ -459,14 +459,14 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly unbind (if necessary) the given vertex and align ids > vertex_id"
 ) {
     constexpr hgl::size_type n_vertices = 4uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
-    std::vector<hgl::id_type> expected_vertices;
+    hgl::default_id_type rem_vid;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -603,9 +603,9 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_flat_incidence_list : public test_flat_incidence_list {
     auto altbind_to_vertex(
-        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
+        auto& sut, const hgl::default_id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -622,9 +622,9 @@ struct test_bf_directed_flat_incidence_list : public test_flat_incidence_list {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
+        auto& sut, const hgl::default_id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (std::size_t i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -690,15 +690,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the major entry and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -800,15 +800,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the minor entries and shift the hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1168,15 +1168,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the minor entries and shift the vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1279,15 +1279,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -1,3 +1,5 @@
+#include "hgl/directional_tags.hpp"
+#include "hgl/impl/layout_tags.hpp"
 #include "testing/hgl/constants.hpp"
 
 #include <doctest.h>
@@ -34,7 +36,8 @@ struct test_flat_incidence_list {
 };
 
 struct test_undirected_vertex_major_flat_incidence_list : public test_flat_incidence_list {
-    using sut_type = hgl::impl::flat_incidence_list<hgl::undirected_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::flat_list_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::flat_incidence_list<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -222,7 +222,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{n_vertices};
         sut.remove_vertices_from(
-            std::vector<hgl::id_type>{constants::id1, constants::id3, constants::id1}
+            std::vector<hgl::default_id_type>{constants::id1, constants::id3, constants::id1}
         );
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
@@ -366,7 +366,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{0uz, n_hyperedges};
         sut.remove_hyperedges_from(
-            std::vector<hgl::id_type>{constants::id1, constants::id3, constants::id1}
+            std::vector<hgl::default_id_type>{constants::id1, constants::id3, constants::id1}
         );
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -46,7 +46,7 @@ using add_properties = hgl::hypergraph_traits<
     Properties,
     typename HypergraphTraits::implementation_tag>;
 
-inline constexpr auto get_id = [](auto&& element) -> hgl::id_type { return element.id(); };
+inline constexpr auto get_id = [](auto&& element) -> hgl::default_id_type { return element.id(); };
 
 TEST_CASE_TEMPLATE_DEFINE(
     "hypergraph structure tests", HypergraphTraits, hypergraph_traits_template
@@ -105,7 +105,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("add_vertex should return a vertex_descriptor with an incremented id") {
         sut_type sut;
 
-        for (hgl::id_type v_id = 0uz; v_id < constants::n_vertices; v_id++) {
+        for (auto v_id = 0u; v_id < constants::n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
             CHECK_EQ(sut.order(), v_id + 1uz);
@@ -247,7 +247,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("add_hyperedge should return a hyperedge_descriptor with an incremented id") {
         sut_type sut;
 
-        for (hgl::id_type e_id = 0uz; e_id < constants::n_hyperedges; e_id++) {
+        for (auto e_id = 0u; e_id < constants::n_hyperedges; e_id++) {
             const auto hyperedge = sut.add_hyperedge();
             CHECK_EQ(hyperedge.id(), e_id);
             CHECK_EQ(sut.size(), e_id + 1uz);
@@ -552,7 +552,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("sequential hyperedges") {
             if constexpr (std::same_as<directional_tag, hgl::undirected_t>) {
-                std::vector<hgl::id_type> expected_hyperedges{};
+                std::vector<hgl::default_id_type> expected_hyperedges{};
                 for (const auto eid : sut.hyperedge_ids()) {
                     sut.bind(vertex_id, eid);
                     expected_hyperedges.push_back(eid);
@@ -568,8 +568,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             }
 
             if constexpr (std::same_as<directional_tag, hgl::bf_directed_t>) {
-                std::vector<hgl::id_type> expected_hyperedges;
-                std::vector<hgl::id_type> expected_in_hyperedges, expected_out_hyperedges;
+                std::vector<hgl::default_id_type> expected_hyperedges;
+                std::vector<hgl::default_id_type> expected_in_hyperedges, expected_out_hyperedges;
                 for (const auto eid : sut.hyperedge_ids()) {
                     if (eid % 2 == 0) {
                         sut.bind_head(vertex_id, eid);
@@ -612,7 +612,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.incident_hyperedges(vertex_id),
-                    std::vector<hgl::id_type>{constants::id2, constants::id4},
+                    std::vector<hgl::default_id_type>{constants::id2, constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -625,7 +625,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_hyperedges(vertex_id),
-                    std::vector<hgl::id_type>{constants::id2, constants::id4},
+                    std::vector<hgl::default_id_type>{constants::id2, constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -633,7 +633,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.in_hyperedges(vertex_id),
-                    std::vector<hgl::id_type>{constants::id2},
+                    std::vector<hgl::default_id_type>{constants::id2},
                     std::equal_to{},
                     get_id
                 ));
@@ -641,7 +641,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.out_hyperedges(vertex_id),
-                    std::vector<hgl::id_type>{constants::id4},
+                    std::vector<hgl::default_id_type>{constants::id4},
                     std::equal_to{},
                     get_id
                 ));
@@ -681,7 +681,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         SUBCASE("sequential vertices") {
             if constexpr (std::same_as<directional_tag, hgl::undirected_t>) {
-                std::vector<hgl::id_type> expected_vertices{};
+                std::vector<hgl::default_id_type> expected_vertices{};
                 for (const auto vid : sut.vertex_ids()) {
                     sut.bind(vid, hyperedge_id);
                     expected_vertices.push_back(vid);
@@ -697,8 +697,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             }
 
             if constexpr (std::same_as<directional_tag, hgl::bf_directed_t>) {
-                std::vector<hgl::id_type> expected_vertices;
-                std::vector<hgl::id_type> expected_head_vertices, expected_tail_vertices;
+                std::vector<hgl::default_id_type> expected_vertices;
+                std::vector<hgl::default_id_type> expected_head_vertices, expected_tail_vertices;
                 for (const auto vid : sut.vertex_ids()) {
                     if (vid % 2 == 0) {
                         sut.bind_head(vid, hyperedge_id);
@@ -744,7 +744,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.incident_vertices(hyperedge_id),
-                    std::vector<hgl::id_type>{constants::id1, constants::id3},
+                    std::vector<hgl::default_id_type>{constants::id1, constants::id3},
                     std::equal_to{},
                     get_id
                 ));
@@ -757,7 +757,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_vertices(hyperedge_id),
-                    std::vector<hgl::id_type>{constants::id1, constants::id3},
+                    std::vector<hgl::default_id_type>{constants::id1, constants::id3},
                     std::equal_to{},
                     get_id
                 ));
@@ -765,7 +765,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.head_vertices(hyperedge_id),
-                    std::vector<hgl::id_type>{constants::id1},
+                    std::vector<hgl::default_id_type>{constants::id1},
                     std::equal_to{},
                     get_id
                 ));
@@ -773,7 +773,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
                 CHECK(std::ranges::equal(
                     sut.tail_vertices(hyperedge_id),
-                    std::vector<hgl::id_type>{constants::id3},
+                    std::vector<hgl::default_id_type>{constants::id3},
                     std::equal_to{},
                     get_id
                 ));

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -9,9 +9,7 @@ namespace hgl_testing {
 
 TEST_SUITE_BEGIN("test_hypergraph_elements");
 
-static_assert(std::same_as<
-              hgl::vertex_descriptor<hgl::empty_properties>,
-              gl::vertex_descriptor<gl::empty_properties, hgl::id_type>>);
+static_assert(std::same_as<hgl::vertex_descriptor<>, gl::vertex_descriptor<>>);
 
 struct test_hyperedge_descriptor {
     using sut_type = hgl::hyperedge_descriptor<>;
@@ -43,7 +41,7 @@ TEST_CASE_FIXTURE(test_hyperedge_descriptor, "id() should return the id of the h
 
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "hyperedge descriptors should be invalid by default") {
     CHECK_FALSE(sut_type{}.is_valid());
-    CHECK_EQ(sut_type{}.id(), hgl::constants::invalid_id<hgl::id_type>);
+    CHECK_EQ(sut_type{}.id(), hgl::constants::invalid_id<hgl::default_id_type>);
 }
 
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "properties should be properly initialized") {
@@ -59,7 +57,8 @@ TEST_CASE("accessing properties should throw for an invalid hyperedge") {
 
     CHECK_THROWS_AS(static_cast<void>(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(
-        static_cast<void>(sut_type{hgl::constants::invalid_id<hgl::id_type>, property}.properties()
+        static_cast<void>(
+            sut_type{hgl::constants::invalid_id<hgl::default_id_type>, property}.properties()
         ),
         std::logic_error
     );

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -41,7 +41,7 @@ TEST_CASE_FIXTURE(test_hyperedge_descriptor, "id() should return the id of the h
 
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "hyperedge descriptors should be invalid by default") {
     CHECK_FALSE(sut_type{}.is_valid());
-    CHECK_EQ(sut_type{}.id(), hgl::constants::invalid_id<hgl::default_id_type>);
+    CHECK_EQ(sut_type{}.id(), hgl::invalid_id);
 }
 
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "properties should be properly initialized") {
@@ -57,10 +57,7 @@ TEST_CASE("accessing properties should throw for an invalid hyperedge") {
 
     CHECK_THROWS_AS(static_cast<void>(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(
-        static_cast<void>(
-            sut_type{hgl::constants::invalid_id<hgl::default_id_type>, property}.properties()
-        ),
-        std::logic_error
+        static_cast<void>(sut_type{hgl::invalid_id, property}.properties()), std::logic_error
     );
 }
 

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -9,8 +9,6 @@ namespace hgl_testing {
 
 TEST_SUITE_BEGIN("test_hypergraph_elements");
 
-static_assert(std::same_as<hgl::vertex_descriptor<>, gl::vertex_descriptor<>>);
-
 struct test_hyperedge_descriptor {
     using sut_type = hgl::hyperedge_descriptor<>;
 
@@ -47,12 +45,12 @@ TEST_CASE_FIXTURE(test_hyperedge_descriptor, "hyperedge descriptors should be in
 TEST_CASE_FIXTURE(test_hyperedge_descriptor, "properties should be properly initialized") {
     boolean_property property{constants::p_true};
 
-    const hgl::hyperedge<boolean_property> sut{id1, property};
+    const hgl::hyperedge_descriptor<boolean_property> sut{id1, property};
     CHECK_EQ(&sut.properties(), &property);
 }
 
 TEST_CASE("accessing properties should throw for an invalid hyperedge") {
-    using sut_type = hgl::hyperedge<boolean_property>;
+    using sut_type = hgl::hyperedge_descriptor<boolean_property>;
     boolean_property property{constants::p_true};
 
     CHECK_THROWS_AS(static_cast<void>(sut_type::invalid().properties()), std::logic_error);

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -14,8 +14,8 @@ static_assert(std::same_as<hgl::vertex_descriptor<>, gl::vertex_descriptor<>>);
 struct test_hyperedge_descriptor {
     using sut_type = hgl::hyperedge_descriptor<>;
 
-    static constexpr hgl::id_type id1 = 0uz;
-    static constexpr hgl::id_type id2 = 1uz;
+    static constexpr hgl::default_id_type id1 = 0u;
+    static constexpr hgl::default_id_type id2 = 1u;
 
     sut_type he1{id1};
     sut_type he2{id2};

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -166,14 +166,14 @@ TEST_CASE_FIXTURE(
     "> hyperedge_id"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 4uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::id_type rem_heid;
-    std::vector<hgl::id_type> expected_hyperedges;
+    hgl::default_id_type rem_heid;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_heid = constants::id1;
@@ -448,14 +448,14 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly unbind (if necessary) the given vertex and align ids > vertex_id"
 ) {
     constexpr hgl::size_type n_vertices = 4uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
-    std::vector<hgl::id_type> expected_vertices;
+    hgl::default_id_type rem_vid;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -592,9 +592,9 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_incidence_list : public test_incidence_list {
     auto altbind_to_vertex(
-        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
+        auto& sut, const hgl::default_id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (auto i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -611,9 +611,9 @@ struct test_bf_directed_incidence_list : public test_incidence_list {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
+        auto& sut, const hgl::default_id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (auto i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -677,15 +677,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the major entry and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -785,15 +785,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the minor entries and shift the hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1151,15 +1151,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the minor entries and shift the vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1262,15 +1262,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -1,7 +1,9 @@
 #include "testing/hgl/constants.hpp"
 
 #include <doctest.h>
+#include <hgl/impl/impl_tags.hpp>
 #include <hgl/impl/incidence_list.hpp>
+#include <hgl/impl/layout_tags.hpp>
 
 #include <algorithm>
 #include <ranges>
@@ -31,7 +33,8 @@ struct test_incidence_list {
 };
 
 struct test_undirected_vertex_major_incidence_list : public test_incidence_list {
-    using sut_type = hgl::impl::incidence_list<hgl::undirected_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::list_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::incidence_list<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -313,7 +316,8 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_hyperedge_major_incidence_list : public test_incidence_list {
-    using sut_type = hgl::impl::incidence_list<hgl::undirected_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::list_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::incidence_list<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -629,7 +633,8 @@ struct test_bf_directed_incidence_list : public test_incidence_list {
 constexpr auto is_empty_pred = [](const auto& rng) { return rng.empty(); };
 
 struct test_bf_directed_vertex_major_incidence_list : public test_bf_directed_incidence_list {
-    using sut_type = hgl::impl::incidence_list<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::list_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::incidence_list<hgl::bf_directed_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -940,7 +945,7 @@ TEST_CASE_FIXTURE(
     "unbind should erase the hyperedge id from a proper vertex entry"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::id_type> expected_storage;
+    std::vector<hgl::default_id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);
@@ -1104,7 +1109,8 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_bf_directed_hyperedge_major_incidence_list : public test_bf_directed_incidence_list {
-    using sut_type = hgl::impl::incidence_list<hgl::bf_directed_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::list_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::incidence_list<hgl::bf_directed_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -1419,7 +1425,7 @@ TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list, "unbind should clear the corresponding bit"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
-    std::vector<hgl::id_type> expected_storage;
+    std::vector<hgl::default_id_type> expected_storage;
 
     SUBCASE("tail bound") {
         sut.bind_tail(constants::id1, constants::id1);

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -1,6 +1,8 @@
+#include "hgl/impl/layout_tags.hpp"
 #include "testing/hgl/constants.hpp"
 
 #include <doctest.h>
+#include <hgl/impl/impl_tags.hpp>
 #include <hgl/impl/incidence_matrix.hpp>
 
 #include <algorithm>
@@ -30,7 +32,8 @@ struct test_incidence_matrix {
 };
 
 struct test_undirected_vertex_major_incidence_matrix : public test_incidence_matrix {
-    using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::matrix_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -357,7 +360,8 @@ TEST_CASE_FIXTURE(
 }
 
 struct test_undirected_hyperedge_major_incidence_matrix : public test_incidence_matrix {
-    using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::matrix_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::incidence_matrix<hgl::undirected_t, impl_tag>;
 };
 
 TEST_CASE_FIXTURE(
@@ -730,7 +734,8 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
 };
 
 struct test_bf_directed_vertex_major_incidence_matrix : public test_bf_directed_incidence_matrix {
-    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::vertex_major_t>;
+    using impl_tag = hgl::impl::matrix_t<hgl::impl::vertex_major_t>;
+    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, impl_tag>;
     using incidence_type = incidence_descriptor_type<sut_type>;
 };
 
@@ -1182,7 +1187,8 @@ TEST_CASE_FIXTURE(
 
 struct test_bf_directed_hyperedge_major_incidence_matrix
 : public test_bf_directed_incidence_matrix {
-    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, hgl::impl::hyperedge_major_t>;
+    using impl_tag = hgl::impl::matrix_t<hgl::impl::hyperedge_major_t>;
+    using sut_type = hgl::impl::incidence_matrix<hgl::bf_directed_t, impl_tag>;
     using incidence_type = incidence_descriptor_type<sut_type>;
 };
 

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -76,15 +76,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the row and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -189,15 +189,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the column and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -418,15 +418,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(constants::id2, hyperedge_id);
     sut.bind(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -517,15 +517,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind(vertex_id, constants::id2);
     sut.bind(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -695,9 +695,9 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     }
 
     auto altbind_to_vertex(
-        auto& sut, const hgl::id_type vertex_id, const hgl::size_type n_hyperedges
+        auto& sut, const hgl::default_id_type vertex_id, const hgl::size_type n_hyperedges
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (auto i = 0uz; i < n_hyperedges; ++i) {
             if (i % 2 == 0) {
@@ -714,9 +714,9 @@ struct test_bf_directed_incidence_matrix : public test_incidence_matrix {
     }
 
     auto altbind_to_hyperedge(
-        auto& sut, const hgl::id_type hyperedge_id, const hgl::size_type n_vertices
+        auto& sut, const hgl::default_id_type hyperedge_id, const hgl::size_type n_vertices
     ) {
-        std::vector<hgl::id_type> tail_bound, head_bound;
+        std::vector<hgl::default_id_type> tail_bound, head_bound;
 
         for (auto i = 0uz; i < n_vertices; ++i) {
             if (i % 2 == 0) {
@@ -779,15 +779,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the row and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -900,15 +900,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the column and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;
@@ -1246,15 +1246,15 @@ TEST_CASE_FIXTURE(
     "remove_vertex should properly remove the column and implicitly shift vertex IDs"
 ) {
     constexpr hgl::size_type n_vertices = 5uz, n_hyperedges = 1uz;
-    constexpr hgl::id_type hyperedge_id = constants::id1;
+    constexpr auto hyperedge_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(constants::id2, hyperedge_id);
     sut.bind_head(constants::id4, hyperedge_id);
 
-    hgl::id_type rem_vid;
+    hgl::default_id_type rem_vid;
     hgl::size_type expected_hyperedge_size;
-    std::vector<hgl::id_type> expected_vertices;
+    std::vector<hgl::default_id_type> expected_vertices;
 
     SUBCASE("not present vertex < first incident vertex") {
         rem_vid = constants::id1;
@@ -1354,15 +1354,15 @@ TEST_CASE_FIXTURE(
     "remove_hyperedge should properly remove the row and implicitly shift hyperedge IDs"
 ) {
     constexpr hgl::size_type n_vertices = 1uz, n_hyperedges = 5uz;
-    constexpr hgl::id_type vertex_id = constants::id1;
+    constexpr auto vertex_id = constants::id1;
 
     sut_type sut{n_vertices, n_hyperedges};
     sut.bind_tail(vertex_id, constants::id2);
     sut.bind_head(vertex_id, constants::id4);
 
-    hgl::id_type rem_eid;
+    hgl::default_id_type rem_eid;
     hgl::size_type expected_vertex_degree;
-    std::vector<hgl::id_type> expected_hyperedges;
+    std::vector<hgl::default_id_type> expected_hyperedges;
 
     SUBCASE("not present hyperedge < first incident hyperedge") {
         rem_eid = constants::id1;


### PR DESCRIPTION
- Extended the implementation tag structures with an `IdType` template parameter and and `id_type` alias
- Aligned the implementation classes to use the implementation tag as a template parameter instead of the layout tag and to use the id type defined in the implementation tag
- Extended the `hypergraph_traits` structure with an `id_type` alias
- Aligned the hypergraph-traits-ralated concepts and template aliases to properly handle the additional id type parameter
- Replaced the usage of the common id type with a configurable id type in the `hypergraph` class
- Removed the `id_type` common alias and added a new `default_id_type = std::uint32_t` (from the GL module`
- Replaced the `constanst::invalid/initial_id` constants with generic tag types