### PR TITLE
YT-CPPGL-64: Implement the flat matrix graph representation models

### DIFF
--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -111,6 +111,8 @@ struct to_impl<impl::list_t, impl::flat_list_t> {
     }
 };
 
+// TODO: matrix <-> flat matrix conversions specializations
+
 } // namespace detail
 
 /// @brief Converts a graph from one implementation model to another.

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -111,7 +111,36 @@ struct to_impl<impl::list_t, impl::flat_list_t> {
     }
 };
 
-// TODO: matrix <-> flat matrix conversions specializations
+// Conversion: matrix -> flat matrix
+template <>
+struct to_impl<impl::flat_matrix_t, impl::matrix_t> {
+    template <typename TargetGraph, typename SourceGraph>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        auto& target_matrix = target._impl._matrix;
+        auto& source_matrix = source._impl._matrix;
+
+        const auto n_vertices = source_matrix.size();
+        target_matrix.resize(n_vertices, n_vertices);
+
+        auto* target_ptr = target_matrix.data_ptr();
+        for (auto& row : source_matrix)
+            target_ptr = std::ranges::move(row, target_ptr).out;
+    }
+};
+
+// Conversion: flat matrix -> matrix
+template <>
+struct to_impl<impl::matrix_t, impl::flat_matrix_t> {
+    template <typename TargetGraph, typename SourceGraph>
+    static void convert(TargetGraph& target, SourceGraph& source) {
+        auto& target_matrix = target._impl._matrix;
+        auto& source_matrix = source._impl._matrix;
+
+        target_matrix.reserve(source_matrix.n_rows());
+        for (auto row : source_matrix.rows())
+            target_matrix.emplace_back(row.begin(), row.end());
+    }
+};
 
 } // namespace detail
 

--- a/include/gl/decl/impl_tags.hpp
+++ b/include/gl/decl/impl_tags.hpp
@@ -16,12 +16,14 @@ struct flat_list_t;
 
 struct matrix_t;
 
+struct flat_matrix_t;
+
 } // namespace impl
 
 namespace traits {
 
 template <typename T>
-concept c_graph_impl_tag = c_one_of<T, impl::list_t, impl::flat_list_t, impl::matrix_t>;
+concept c_graph_impl_tag = c_one_of<T, impl::list_t, impl::flat_list_t, impl::matrix_t, impl::flat_matrix_t>;
 
 } // namespace traits
 

--- a/include/gl/decl/impl_tags.hpp
+++ b/include/gl/decl/impl_tags.hpp
@@ -23,7 +23,8 @@ struct flat_matrix_t;
 namespace traits {
 
 template <typename T>
-concept c_graph_impl_tag = c_one_of<T, impl::list_t, impl::flat_list_t, impl::matrix_t, impl::flat_matrix_t>;
+concept c_graph_impl_tag =
+    c_one_of<T, impl::list_t, impl::flat_list_t, impl::matrix_t, impl::flat_matrix_t>;
 
 } // namespace traits
 

--- a/include/gl/graph_traits.hpp
+++ b/include/gl/graph_traits.hpp
@@ -54,6 +54,14 @@ using matrix_graph_traits =
     graph_traits<DirectionalTag, VertexProperties, EdgeProperties, impl::matrix_t, IdType>;
 
 template <
+    traits::c_graph_directional_tag DirectionalTag = directed_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using flat_matrix_graph_traits =
+    graph_traits<DirectionalTag, VertexProperties, EdgeProperties, impl::flat_matrix_t, IdType>;
+
+template <
     traits::c_properties VertexProperties = empty_properties,
     traits::c_properties EdgeProperties = empty_properties,
     traits::c_graph_impl_tag ImplTag = impl::list_t,
@@ -91,7 +99,13 @@ concept c_matrix_graph_traits =
     and std::same_as<typename TraitsType::implementation_tag, impl::matrix_t>;
 
 template <typename TraitsType>
-concept c_adjacency_matrix_graph_traits = c_matrix_graph_traits<TraitsType>;
+concept c_flat_matrix_graph_traits =
+    c_instantiation_of<TraitsType, graph_traits>
+    and std::same_as<typename TraitsType::implementation_tag, impl::flat_matrix_t>;
+
+template <typename TraitsType>
+concept c_adjacency_matrix_graph_traits =
+    c_matrix_graph_traits<TraitsType> or c_flat_matrix_graph_traits<TraitsType>;
 
 template <typename TraitsType>
 concept c_directed_graph_traits =

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -36,7 +36,7 @@ public:
     using vertex_type = typename GraphTraits::vertex_type;
     using edge_type = typename GraphTraits::edge_type;
     using item_type = specialized::adjacency_list_item<id_type>;
-    using adjacency_list_type = typename specialized::adjacency_list_impl_traits<
+    using adjacency_storage_type = typename specialized::adjacency_list_impl_traits<
         adjacency_list>::template storage_type<item_type>;
 
     adjacency_list() = default;
@@ -305,7 +305,7 @@ private:
         }
     }
 
-    adjacency_list_type _list{};
+    adjacency_storage_type _list{};
 };
 
 } // namespace impl

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -162,7 +162,7 @@ public:
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         specialized_impl::remove_edge(*this, edge);
-        for (auto& row : this->_matrix)
+        for (auto&& row : this->_matrix)
             for (auto& edge_id : row)
                 if (edge_id != invalid_id and edge_id > edge.id())
                     edge_id--;
@@ -315,7 +315,7 @@ private:
             std::ranges::unique(removed_edge_ids).begin(), removed_edge_ids.end()
         );
 
-        for (auto& row : this->_matrix) {
+        for (auto&& row : this->_matrix) {
             for (auto& edge_id : row) {
                 if (edge_id == invalid_id)
                     continue;

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -6,6 +6,7 @@
 
 #include "gl/constants.hpp"
 #include "gl/impl/specialized/adjacency_matrix.hpp"
+#include "gl/impl/specialized/flat_adjacency_matrix.hpp"
 #include "gl/types/core.hpp"
 
 #ifdef GL_TESTING
@@ -33,15 +34,14 @@ public:
 
     using vertex_type = typename GraphTraits::vertex_type;
     using edge_type = typename GraphTraits::edge_type;
-    using row_type = std::vector<id_type>;
-    using matrix_type = std::vector<row_type>;
+
+    using adjacency_storage_type = typename specialized::adjacency_matrix_impl_traits<
+        adjacency_matrix>::template storage_type<id_type>;
 
     adjacency_matrix() = default;
 
-    explicit adjacency_matrix(size_type n_vertices) : _matrix(n_vertices) {
-        // initialize a full n x n matrix with null elements
-        for (auto& row : this->_matrix)
-            row.resize(n_vertices, invalid_id);
+    explicit adjacency_matrix(size_type n_vertices) {
+        specialized_impl::init(*this, n_vertices);
     }
 
     adjacency_matrix(const adjacency_matrix&) = default;
@@ -55,19 +55,11 @@ public:
     // --- vertex methods ---
 
     void add_vertex() {
-        for (auto& row : this->_matrix)
-            row.emplace_back(invalid_id);
-        this->_matrix.emplace_back(this->_matrix.size() + 1uz, invalid_id);
+        specialized_impl::add_vertex(*this);
     }
 
     void add_vertices(size_type n) {
-        const auto new_n_vertices = this->_matrix.size() + n;
-
-        for (auto& row : this->_matrix)
-            row.resize(new_n_vertices, invalid_id);
-
-        for (auto _ = 0uz; _ < n; ++_)
-            this->_matrix.emplace_back(new_n_vertices, invalid_id);
+        specialized_impl::add_vertices(*this, n);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type in_degree(id_type vertex_id) const {
@@ -339,7 +331,7 @@ private:
         }
     }
 
-    matrix_type _matrix{};
+    adjacency_storage_type _matrix{};
 };
 
 } // namespace impl

--- a/include/gl/impl/impl_tags.hpp
+++ b/include/gl/impl/impl_tags.hpp
@@ -28,4 +28,10 @@ struct matrix_t {
     using type = adjacency_matrix<GraphTraits>;
 };
 
+struct flat_matrix_t {
+    template <traits::c_instantiation_of<graph_traits> GraphTraits>
+    requires(std::same_as<typename GraphTraits::implementation_tag, flat_matrix_t>)
+    using type = adjacency_matrix<GraphTraits>;
+};
+
 } // namespace gl::impl

--- a/include/gl/impl/specialized/flat_adjacency_list.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_list.hpp
@@ -95,7 +95,7 @@ struct directed_flat_adjacency_list {
             removed_edges.push_back(item.edge_id);
 
         // rebuild the graph (faster then shifting the entire data block for each removed edge)
-        typename impl_type::adjacency_list_type new_list;
+        typename impl_type::adjacency_storage_type new_list;
         new_list.reserve_segments(self._list.size() - 1uz);
         new_list.reserve_data(self._list.data_size() - self._list[vertex_idx].size());
 
@@ -205,7 +205,7 @@ struct undirected_flat_adjacency_list {
             | std::ranges::to<std::vector>();
 
         // rebuild the graph (faster then shifting the entire data block for each removed edge)
-        typename impl_type::adjacency_list_type new_list;
+        typename impl_type::adjacency_storage_type new_list;
         new_list.reserve_segments(self._list.size() - 1uz);
         const auto estimated_new_size =
             self._list.data_size() - (self._list[vertex_idx].size() * 2uz);

--- a/include/gl/impl/specialized/flat_adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_matrix.hpp
@@ -23,11 +23,13 @@ requires(traits::c_directed_edge<typename AdjacencyMatrix::edge_type>)
 struct directed_flat_adjacency_matrix {
     using impl_type = AdjacencyMatrix;
     using id_type = typename impl_type::id_type;
+    using storage_type = typename impl_type::adjacency_storage_type;
+
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
     static void init(impl_type& self, size_type n_vertices) {
-        self._matrix.resize(n_vertices, n_vertices, invalid_id);
+        self._matrix = storage_type(n_vertices, n_vertices, invalid_id);
     }
 
     static void add_vertex(impl_type& self) {
@@ -52,7 +54,7 @@ struct directed_flat_adjacency_matrix {
         const impl_type& self, id_type vertex_id
     ) {
         const auto row = self._matrix[to_idx(vertex_id)];
-        return row.size() - std::ranges::count(row, invalid_id_v<id_type>); // <-- FIXED
+        return row.size() - std::ranges::count(row, invalid_id_v<id_type>);
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type degree(
@@ -73,7 +75,7 @@ struct directed_flat_adjacency_matrix {
     [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
         std::vector<size_type> in_degree_map(self._matrix.n_rows(), 0uz);
 
-        for (const auto& row : self._matrix.rows())
+        for (const auto row : self._matrix.rows())
             for (auto [target_id, edge_id] : std::views::enumerate(row))
                 in_degree_map[static_cast<size_type>(target_id)] +=
                     static_cast<size_type>(edge_id != invalid_id);
@@ -105,13 +107,12 @@ struct directed_flat_adjacency_matrix {
     static std::vector<id_type> remove_vertex(impl_type& self, id_type vertex_id) {
         const auto vertex_idx = to_idx(vertex_id);
         std::vector<id_type> removed_edges;
+        removed_edges.reserve(self._matrix.size());
 
         // extract out-edges
-        const auto row = self._matrix[vertex_idx];
-        for (auto edge_id : row) {
+        for (auto edge_id : self._matrix[vertex_idx])
             if (edge_id != invalid_id)
                 removed_edges.push_back(edge_id);
-        }
 
         // extract in-edges
         const auto col = self._matrix.col(vertex_idx);
@@ -160,11 +161,13 @@ requires(traits::c_undirected_edge<typename AdjacencyMatrix::edge_type>)
 struct undirected_flat_adjacency_matrix {
     using impl_type = AdjacencyMatrix;
     using id_type = typename impl_type::id_type;
+    using storage_type = typename impl_type::adjacency_storage_type;
+
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
     static void init(impl_type& self, size_type n_vertices) {
-        self._matrix.resize(n_vertices, n_vertices, invalid_id);
+        self._matrix = storage_type(n_vertices, n_vertices, invalid_id);
     }
 
     static void add_vertex(impl_type& self) {

--- a/include/gl/impl/specialized/flat_adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_matrix.hpp
@@ -7,88 +7,52 @@
 #include "gl/constants.hpp"
 #include "gl/decl/impl_tags.hpp"
 #include "gl/graph_traits.hpp"
+#include "gl/impl/specialized/adjacency_matrix.hpp"
 #include "gl/types/core.hpp"
+#include "gl/types/flat_matrix.hpp"
 
 #include <algorithm>
+#include <format>
+#include <ranges>
 #include <vector>
 
-namespace gl::impl {
-
-template <traits::c_adjacency_matrix_graph_traits GraphTraits>
-class adjacency_matrix;
-
-namespace specialized {
-
-namespace detail {
-
-[[nodiscard]] auto& strict_get(auto& id_matrix, const auto& edge) {
-    // get the edge and validate the address
-    const auto [source_id, target_id] = edge.incident_vertices();
-    auto& edge_id = id_matrix[to_idx(source_id)][to_idx(target_id)];
-    if (edge.id() != edge_id)
-        throw std::invalid_argument(std::format(
-            "Got invalid edge [id = {} | vertices = ({}, {})]", edge.id(), source_id, target_id
-        ));
-
-    return edge_id;
-}
-
-template <traits::c_id_type IdType>
-inline void check_edge_override(
-    const auto& id_matrix, const IdType source_id, const IdType target_id
-) {
-    if (const auto edge_id = id_matrix[to_idx(source_id)][to_idx(target_id)]; edge_id != invalid_id)
-        throw std::logic_error(std::format(
-            "Cannot override an existing edge: [id = {}, vertices = ({}, {})]",
-            edge_id,
-            source_id,
-            target_id
-        ));
-}
-
-} // namespace detail
+namespace gl::impl::specialized {
 
 template <traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(traits::c_directed_edge<typename AdjacencyMatrix::edge_type>)
-struct directed_adjacency_matrix {
+struct directed_flat_adjacency_matrix {
     using impl_type = AdjacencyMatrix;
     using id_type = typename impl_type::id_type;
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
     static void init(impl_type& self, size_type n_vertices) {
-        self._matrix.resize(n_vertices);
-        for (auto& row : self._matrix)
-            row.resize(n_vertices, invalid_id);
+        self._matrix.resize(n_vertices, n_vertices, invalid_id);
     }
 
     static void add_vertex(impl_type& self) {
-        for (auto& row : self._matrix)
-            row.emplace_back(invalid_id);
-        self._matrix.emplace_back(self._matrix.size() + 1uz, invalid_id);
+        const auto new_size = self._matrix.n_rows() + 1uz;
+        self._matrix.resize(new_size, new_size, invalid_id);
     }
 
     static void add_vertices(impl_type& self, size_type n) {
-        const auto new_n_vertices = self._matrix.size() + n;
-        for (auto& row : self._matrix)
-            row.resize(new_n_vertices, invalid_id);
-        for (auto _ = 0uz; _ < n; ++_)
-            self._matrix.emplace_back(new_n_vertices, invalid_id);
+        const auto new_size = self._matrix.n_rows() + n;
+        self._matrix.resize(new_size, new_size, invalid_id);
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type in_degree(
         const impl_type& self, id_type vertex_id
     ) {
-        return std::ranges::count_if(self._matrix, [vertex_id](const auto& row) {
-            return row[to_idx(vertex_id)] != invalid_id;
+        return std::ranges::count_if(self._matrix.col(to_idx(vertex_id)), [](auto edge_id) {
+            return edge_id != invalid_id;
         });
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type out_degree(
         const impl_type& self, id_type vertex_id
     ) {
-        return self._matrix[vertex_id].size()
-             - std::ranges::count(self._matrix[vertex_id], invalid_id_v<id_type>);
+        const auto row = self._matrix[to_idx(vertex_id)];
+        return row.size() - std::ranges::count(row, invalid_id);
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type degree(
@@ -96,17 +60,20 @@ struct directed_adjacency_matrix {
     ) {
         size_type deg = 0uz;
         const auto vertex_idx = to_idx(vertex_id);
-        for (auto v_idx = 0uz; v_idx < self._matrix.size(); ++v_idx)
-            deg += static_cast<size_type>(self._matrix[vertex_idx][v_idx] != invalid_id)
-                 + static_cast<size_type>(self._matrix[v_idx][vertex_idx] != invalid_id);
+        const auto row = self._matrix[vertex_idx];
+        const auto col = self._matrix.col(vertex_idx);
+
+        for (auto v_idx = 0uz; v_idx < self._matrix.n_rows(); ++v_idx)
+            deg += static_cast<size_type>(row[v_idx] != invalid_id)
+                 + static_cast<size_type>(col[v_idx] != invalid_id);
 
         return deg;
     }
 
     [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
-        std::vector<size_type> in_degree_map(self._matrix.size(), 0uz);
+        std::vector<size_type> in_degree_map(self._matrix.n_rows(), 0uz);
 
-        for (const auto& row : self._matrix)
+        for (const auto& row : self._matrix.rows())
             for (auto [target_id, edge_id] : std::views::enumerate(row))
                 in_degree_map[static_cast<size_type>(target_id)] +=
                     static_cast<size_type>(edge_id != invalid_id);
@@ -115,17 +82,17 @@ struct directed_adjacency_matrix {
     }
 
     [[nodiscard]] static std::vector<size_type> out_degree_map(const impl_type& self) {
-        return std::views::iota(initial_id_v<id_type>, self._matrix.size())
+        return std::views::iota(initial_id_v<id_type>, static_cast<id_type>(self._matrix.n_rows()))
              | std::views::transform([&](id_type id) { return out_degree(self, id); })
              | std::ranges::to<std::vector>();
     }
 
     [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
-        std::vector<size_type> degree_map(self._matrix.size(), 0uz);
+        std::vector<size_type> degree_map(self._matrix.n_rows(), 0uz);
 
-        for (auto src_idx = 0uz; src_idx < self._matrix.size(); ++src_idx) {
-            for (auto tgt_idx = 0uz; tgt_idx < self._matrix.size(); ++tgt_idx) {
-                if (self._matrix[src_idx][tgt_idx] != invalid_id) {
+        for (auto src_idx = 0uz; src_idx < self._matrix.n_rows(); ++src_idx) {
+            for (auto tgt_idx = 0uz; tgt_idx < self._matrix.n_cols(); ++tgt_idx) {
+                if (self._matrix[src_idx, tgt_idx] != invalid_id) {
                     ++degree_map[src_idx];
                     ++degree_map[tgt_idx];
                 }
@@ -137,19 +104,26 @@ struct directed_adjacency_matrix {
 
     static std::vector<id_type> remove_vertex(impl_type& self, id_type vertex_id) {
         const auto vertex_idx = to_idx(vertex_id);
+        std::vector<id_type> removed_edges;
 
-        auto removed_edges =
-            self._matrix[vertex_idx]
-            | std::views::filter([](auto edge_id) { return edge_id != invalid_id; })
-            | std::ranges::to<std::vector>();
-
-        self._matrix.erase(std::next(std::begin(self._matrix), vertex_idx));
-
-        for (auto& row : self._matrix) {
-            if (const auto edge_id = row[vertex_idx]; edge_id != invalid_id)
+        // extract out-edges
+        const auto row = self._matrix[vertex_idx];
+        for (auto edge_id : row) {
+            if (edge_id != invalid_id)
                 removed_edges.push_back(edge_id);
-            row.erase(std::next(std::begin(row), vertex_idx));
         }
+
+        // extract in-edges
+        const auto col = self._matrix.col(vertex_idx);
+        for (auto r_idx = 0uz; r_idx < self._matrix.n_rows(); ++r_idx) {
+            if (r_idx == vertex_idx) continue;
+            if (const auto edge_id = col[r_idx]; edge_id != invalid_id)
+                removed_edges.push_back(edge_id);
+        }
+
+        // elegantly remove from the 2D grid
+        self._matrix.erase_row(vertex_idx);
+        self._matrix.erase_col(vertex_idx);
 
         return removed_edges;
     }
@@ -158,7 +132,7 @@ struct directed_adjacency_matrix {
         impl_type& self, id_type edge_id, id_type source_id, id_type target_id
     ) {
         detail::check_edge_override(self._matrix, source_id, target_id);
-        self._matrix[to_idx(source_id)][to_idx(target_id)] = edge_id;
+        self._matrix[to_idx(source_id), to_idx(target_id)] = edge_id;
     }
 
     static void add_edges_from(
@@ -170,7 +144,7 @@ struct directed_adjacency_matrix {
         for (const auto target_id : target_ids)
             detail::check_edge_override(self._matrix, source_id, target_id);
 
-        auto& matrix_source_row = self._matrix[to_idx(source_id)];
+        auto matrix_source_row = self._matrix[to_idx(source_id)];
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids))
             matrix_source_row[to_idx(target_id)] = edge_id;
     }
@@ -182,30 +156,24 @@ struct directed_adjacency_matrix {
 
 template <traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
 requires(traits::c_undirected_edge<typename AdjacencyMatrix::edge_type>)
-struct undirected_adjacency_matrix {
+struct undirected_flat_adjacency_matrix {
     using impl_type = AdjacencyMatrix;
     using id_type = typename impl_type::id_type;
     using vertex_type = typename impl_type::vertex_type;
     using edge_type = typename impl_type::edge_type;
 
     static void init(impl_type& self, size_type n_vertices) {
-        self._matrix.resize(n_vertices);
-        for (auto& row : self._matrix)
-            row.resize(n_vertices, invalid_id);
+        self._matrix.resize(n_vertices, n_vertices, invalid_id);
     }
 
     static void add_vertex(impl_type& self) {
-        for (auto& row : self._matrix)
-            row.emplace_back(invalid_id);
-        self._matrix.emplace_back(self._matrix.size() + 1uz, invalid_id);
+        const auto new_size = self._matrix.n_rows() + 1uz;
+        self._matrix.resize(new_size, new_size, invalid_id);
     }
 
     static void add_vertices(impl_type& self, size_type n) {
-        const auto new_n_vertices = self._matrix.size() + n;
-        for (auto& row : self._matrix)
-            row.resize(new_n_vertices, invalid_id);
-        for (auto _ = 0uz; _ < n; ++_)
-            self._matrix.emplace_back(new_n_vertices, invalid_id);
+        const auto new_size = self._matrix.n_rows() + n;
+        self._matrix.resize(new_size, new_size, invalid_id);
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type in_degree(
@@ -224,9 +192,10 @@ struct undirected_adjacency_matrix {
         const impl_type& self, id_type vertex_id
     ) {
         const auto vertex_idx = to_idx(vertex_id);
-        return self._matrix.size()
-             - std::ranges::count(self._matrix[vertex_idx], invalid_id_v<id_type>)
-             + static_cast<size_type>(self._matrix[vertex_idx][vertex_idx] != invalid_id);
+        const auto row = self._matrix[vertex_idx];
+        return self._matrix.n_cols()
+             - std::ranges::count(row, invalid_id)
+             + static_cast<size_type>(self._matrix[vertex_idx, vertex_idx] != invalid_id);
     }
 
     [[nodiscard]] gl_attr_force_inline static std::vector<size_type> in_degree_map(
@@ -242,11 +211,11 @@ struct undirected_adjacency_matrix {
     }
 
     [[nodiscard]] static std::vector<size_type> degree_map(const impl_type& self) {
-        std::vector<size_type> degree_map(self._matrix.size(), 0uz);
+        std::vector<size_type> degree_map(self._matrix.n_rows(), 0uz);
 
-        for (auto src_idx = 0uz; src_idx < self._matrix.size(); ++src_idx) {
+        for (auto src_idx = 0uz; src_idx < self._matrix.n_rows(); ++src_idx) {
             for (auto tgt_idx = 0uz; tgt_idx <= src_idx; ++tgt_idx) {
-                if (self._matrix[src_idx][tgt_idx] != invalid_id) {
+                if (self._matrix[src_idx, tgt_idx] != invalid_id) {
                     ++degree_map[src_idx];
                     ++degree_map[tgt_idx];
                 }
@@ -264,9 +233,8 @@ struct undirected_adjacency_matrix {
             | std::views::filter([](auto edge_id) { return edge_id != invalid_id; })
             | std::ranges::to<std::vector>();
 
-        self._matrix.erase(std::next(std::begin(self._matrix), vertex_idx));
-        for (auto& row : self._matrix)
-            row.erase(std::next(std::begin(row), vertex_idx));
+        self._matrix.erase_row(vertex_idx);
+        self._matrix.erase_col(vertex_idx);
 
         return removed_edges;
     }
@@ -277,9 +245,9 @@ struct undirected_adjacency_matrix {
         const auto source_idx = to_idx(source_id);
         const auto target_idx = to_idx(target_id);
 
-        self._matrix[source_idx][target_idx] = edge_id;
+        self._matrix[source_idx, target_idx] = edge_id;
         if (target_idx != source_idx)
-            self._matrix[target_idx][source_idx] = edge_id;
+            self._matrix[target_idx, source_idx] = edge_id;
     }
 
     static void add_edges_from(
@@ -292,13 +260,13 @@ struct undirected_adjacency_matrix {
             detail::check_edge_override(self._matrix, source_id, target_id);
 
         const auto source_idx = to_idx(source_id);
-        auto& matrix_source_row = self._matrix[source_idx];
+        auto matrix_source_row = self._matrix[source_idx];
 
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids)) {
             const auto target_idx = to_idx(target_id);
             matrix_source_row[target_idx] = edge_id;
             if (target_idx != source_idx)
-                self._matrix[target_idx][source_idx] = edge_id;
+                self._matrix[target_idx, source_idx] = edge_id;
         }
     }
 
@@ -308,38 +276,29 @@ struct undirected_adjacency_matrix {
         }
         else {
             detail::strict_get(self._matrix, edge) = invalid_id;
-            // if the edge was found in the first matrix cell, it will also be present in the second matrix cell
-            self._matrix[to_idx(edge.target())][to_idx(edge.source())] = invalid_id;
+            self._matrix[to_idx(edge.target()), to_idx(edge.source())] = invalid_id;
         }
     }
 };
 
 template <traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
-struct adjacency_matrix_impl_traits {
-    using type = void;
+requires traits::c_directed_edge<typename AdjacencyMatrix::edge_type>
+     and std::same_as<typename AdjacencyMatrix::implementation_tag, flat_matrix_t>
+struct adjacency_matrix_impl_traits<AdjacencyMatrix> {
+    using type = directed_flat_adjacency_matrix<AdjacencyMatrix>;
 
     template <traits::c_id_type IdType>
-    using storage_type = void;
+    using storage_type = flat_matrix<IdType>;
 };
 
 template <traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
-requires(traits::c_directed_edge<typename AdjacencyMatrix::edge_type>)
+requires traits::c_undirected_edge<typename AdjacencyMatrix::edge_type>
+     and std::same_as<typename AdjacencyMatrix::implementation_tag, flat_matrix_t>
 struct adjacency_matrix_impl_traits<AdjacencyMatrix> {
-    using type = directed_adjacency_matrix<AdjacencyMatrix>;
+    using type = undirected_flat_adjacency_matrix<AdjacencyMatrix>;
 
     template <traits::c_id_type IdType>
-    using storage_type = std::vector<std::vector<IdType>>;
+    using storage_type = flat_matrix<IdType>;
 };
 
-template <traits::c_instantiation_of<adjacency_matrix> AdjacencyMatrix>
-requires(traits::c_undirected_edge<typename AdjacencyMatrix::edge_type>)
-struct adjacency_matrix_impl_traits<AdjacencyMatrix> {
-    using type = undirected_adjacency_matrix<AdjacencyMatrix>;
-
-    template <traits::c_id_type IdType>
-    using storage_type = std::vector<std::vector<IdType>>;
-};
-
-} // namespace specialized
-
-} // namespace gl::impl
+} // namespace gl::impl::specialized

--- a/include/gl/impl/specialized/flat_adjacency_matrix.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_matrix.hpp
@@ -52,7 +52,7 @@ struct directed_flat_adjacency_matrix {
         const impl_type& self, id_type vertex_id
     ) {
         const auto row = self._matrix[to_idx(vertex_id)];
-        return row.size() - std::ranges::count(row, invalid_id);
+        return row.size() - std::ranges::count(row, invalid_id_v<id_type>); // <-- FIXED
     }
 
     [[nodiscard]] gl_attr_force_inline static size_type degree(
@@ -116,7 +116,8 @@ struct directed_flat_adjacency_matrix {
         // extract in-edges
         const auto col = self._matrix.col(vertex_idx);
         for (auto r_idx = 0uz; r_idx < self._matrix.n_rows(); ++r_idx) {
-            if (r_idx == vertex_idx) continue;
+            if (r_idx == vertex_idx)
+                continue;
             if (const auto edge_id = col[r_idx]; edge_id != invalid_id)
                 removed_edges.push_back(edge_id);
         }
@@ -193,8 +194,7 @@ struct undirected_flat_adjacency_matrix {
     ) {
         const auto vertex_idx = to_idx(vertex_id);
         const auto row = self._matrix[vertex_idx];
-        return self._matrix.n_cols()
-             - std::ranges::count(row, invalid_id)
+        return self._matrix.n_cols() - std::ranges::count(row, invalid_id_v<id_type>)
              + static_cast<size_type>(self._matrix[vertex_idx, vertex_idx] != invalid_id);
     }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -139,7 +139,9 @@ TEST_CASE_TEMPLATE_DEFINE(
 TEST_CASE_TEMPLATE_INSTANTIATE(
     directional_tag_sut_template,
     gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>, // directed adj list
-    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>> // undirected adj list
+    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adj list
+    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj list
+    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj list
 );
 
 namespace {

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -20,7 +20,7 @@ struct test_adjacency_matrix {
         return sut._matrix;
     }
 
-    gl::size_type size(const auto& sut) const {
+    [[nodiscard]] gl::size_type size(const auto& sut) const {
         return sut._matrix.size();
     }
 
@@ -138,10 +138,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     directional_tag_sut_template,
-    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>, // directed adj list
-    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adj list
-    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj list
-    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj list
+    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>, // directed adj matrix
+    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adj matrix
+    gl::impl::adjacency_matrix<
+        gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj matrix
+    gl::impl::adjacency_matrix<
+        gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj matrix
 );
 
 namespace {
@@ -150,18 +152,20 @@ constexpr gl::size_type n_incident_edges_for_fully_connected_vertex = constants:
 
 } // namespace
 
+template <typename SutType>
 struct test_directed_adjacency_matrix : public test_adjacency_matrix {
-    using edge_type = gl::directed_edge<>;
-    using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>;
+    using sut_type = SutType;
+    using id_type = typename sut_type::id_type;
+    using edge_type = typename sut_type::edge_type;
 
-    edge_type add_edge(const gl::default_id_type source_id, const gl::default_id_type target_id) {
+    edge_type add_edge(const id_type source_id, const id_type target_id) {
         const auto new_edge_id = this->next_edge_id++;
         sut.add_edge(new_edge_id, source_id, target_id);
         return edge_type{new_edge_id, source_id, target_id};
     }
 
-    void fully_connect_vertex(const auto source_id, const bool no_loops = true) {
-        for (const auto target_id : constants::vertex_id_view) {
+    void fully_connect_vertex(const id_type source_id, const bool no_loops = true) {
+        for (const id_type target_id : constants::vertex_id_view) {
             if (target_id == source_id and no_loops)
                 continue;
 
@@ -191,278 +195,269 @@ struct test_directed_adjacency_matrix : public test_adjacency_matrix {
         n_incident_edges_for_fully_connected_vertex * constants::n_elements;
 };
 
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix, "add_edge should add the edge only to the source vertex list"
-) {
-    const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
+TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_adj_matrix_template) {
+    using fixture_type = test_directed_adjacency_matrix<SutType>;
+    using sut_type = typename fixture_type::sut_type;
+    using edge_type = typename fixture_type::edge_type;
 
-    REQUIRE(new_edge.is_incident_from(constants::v1_id));
-    REQUIRE(new_edge.is_incident_to(constants::v2_id));
+    fixture_type fixture;
+    auto& sut = fixture.sut;
 
-    auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-    CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-    CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), 0uz);
+    const auto size = [&fixture](const auto& sut) { return fixture.size(sut); };
+    const auto add_edge = [&fixture](const auto source_id, const auto target_id) {
+        return fixture.add_edge(source_id, target_id);
+    };
+    const auto fully_connect_vertex = [&fixture](const auto source_id, const bool no_loops = true) {
+        fixture.fully_connect_vertex(source_id, no_loops);
+    };
+    const auto init_complete_graph = [&fixture](const bool no_loops = true) {
+        fixture.init_complete_graph(no_loops);
+    };
 
-    const auto& new_edge_extracted = *std::ranges::begin(adjacent_edges_1);
-    CHECK_EQ(new_edge_extracted, new_edge);
-}
+    SUBCASE("add_edge should add the edge only to the source vertex list") {
+        const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
 
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "at should return a view equivalent to the matrix row of the given vertex"
-) {
-    for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements)) {
-        const auto edge = add_edge(vertex_id, (vertex_id + 1) % constants::n_elements);
-        auto row_view = sut.at(vertex_id);
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
+        REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        REQUIRE_EQ(std::ranges::count_if(row_view, &edge_type::is_valid), 1uz);
+        auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+        CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+        CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), 0uz);
 
-        const auto edge_it = std::ranges::find_if(row_view, &edge_type::is_valid);
-        REQUIRE_NE(edge_it, row_view.end());
-        REQUIRE_EQ(*edge_it, edge);
+        const auto& new_edge_extracted = *std::ranges::begin(adjacent_edges_1);
+        CHECK_EQ(new_edge_extracted, new_edge);
+    }
+
+    SUBCASE("at should return a view equivalent to the matrix row of the given vertex") {
+        for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements)) {
+            const auto edge = add_edge(vertex_id, (vertex_id + 1u) % constants::n_elements);
+            auto row_view = sut.at(vertex_id);
+
+            REQUIRE_EQ(std::ranges::count_if(row_view, &edge_type::is_valid), 1uz);
+
+            const auto edge_it = std::ranges::find_if(row_view, &edge_type::is_valid);
+            REQUIRE_NE(edge_it, row_view.end());
+            REQUIRE_EQ(*edge_it, edge);
+        }
+    }
+
+    SUBCASE("adjacent_edges should return a filtered view of edges adjacent with the given vertex"
+    ) {
+        const auto vertex_id = constants::v1_id;
+        const auto edge = add_edge(vertex_id, constants::v2_id);
+        auto adjacent_edges = sut.adjacent_edges(vertex_id);
+
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
+    }
+
+    SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
+            "vertices with the given ids in the specified direction") {
+        add_edge(constants::v1_id, constants::v2_id);
+
+        CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v1_id));
+        CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
+    }
+
+    SUBCASE("has_edge(edge_ptr) should return true if the given edge is present in the graph") {
+        const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
+        CHECK(sut.has_edge(valid_edge));
+
+        const edge_type invalid_edge{gl::invalid_id, constants::v1_id, constants::v2_id};
+        CHECK_FALSE(sut.has_edge(invalid_edge));
+
+        // edge connecting vertices not connected in the actual graph
+        const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
+        CHECK_FALSE(sut.has_edge(not_present_edge));
+    }
+
+    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+            "vertices") {
+        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+    }
+
+    SUBCASE("get_edge(id, id) should return a valid edge if the given vertices are connected") {
+        const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
+
+        const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
+        REQUIRE(edge_opt.has_value());
+        CHECK_EQ(*edge_opt, edge_1);
+
+        CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
+    }
+
+    SUBCASE("remove_edge should throw when an edge is invalid") {
+        // not existing edge between valid vertices
+        CHECK_THROWS_AS(
+            sut.remove_edge(edge_type{fixture.next_edge_id++, constants::v1_id, constants::v2_id}),
+            std::invalid_argument
+        );
+    }
+
+    SUBCASE("remove_edge should remove the edge from the source vertex's list") {
+        fully_connect_vertex(constants::v1_id);
+
+        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
+        REQUIRE_EQ(
+            gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex
+        );
+
+        const auto edge_to_remove = *std::ranges::begin(adjacent_edges);
+        sut.remove_edge(edge_to_remove);
+
+        // validate that the adjacent edges list has been properly aligned
+        adjacent_edges = sut.adjacent_edges(constants::v1_id);
+        REQUIRE_EQ(
+            gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex - 1uz
+        );
+        CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
+    }
+
+    SUBCASE("in_edges should return edges where the vertex is the target") {
+        const auto edge1 = add_edge(constants::v2_id, constants::v1_id);
+        const auto edge2 = add_edge(constants::v3_id, constants::v1_id);
+
+        const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
+
+        REQUIRE_EQ(in_edges.size(), 2uz);
+        CHECK(std::ranges::contains(in_edges, edge1));
+        CHECK(std::ranges::contains(in_edges, edge2));
+    }
+
+    SUBCASE("out_edges should return edges where the vertex is the source") {
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+
+        const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
+
+        REQUIRE_EQ(out_edges.size(), 2uz);
+        CHECK(std::ranges::contains(out_edges, edge1));
+        CHECK(std::ranges::contains(out_edges, edge2));
+    }
+
+    SUBCASE("{in/out}_degree should return the number of edges incident {to/from} the given vertex"
+    ) {
+        init_complete_graph();
+
+        std::function<gl::size_type(const gl::default_id_type)> deg_proj;
+
+        SUBCASE("in_degree") {
+            deg_proj = [&sut](const auto vertex_id) { return sut.in_degree(vertex_id); };
+        }
+
+        SUBCASE("out_degree") {
+            deg_proj = [&sut](const auto vertex_id) { return sut.out_degree(vertex_id); };
+        }
+
+        CAPTURE(deg_proj);
+
+        CHECK(std::ranges::all_of(
+            constants::vertex_id_view,
+            [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+            deg_proj
+        ));
+
+        add_edge(constants::v1_id, constants::v1_id);
+
+        CHECK_EQ(deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + 1uz);
+    }
+
+    SUBCASE("degree should return the number of edges incident with the given vertex") {
+        init_complete_graph();
+        const auto deg_proj = [&sut](const auto vertex_id) { return sut.degree(vertex_id); };
+
+        CHECK(std::ranges::all_of(
+            constants::vertex_id_view,
+            [](const auto deg) { return deg == 2uz * n_incident_edges_for_fully_connected_vertex; },
+            deg_proj
+        ));
+
+        add_edge(constants::v1_id, constants::v1_id);
+
+        CHECK_EQ(
+            deg_proj(constants::v1_id), 2uz * (n_incident_edges_for_fully_connected_vertex + 1uz)
+        );
+    }
+
+    SUBCASE("{in/out}_degree_map should return a map of numbers of edges incident {to/from} the "
+            "corresponding vertices") {
+        init_complete_graph(false);
+        const auto expected_deg = constants::n_elements;
+
+        std::vector<gl::size_type> degree_map;
+
+        SUBCASE("in_degree") {
+            degree_map = sut.in_degree_map();
+        }
+
+        SUBCASE("out_degree") {
+            degree_map = sut.out_degree_map();
+        }
+
+        CAPTURE(degree_map);
+
+        REQUIRE_EQ(degree_map.size(), constants::n_elements);
+        CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
+    }
+
+    SUBCASE("degree_map should return a map of the numbers of edges incident with the "
+            "corresponding "
+            "vertices") {
+        init_complete_graph(false);
+        const auto expected_deg = constants::n_elements * 2uz;
+
+        std::vector<gl::size_type> degree_map = sut.degree_map();
+
+        REQUIRE_EQ(degree_map.size(), constants::n_elements);
+        CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
+    }
+
+    SUBCASE("remove_vertex should remove the given vertex and all edges incident with it") {
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge3 = add_edge(constants::v2_id, constants::v1_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+        const auto edge4 = add_edge(constants::v3_id, constants::v1_id);
+
+        const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
+        const auto edge6 = add_edge(constants::v3_id, constants::v2_id);
+
+        const auto removed_vertex_id = constants::v1_id;
+        const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
+
+        constexpr gl::size_type n_removed_edges = 4uz;
+        REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
+        for (const auto edge_id : {edge1.id(), edge2.id(), edge3.id(), edge4.id()})
+            CHECK(std::ranges::contains(removed_edge_ids, edge_id));
+        for (const auto edge_id : {edge5.id(), edge6.id()})
+            CHECK_FALSE(std::ranges::contains(removed_edge_ids, edge_id));
+
+        // Check the structure of the graph considering the aligned IDs
+        CHECK_EQ(size(sut), constants::n_elements - 1uz);
+
+        auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
+        CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge5.id() - n_removed_edges);
+        CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
+
+        auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
+        CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge6.id() - n_removed_edges);
+        CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
     }
 }
 
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "adjacent_edges should return a filtered view of edges adjacent with the given vertex"
-) {
-    const auto vertex_id = constants::v1_id;
-    const auto edge = add_edge(vertex_id, constants::v2_id);
-    auto adjacent_edges = sut.adjacent_edges(vertex_id);
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    directed_adj_matrix_template,
+    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::directed_t>>, // normal adj matrix
+    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::directed_t>> // flat adj matrix
+);
 
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
-    CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
-    "with the given ids in the specified direction"
-) {
-    add_edge(constants::v1_id, constants::v2_id);
-
-    CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
-    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v1_id));
-    CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
-    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "has_edge(edge_ptr) should return true if the given edge is present in the graph"
-) {
-    const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
-    CHECK(sut.has_edge(valid_edge));
-
-    const edge_type invalid_edge{gl::invalid_id, constants::v1_id, constants::v2_id};
-    CHECK_FALSE(sut.has_edge(invalid_edge));
-
-    // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
-    CHECK_FALSE(sut.has_edge(not_present_edge));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
-) {
-    CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "get_edge(id, id) should return a valid edge if the given vertices are connected"
-) {
-    const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
-
-    const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
-    REQUIRE(edge_opt.has_value());
-    CHECK_EQ(*edge_opt, edge_1);
-
-    CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix, "remove_edge should throw when an edge is invalid"
-) {
-    // not existing edge between valid vertices
-    CHECK_THROWS_AS(
-        sut.remove_edge(edge_type{next_edge_id++, constants::v1_id, constants::v2_id}),
-        std::invalid_argument
-    );
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "remove_edge should remove the edge from the source vertex's list"
-) {
-    fully_connect_vertex(constants::v1_id);
-
-    auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex);
-
-    const auto edge_to_remove = *std::ranges::begin(adjacent_edges);
-    sut.remove_edge(edge_to_remove);
-
-    // validate that the adjacent edges list has been properly aligned
-    adjacent_edges = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(
-        gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex - 1uz
-    );
-    CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix, "in_edges should return edges where the vertex is the target"
-) {
-    const auto edge1 = add_edge(constants::v2_id, constants::v1_id);
-    const auto edge2 = add_edge(constants::v3_id, constants::v1_id);
-
-    const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
-
-    REQUIRE_EQ(in_edges.size(), 2uz);
-    CHECK(std::ranges::contains(in_edges, edge1));
-    CHECK(std::ranges::contains(in_edges, edge2));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix, "out_edges should return edges where the vertex is the source"
-) {
-    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
-    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
-
-    const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
-
-    REQUIRE_EQ(out_edges.size(), 2uz);
-    CHECK(std::ranges::contains(out_edges, edge1));
-    CHECK(std::ranges::contains(out_edges, edge2));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "{in/out}_degree should return the number of edges incident {to/from} the given vertex"
-) {
-    init_complete_graph();
-
-    std::function<gl::size_type(const gl::default_id_type)> deg_proj;
-
-    SUBCASE("in_degree") {
-        deg_proj = [this](const auto vertex_id) { return sut.in_degree(vertex_id); };
-    }
-
-    SUBCASE("out_degree") {
-        deg_proj = [this](const auto vertex_id) { return sut.out_degree(vertex_id); };
-    }
-
-    CAPTURE(deg_proj);
-
-    CHECK(std::ranges::all_of(
-        constants::vertex_id_view,
-        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
-        deg_proj
-    ));
-
-    add_edge(constants::v1_id, constants::v1_id);
-
-    CHECK_EQ(deg_proj(constants::v1_id), n_incident_edges_for_fully_connected_vertex + 1uz);
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "degree should return the number of edges incident with the given vertex"
-) {
-    init_complete_graph();
-    const auto deg_proj = [this](const auto vertex_id) { return sut.degree(vertex_id); };
-
-    CHECK(std::ranges::all_of(
-        constants::vertex_id_view,
-        [](const auto deg) { return deg == 2uz * n_incident_edges_for_fully_connected_vertex; },
-        deg_proj
-    ));
-
-    add_edge(constants::v1_id, constants::v1_id);
-
-    CHECK_EQ(deg_proj(constants::v1_id), 2uz * (n_incident_edges_for_fully_connected_vertex + 1uz));
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "{in/out}_degree_map should return a map of numbers of edges incident {to/from} the "
-    "corresponding vertices"
-) {
-    init_complete_graph(false);
-    const auto expected_deg = constants::n_elements;
-
-    std::vector<gl::size_type> degree_map;
-
-    SUBCASE("in_degree") {
-        degree_map = sut.in_degree_map();
-    }
-
-    SUBCASE("out_degree") {
-        degree_map = sut.out_degree_map();
-    }
-
-    CAPTURE(degree_map);
-
-    REQUIRE_EQ(degree_map.size(), constants::n_elements);
-    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "degree_map should return a map of the numbers of edges incident with the corresponding "
-    "vertices"
-) {
-    init_complete_graph(false);
-    const auto expected_deg = constants::n_elements * 2uz;
-
-    std::vector<gl::size_type> degree_map = sut.degree_map();
-
-    REQUIRE_EQ(degree_map.size(), constants::n_elements);
-    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
-}
-
-TEST_CASE_FIXTURE(
-    test_directed_adjacency_matrix,
-    "remove_vertex should remove the given vertex and all edges incident with it"
-) {
-    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
-    const auto edge3 = add_edge(constants::v2_id, constants::v1_id);
-    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
-    const auto edge4 = add_edge(constants::v3_id, constants::v1_id);
-
-    const auto edge5 = add_edge(constants::v2_id, constants::v3_id);
-    const auto edge6 = add_edge(constants::v3_id, constants::v2_id);
-
-    const auto removed_vertex_id = constants::v1_id;
-    const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
-
-    constexpr gl::size_type n_removed_edges = 4uz;
-    REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
-    for (const auto edge_id : {edge1.id(), edge2.id(), edge3.id(), edge4.id()})
-        CHECK(std::ranges::contains(removed_edge_ids, edge_id));
-    for (const auto edge_id : {edge5.id(), edge6.id()})
-        CHECK_FALSE(std::ranges::contains(removed_edge_ids, edge_id));
-
-    // Check the structure of the graph considering the aligned IDs
-    CHECK_EQ(size(sut), constants::n_elements - 1uz);
-
-    auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
-    CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge5.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
-
-    auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
-    CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge6.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
-}
-
+template <typename SutType>
 struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
-    using edge_type = gl::undirected_edge<>;
-    using sut_type = gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>;
+    using sut_type = SutType;
+    using edge_type = typename sut_type::edge_type;
 
     edge_type add_edge(const auto source_id, const auto target_id) {
         const auto new_edge_id = this->next_edge_id++;
@@ -504,277 +499,273 @@ struct test_undirected_adjacency_matrix : public test_adjacency_matrix {
         (n_incident_edges_for_fully_connected_vertex * constants::n_elements) / 2;
 };
 
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix, "add_edge should add the edge to the lists of both vertices"
+TEST_CASE_TEMPLATE_DEFINE(
+    "undirected adjacency matrix tests", SutType, undirected_adj_matrix_template
 ) {
-    const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
-    REQUIRE(new_edge.is_incident_from(constants::v1_id));
-    REQUIRE(new_edge.is_incident_to(constants::v2_id));
+    using fixture_type = test_undirected_adjacency_matrix<SutType>;
+    using sut_type = typename fixture_type::sut_type;
+    using edge_type = typename fixture_type::edge_type;
 
-    auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-    auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+    fixture_type fixture;
+    auto& sut = fixture.sut;
 
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
+    const auto size = [&fixture](const auto& sut) { return fixture.size(sut); };
+    const auto add_edge = [&fixture](const auto source_id, const auto target_id) {
+        return fixture.add_edge(source_id, target_id);
+    };
+    const auto fully_connect_vertex = [&fixture](const auto source_id, const bool no_loops = true) {
+        fixture.fully_connect_vertex(source_id, no_loops);
+    };
+    const auto init_complete_graph = [&fixture](const bool no_loops = true) {
+        fixture.init_complete_graph(no_loops);
+    };
 
-    const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
-    CHECK_EQ(new_edge_extracted_1, new_edge);
+    SUBCASE("add_edge should add the edge to the lists of both vertices") {
+        const auto new_edge = add_edge(constants::v1_id, constants::v2_id);
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
+        REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-    const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
-    CHECK_EQ(new_edge_extracted_2, new_edge);
-}
+        auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
+        auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
 
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "add_edge should add the edge once to the vertex list if the edge is a loop"
-) {
-    const auto new_edge = add_edge(constants::v1_id, constants::v1_id);
-    REQUIRE(new_edge.is_loop());
-    REQUIRE(new_edge.is_incident_from(constants::v1_id));
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
 
-    auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
+        const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+        CHECK_EQ(new_edge_extracted_1, new_edge);
 
-    const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges);
-    CHECK_EQ(new_edge_extracted_1, new_edge);
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "at should return a view equivalent to the matrix row of the given vertex"
-) {
-    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
-    const auto edge2 = add_edge(constants::v2_id, constants::v3_id);
-    const auto edge3 = add_edge(constants::v3_id, constants::v1_id);
-
-    auto v1_row_view = sut.at(constants::v1_id);
-    REQUIRE_EQ(std::ranges::count_if(v1_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v1_row_view[constants::v2_id], edge1);
-    CHECK_EQ(v1_row_view[constants::v3_id], edge3);
-
-    auto v2_row_view = sut.at(constants::v2_id);
-    REQUIRE_EQ(std::ranges::count_if(v2_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v2_row_view[constants::v1_id], edge1);
-    CHECK_EQ(v2_row_view[constants::v3_id], edge2);
-
-    auto v3_row_view = sut.at(constants::v3_id);
-    REQUIRE_EQ(std::ranges::count_if(v3_row_view, &edge_type::is_valid), 2uz);
-    CHECK_EQ(v3_row_view[constants::v1_id], edge3);
-    CHECK_EQ(v3_row_view[constants::v2_id], edge2);
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "adjacent_edges should return a filtered view of edges adjacent with the given vertex"
-) {
-    const auto vertex_id = constants::v1_id;
-    const auto edge = add_edge(vertex_id, constants::v2_id);
-    auto adjacent_edges = sut.adjacent_edges(vertex_id);
-
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
-    CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "has_edge(id, id) should return true if there is an edge in the graph which connects vertices "
-    "with the given ids in any direction"
-) {
-    add_edge(constants::v1_id, constants::v2_id);
-
-    CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
-    CHECK(sut.has_edge(constants::v2_id, constants::v1_id));
-    CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
-    CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "has_edge(edge_ptr) should return true if the given edge is present in the graph"
-) {
-    const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
-    CHECK(sut.has_edge(valid_edge));
-
-    const edge_type invalid_edge{gl::invalid_id, constants::v1_id, constants::v2_id};
-    CHECK_FALSE(sut.has_edge(invalid_edge));
-
-    // edge connecting vertices not connected in the actual graph
-    const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
-    CHECK_FALSE(sut.has_edge(not_present_edge));
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "get_edge(id, id) should return nullopt if there is no edge connecting the given vertices"
-) {
-    CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "get_edge(id, id) should return a valid edge if the given vertices are connected"
-) {
-    const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
-
-    const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
-    REQUIRE(edge_opt_1.has_value());
-    CHECK_EQ(*edge_opt_1, edge_1);
-
-    const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
-    REQUIRE(edge_opt_2.has_value());
-    CHECK_EQ(*edge_opt_2, edge_1);
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix, "remove_edge should throw when an edge is invalid"
-) {
-    // not existing edge between valid vertices
-    CHECK_THROWS_AS(
-        sut.remove_edge(edge_type{next_edge_id++, constants::v1_id, constants::v2_id}),
-        std::invalid_argument
-    );
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "remove_edge should remove the edge from both the first and second vertices' list"
-) {
-    fully_connect_vertex(constants::v1_id);
-
-    auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(
-        gl::util::range_size(adjacent_edges_first), n_incident_edges_for_fully_connected_vertex
-    );
-
-    const auto edge_to_remove = *std::ranges::begin(adjacent_edges_first);
-
-    const auto target_id = edge_to_remove.target();
-    REQUIRE_EQ(gl::util::range_size(sut.adjacent_edges(target_id)), 1uz);
-
-    sut.remove_edge(edge_to_remove);
-
-    // validate that the first adjacent edges list has been properly aligned
-    adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
-    REQUIRE_EQ(
-        gl::util::range_size(adjacent_edges_first),
-        n_incident_edges_for_fully_connected_vertex - 1uz
-    );
-    CHECK_EQ(std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end());
-
-    // validate that the second adjacent edges list has been properly aligned
-    auto adjacent_edges_second = sut.adjacent_edges(target_id);
-    REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), 0uz);
-    CHECK_EQ(std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end());
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "in_edges and out_edges should return the same edges for undirected graphs"
-) {
-    add_edge(constants::v1_id, constants::v2_id);
-    add_edge(constants::v1_id, constants::v3_id);
-
-    const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
-    const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
-
-    CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
-    CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "{in_/out_/}degree should return the number of edges incident {to/from/with} the given vertex"
-) {
-    init_complete_graph();
-
-    std::function<gl::size_type(const gl::default_id_type)> deg_proj;
-
-    SUBCASE("degree") {
-        deg_proj = [this](const auto vertex_id) { return sut.degree(vertex_id); };
+        const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+        CHECK_EQ(new_edge_extracted_2, new_edge);
     }
 
-    SUBCASE("in_degree") {
-        deg_proj = [this](const auto vertex_id) { return sut.in_degree(vertex_id); };
+    SUBCASE("add_edge should add the edge once to the vertex list if the edge is a loop") {
+        const auto new_edge = add_edge(constants::v1_id, constants::v1_id);
+        REQUIRE(new_edge.is_loop());
+        REQUIRE(new_edge.is_incident_from(constants::v1_id));
+
+        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
+
+        const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges);
+        CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
-    SUBCASE("out_degree") {
-        deg_proj = [this](const auto vertex_id) { return sut.out_degree(vertex_id); };
+    SUBCASE("at should return a view equivalent to the matrix row of the given vertex") {
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge2 = add_edge(constants::v2_id, constants::v3_id);
+        const auto edge3 = add_edge(constants::v3_id, constants::v1_id);
+
+        auto v1_row_view = sut.at(constants::v1_id);
+        REQUIRE_EQ(std::ranges::count_if(v1_row_view, &edge_type::is_valid), 2uz);
+        CHECK_EQ(v1_row_view[constants::v2_id], edge1);
+        CHECK_EQ(v1_row_view[constants::v3_id], edge3);
+
+        auto v2_row_view = sut.at(constants::v2_id);
+        REQUIRE_EQ(std::ranges::count_if(v2_row_view, &edge_type::is_valid), 2uz);
+        CHECK_EQ(v2_row_view[constants::v1_id], edge1);
+        CHECK_EQ(v2_row_view[constants::v3_id], edge2);
+
+        auto v3_row_view = sut.at(constants::v3_id);
+        REQUIRE_EQ(std::ranges::count_if(v3_row_view, &edge_type::is_valid), 2uz);
+        CHECK_EQ(v3_row_view[constants::v1_id], edge3);
+        CHECK_EQ(v3_row_view[constants::v2_id], edge2);
     }
 
-    CAPTURE(deg_proj);
+    SUBCASE("adjacent_edges should return a filtered view of edges adjacent with the given vertex"
+    ) {
+        const auto vertex_id = constants::v1_id;
+        const auto edge = add_edge(vertex_id, constants::v2_id);
+        auto adjacent_edges = sut.adjacent_edges(vertex_id);
 
-    CHECK(std::ranges::all_of(
-        constants::vertex_id_view,
-        [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
-        deg_proj
-    ));
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
+    }
 
-    add_edge(constants::v1_id, constants::v1_id);
+    SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
+            "vertices with the given ids in any direction") {
+        add_edge(constants::v1_id, constants::v2_id);
 
-    CHECK_EQ(
-        deg_proj(constants::v1_id),
-        n_incident_edges_for_fully_connected_vertex + 2uz // loops counted twice
-    );
+        CHECK(sut.has_edge(constants::v1_id, constants::v2_id));
+        CHECK(sut.has_edge(constants::v2_id, constants::v1_id));
+        CHECK_FALSE(sut.has_edge(constants::v1_id, constants::v3_id));
+        CHECK_FALSE(sut.has_edge(constants::v2_id, constants::v3_id));
+    }
+
+    SUBCASE("has_edge(edge_ptr) should return true if the given edge is present in the graph") {
+        const auto valid_edge = add_edge(constants::v1_id, constants::v2_id);
+        CHECK(sut.has_edge(valid_edge));
+
+        const edge_type invalid_edge{gl::invalid_id, constants::v1_id, constants::v2_id};
+        CHECK_FALSE(sut.has_edge(invalid_edge));
+
+        // edge connecting vertices not connected in the actual graph
+        const edge_type not_present_edge{valid_edge.id(), constants::v2_id, constants::v3_id};
+        CHECK_FALSE(sut.has_edge(not_present_edge));
+    }
+
+    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+            "vertices") {
+        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+    }
+
+    SUBCASE("get_edge(id, id) should return a valid edge if the given vertices are connected") {
+        const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
+
+        const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
+        REQUIRE(edge_opt_1.has_value());
+        CHECK_EQ(*edge_opt_1, edge_1);
+
+        const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
+        REQUIRE(edge_opt_2.has_value());
+        CHECK_EQ(*edge_opt_2, edge_1);
+    }
+
+    SUBCASE("remove_edge should throw when an edge is invalid") {
+        // not existing edge between valid vertices
+        CHECK_THROWS_AS(
+            sut.remove_edge(edge_type{fixture.next_edge_id++, constants::v1_id, constants::v2_id}),
+            std::invalid_argument
+        );
+    }
+
+    SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
+        fully_connect_vertex(constants::v1_id);
+
+        auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
+        REQUIRE_EQ(
+            gl::util::range_size(adjacent_edges_first), n_incident_edges_for_fully_connected_vertex
+        );
+
+        const auto edge_to_remove = *std::ranges::begin(adjacent_edges_first);
+
+        const auto target_id = edge_to_remove.target();
+        REQUIRE_EQ(gl::util::range_size(sut.adjacent_edges(target_id)), 1uz);
+
+        sut.remove_edge(edge_to_remove);
+
+        // validate that the first adjacent edges list has been properly aligned
+        adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
+        REQUIRE_EQ(
+            gl::util::range_size(adjacent_edges_first),
+            n_incident_edges_for_fully_connected_vertex - 1uz
+        );
+        CHECK_EQ(
+            std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end()
+        );
+
+        // validate that the second adjacent edges list has been properly aligned
+        auto adjacent_edges_second = sut.adjacent_edges(target_id);
+        REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), 0uz);
+        CHECK_EQ(
+            std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end()
+        );
+    }
+
+    SUBCASE("in_edges and out_edges should return the same edges for undirected graphs") {
+        add_edge(constants::v1_id, constants::v2_id);
+        add_edge(constants::v1_id, constants::v3_id);
+
+        const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
+        const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
+
+        CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
+    }
+
+    SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from/with} the given "
+            "vertex") {
+        init_complete_graph();
+
+        std::function<gl::size_type(const gl::default_id_type)> deg_proj;
+
+        SUBCASE("degree") {
+            deg_proj = [&sut](const auto vertex_id) { return sut.degree(vertex_id); };
+        }
+
+        SUBCASE("in_degree") {
+            deg_proj = [&sut](const auto vertex_id) { return sut.in_degree(vertex_id); };
+        }
+
+        SUBCASE("out_degree") {
+            deg_proj = [&sut](const auto vertex_id) { return sut.out_degree(vertex_id); };
+        }
+
+        CAPTURE(deg_proj);
+
+        CHECK(std::ranges::all_of(
+            constants::vertex_id_view,
+            [](const auto deg) { return deg == n_incident_edges_for_fully_connected_vertex; },
+            deg_proj
+        ));
+
+        add_edge(constants::v1_id, constants::v1_id);
+
+        CHECK_EQ(
+            deg_proj(constants::v1_id),
+            n_incident_edges_for_fully_connected_vertex + 2uz // loops counted twice
+        );
+    }
+
+    SUBCASE("{in_/out_/}degree_map should return a map of numbers of edges incident {to/from/with} "
+            "the "
+            "corresponding vertices") {
+        init_complete_graph(false);
+        const auto expected_deg = constants::n_elements + 1;
+
+        std::vector<gl::size_type> degree_map;
+
+        SUBCASE("in_degree") {
+            degree_map = sut.in_degree_map();
+        }
+
+        SUBCASE("out_degree") {
+            degree_map = sut.out_degree_map();
+        }
+
+        SUBCASE("degree") {
+            degree_map = sut.degree_map();
+        }
+
+        CAPTURE(degree_map);
+
+        REQUIRE_EQ(degree_map.size(), constants::n_elements);
+        CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
+    }
+
+    SUBCASE("remove_vertex should remove the given vertex and all edges incident with it") {
+        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
+        const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
+        const auto edge3 = add_edge(constants::v2_id, constants::v3_id);
+
+        const auto removed_vertex_id = 0uz;
+        const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
+
+        constexpr gl::size_type n_removed_edges = 2uz;
+        REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
+        for (const auto edge_id : {edge1.id(), edge2.id()})
+            CHECK(std::ranges::contains(removed_edge_ids, edge_id));
+        CHECK_FALSE(std::ranges::contains(removed_edge_ids, edge3.id()));
+
+        // Check the structure of the graph considering the aligned IDs
+        CHECK_EQ(size(sut), constants::n_elements - 1uz);
+
+        auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
+        CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge3.id() - n_removed_edges);
+        CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
+
+        auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
+        CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge3.id() - n_removed_edges);
+        CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
+    }
 }
 
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "{in_/out_/}degree_map should return a map of numbers of edges incident {to/from/with} the "
-    "corresponding vertices"
-) {
-    init_complete_graph(false);
-    const auto expected_deg = constants::n_elements + 1;
-
-    std::vector<gl::size_type> degree_map;
-
-    SUBCASE("in_degree") {
-        degree_map = sut.in_degree_map();
-    }
-
-    SUBCASE("out_degree") {
-        degree_map = sut.out_degree_map();
-    }
-
-    SUBCASE("degree") {
-        degree_map = sut.degree_map();
-    }
-
-    CAPTURE(degree_map);
-
-    REQUIRE_EQ(degree_map.size(), constants::n_elements);
-    CHECK_EQ(std::ranges::count(degree_map, expected_deg), constants::n_elements);
-}
-
-TEST_CASE_FIXTURE(
-    test_undirected_adjacency_matrix,
-    "remove_vertex should remove the given vertex and all edges incident with it"
-) {
-    const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
-    const auto edge2 = add_edge(constants::v1_id, constants::v3_id);
-    const auto edge3 = add_edge(constants::v2_id, constants::v3_id);
-
-    const auto removed_vertex_id = 0uz;
-    const auto removed_edge_ids = sut.remove_vertex(removed_vertex_id);
-
-    constexpr gl::size_type n_removed_edges = 2uz;
-    REQUIRE_EQ(removed_edge_ids.size(), n_removed_edges);
-    for (const auto edge_id : {edge1.id(), edge2.id()})
-        CHECK(std::ranges::contains(removed_edge_ids, edge_id));
-    CHECK_FALSE(std::ranges::contains(removed_edge_ids, edge3.id()));
-
-    // Check the structure of the graph considering the aligned IDs
-    CHECK_EQ(size(sut), constants::n_elements - 1uz);
-
-    auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
-    CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge3.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
-
-    auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
-    CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge3.id() - n_removed_edges);
-    CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
-}
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    undirected_adj_matrix_template,
+    gl::impl::adjacency_matrix<gl::matrix_graph_traits<gl::undirected_t>>, // normal adj matrix
+    gl::impl::adjacency_matrix<gl::flat_matrix_graph_traits<gl::undirected_t>> // flat adj matrix
+);
 
 TEST_SUITE_END(); // test_adjacency_matrix
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -403,8 +403,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
     }
 
     SUBCASE("degree_map should return a map of the numbers of edges incident with the "
-            "corresponding "
-            "vertices") {
+            "corresponding vertices") {
         init_complete_graph(false);
         const auto expected_deg = constants::n_elements * 2uz;
 

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -97,7 +97,13 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        visited_property>> // undirected adjacency matrix
+        visited_property>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        visited_property>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        visited_property>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -158,7 +164,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -185,7 +193,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 TEST_SUITE_END(); // test_alg_bfs

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -175,7 +175,13 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         gl::binary_color_property>, // directed adjacency matrix graph
     gl::matrix_graph_traits<
         gl::undirected_t,
-        gl::binary_color_property> // undirected adjacency matrix graph
+        gl::binary_color_property>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        gl::binary_color_property>, // directed flat adjacency matrix graph
+    gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        gl::binary_color_property> // undirected flat adjacency matrix graph
 );
 
 TEST_SUITE_END(); // test_alg_coloring

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -104,7 +104,13 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        visited_property>> // undirected adjacency matrix
+        visited_property>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        visited_property>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        visited_property>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -165,7 +171,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -190,7 +198,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 // --- recursive dfs tests ---
@@ -292,7 +302,13 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         visited_property>>, // directed adjacency matrix
     gl::graph<gl::matrix_graph_traits<
         gl::undirected_t,
-        visited_property>> // undirected adjacency matrix
+        visited_property>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        visited_property>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        visited_property>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -358,7 +374,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -384,7 +402,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adjacency matrix
 );
 
 TEST_SUITE_END(); // test_alg_dfs

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -134,7 +134,15 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::matrix_graph_traits<
         gl::undirected_t,
         gl::empty_properties,
-        gl::weight_property<>> // undirected adjacency matrix graph
+        gl::weight_property<>>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        gl::empty_properties,
+        gl::weight_property<>>, // directed flat adjacency matrix graph
+    gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        gl::empty_properties,
+        gl::weight_property<>> // undirected flat adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -203,7 +211,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::flat_list_graph_traits<gl::directed_t>, // directed flat adjacency list graph
     gl::flat_list_graph_traits<gl::undirected_t>, // undirected flat adjacency list graph
     gl::matrix_graph_traits<gl::directed_t>, // directed adjacency matrix graph
-    gl::matrix_graph_traits<gl::undirected_t> // undirected adjacency matrix graph
+    gl::matrix_graph_traits<gl::undirected_t>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::directed_t>, // directed flat adjacency matrix
+    gl::flat_matrix_graph_traits<gl::undirected_t> // undirected flat adjacency matrix
 );
 
 TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -1,3 +1,4 @@
+#include "gl/impl/impl_tags.hpp"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 #include "testing/gl/functional.hpp"
@@ -103,7 +104,11 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::undirected_graph_traits<
         gl::empty_properties,
         gl::weight_property<>,
-        gl::impl::matrix_t> // undirected adjacency matrix graph
+        gl::impl::matrix_t>, // undirected adjacency matrix graph,
+    gl::undirected_graph_traits<
+        gl::empty_properties,
+        gl::weight_property<>,
+        gl::impl::flat_matrix_t> // undirected flat adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -151,7 +156,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     edge_heap_prim_unwieghted_edge_traits_type_template,
     gl::list_graph_traits<gl::undirected_t>, // undirected adjacency list graph
     gl::flat_list_graph_traits<gl::undirected_t>, // undirected flat adjacency list graph
-    gl::matrix_graph_traits<gl::undirected_t> // undirected adjacency matrix graph
+    gl::matrix_graph_traits<gl::undirected_t>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::undirected_t> // undirected flat adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -243,7 +249,11 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::undirected_graph_traits<
         gl::empty_properties,
         gl::weight_property<>,
-        gl::impl::matrix_t> // undirected adjacency matrix graph
+        gl::impl::matrix_t>, // undirected adjacency matrix graph
+    gl::undirected_graph_traits<
+        gl::empty_properties,
+        gl::weight_property<>,
+        gl::impl::flat_matrix_t> // undirected flat adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -291,7 +301,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     vertex_heap_prim_unwieghted_edge_traits_type_template,
     gl::list_graph_traits<gl::undirected_t>, // undirected adjacency list graph
     gl::flat_list_graph_traits<gl::undirected_t>, // undirected flat adjacency list graph
-    gl::matrix_graph_traits<gl::undirected_t> // undirected adjacency matrix graph
+    gl::matrix_graph_traits<gl::undirected_t>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::undirected_t> // undirected flat adjacency matrix graph
 );
 
 TEST_SUITE_END(); // test_alg_mst

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -96,7 +96,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     directed_traits_type_template,
     gl::list_graph_traits<gl::directed_t>, // adjacency list graph
     gl::flat_list_graph_traits<gl::directed_t>, // flat adjacency list graph
-    gl::matrix_graph_traits<gl::directed_t> // adjacency matrix graph
+    gl::matrix_graph_traits<gl::directed_t>, // adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::directed_t> // flat adjacency matrix graph
 );
 
 TEST_SUITE_END(); // test_alg_topological_sort

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -92,6 +92,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using list_graph = gl::graph<gl::list_graph_traits<DT, VP, EP>>;
     using flat_list_graph = gl::graph<gl::flat_list_graph_traits<DT, VP, EP>>;
     using matrix_graph = gl::graph<gl::matrix_graph_traits<DT, VP, EP>>;
+    using flat_matrix_graph = gl::graph<gl::flat_matrix_graph_traits<DT, VP, EP>>;
 
     test_conversion fixture;
 
@@ -113,12 +114,18 @@ TEST_CASE_TEMPLATE_DEFINE(
                     auto dst = gl::to<gl::impl::matrix_t>(std::move(src));
                     fixture.validate_graph(dst);
                 }
+                SUBCASE("to flat-matrix") {
+                    auto src = fixture.create_test_graph<Source>();
+                    auto dst = gl::to<gl::impl::flat_matrix_t>(std::move(src));
+                    fixture.validate_graph(dst);
+                }
             }
         };
 
     test_conversion_for(std::type_identity<list_graph>{}, "source: list");
     test_conversion_for(std::type_identity<flat_list_graph>{}, "source: flat-list");
     test_conversion_for(std::type_identity<matrix_graph>{}, "source: matrix");
+    test_conversion_for(std::type_identity<flat_matrix_graph>{}, "source: matrix");
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -125,7 +125,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     test_conversion_for(std::type_identity<list_graph>{}, "source: list");
     test_conversion_for(std::type_identity<flat_list_graph>{}, "source: flat-list");
     test_conversion_for(std::type_identity<matrix_graph>{}, "source: matrix");
-    test_conversion_for(std::type_identity<flat_matrix_graph>{}, "source: matrix");
+    test_conversion_for(std::type_identity<flat_matrix_graph>{}, "source: flat-matrix");
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -898,7 +898,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::flat_list_graph_traits<gl::directed_t>, // directed flat adjacency list
     gl::flat_list_graph_traits<gl::undirected_t>, // undirected flat adjacency list
     gl::matrix_graph_traits<gl::directed_t>, // directed adjacency matrix
-    gl::matrix_graph_traits<gl::undirected_t> // undirected adjacency matrix
+    gl::matrix_graph_traits<gl::undirected_t>, // undirected adjacency matrix
+    gl::matrix_graph_traits<gl::directed_t>, // directed adj matrix
+    gl::matrix_graph_traits<gl::undirected_t> // undirected adj matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE("properties getter tests", TraitsType, property_graph_traits_template) {
@@ -961,7 +963,15 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::matrix_graph_traits<
         gl::undirected_t,
         gl::name_property,
-        gl::name_property> // undirected adjacency matrix
+        gl::name_property>, // undirected adjacency matrix
+    gl::flat_matrix_graph_traits<
+        gl::directed_t,
+        gl::name_property,
+        gl::name_property>, // directed flat adjacency matrix
+    gl::flat_matrix_graph_traits<
+        gl::undirected_t,
+        gl::name_property,
+        gl::name_property> // undirected flat adjacency matrix
 );
 
 TEST_SUITE_END(); // test_graph

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -126,7 +126,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adj list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adj list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adj matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adj matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adj matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj matrix
 );
 
 TEST_SUITE_END(); // test_graph_file_io

--- a/tests/source/gl/test_graph_incidence.cpp
+++ b/tests/source/gl/test_graph_incidence.cpp
@@ -160,7 +160,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adj list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adj list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adj matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adj matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adj matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj matrix
 );
 
 TEST_SUITE_END(); // test_graph_incidence

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -246,7 +246,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // directed flat adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // undirected flat adjacency list
     gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // directed adjacency matrix
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // undirected adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // undirected adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>>, // directed flat adj matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // undirected flat adj matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -338,7 +340,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     directed_graph_type_template,
     gl::graph<gl::list_graph_traits<gl::directed_t>>, // adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::directed_t>>, // flat adjacency list
-    gl::graph<gl::matrix_graph_traits<gl::directed_t>> // adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::directed_t>>, // adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::directed_t>> // flat adj matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -424,7 +427,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     undirected_graph_type_template,
     gl::graph<gl::list_graph_traits<gl::undirected_t>>, // adjacency list
     gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>, // flat adjacency list
-    gl::graph<gl::matrix_graph_traits<gl::undirected_t>> // adjacency matrix
+    gl::graph<gl::matrix_graph_traits<gl::undirected_t>>, // adjacency matrix
+    gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>> // flat adj matrix
 );
 
 TEST_SUITE_END(); // test_graph_topology_builders

--- a/tests/source/gl/test_vertex_degree_getters.cpp
+++ b/tests/source/gl/test_vertex_degree_getters.cpp
@@ -97,7 +97,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     directed_graph_traits_template,
     gl::list_graph_traits<gl::directed_t>, // directed adjacency list graph
     gl::flat_list_graph_traits<gl::directed_t>, // directed flat adjacency list graph
-    gl::matrix_graph_traits<gl::directed_t> // directed adjacency matrix graph
+    gl::matrix_graph_traits<gl::directed_t>, // directed adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::directed_t> // directed flat adjacency matrix graph
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
@@ -170,7 +171,8 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
     undirected_graph_traits_template,
     gl::list_graph_traits<gl::undirected_t>, // undirected adjacency list graph
     gl::flat_list_graph_traits<gl::undirected_t>, // undirected flat adjacency list graph
-    gl::matrix_graph_traits<gl::undirected_t> // undirected adjacency matrix graph
+    gl::matrix_graph_traits<gl::undirected_t>, // undirected adjacency matrix graph
+    gl::flat_matrix_graph_traits<gl::undirected_t> // undirected flat adjacency matrix graph
 );
 
 TEST_SUITE_END(); // test_vertex_degree_getters

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -280,6 +280,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     using list_graph = gl::graph<gl::list_graph_traits<gl::undirected_t>>;
     using flat_list_graph = gl::graph<gl::flat_list_graph_traits<gl::undirected_t>>;
     using matrix_graph = gl::graph<gl::matrix_graph_traits<gl::undirected_t>>;
+    using flat_matrix_graph = gl::graph<gl::flat_matrix_graph_traits<gl::undirected_t>>;
 
     SUBCASE("projection should produce a clique for each hyperedge") {
         sut_type sut{4ull, 4ull};
@@ -327,6 +328,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         test_conversion_for(std::type_identity<list_graph>{}, "target model: list");
         test_conversion_for(std::type_identity<flat_list_graph>{}, "target model: flat-list");
         test_conversion_for(std::type_identity<matrix_graph>{}, "target model: matrix");
+        test_conversion_for(std::type_identity<flat_matrix_graph>{}, "target model: flat-matrix");
     }
 
     SUBCASE("incidence_graph should produce a bipartite graph connecting vertices to hyperedges") {
@@ -380,6 +382,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         test_conversion_for(std::type_identity<list_graph>{}, "target model: list");
         test_conversion_for(std::type_identity<flat_list_graph>{}, "target model: flat list");
         test_conversion_for(std::type_identity<matrix_graph>{}, "target model: matrix");
+        test_conversion_for(std::type_identity<flat_matrix_graph>{}, "target model: flat-matrix");
     }
 }
 
@@ -425,6 +428,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::flat_list_t>>;
     using matrix_graph = gl::graph<
         gl::directed_graph_traits<gl::empty_properties, gl::empty_properties, gl::impl::matrix_t>>;
+    using flat_matrix_graph = gl::graph<gl::directed_graph_traits<
+        gl::empty_properties,
+        gl::empty_properties,
+        gl::impl::flat_matrix_t>>;
 
     SUBCASE("projection should produce directed edges from tails to heads for each hyperedge") {
         sut_type sut{4ull, 2uz};
@@ -465,6 +472,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         test_conversion_for(std::type_identity<list_graph>{}, "target model: list");
         test_conversion_for(std::type_identity<flat_list_graph>{}, "target model: flat list");
         test_conversion_for(std::type_identity<matrix_graph>{}, "target model: matrix");
+        test_conversion_for(std::type_identity<flat_matrix_graph>{}, "target model: flat-matrix");
     }
 
     SUBCASE("incidence_graph should produce a directed bipartite graph connecting tails to "
@@ -510,6 +518,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         test_conversion_for(std::type_identity<list_graph>{}, "target model: list");
         test_conversion_for(std::type_identity<flat_list_graph>{}, "target model: flat list");
         test_conversion_for(std::type_identity<matrix_graph>{}, "target model: matrix");
+        test_conversion_for(std::type_identity<flat_matrix_graph>{}, "target model: flat-matrix");
     }
 }
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,3 @@
+1. matrix <-> flat matrix conversions specializations
+2. Extend conversion template tests
+3. Extend hgl -> gl conversion tests

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,4 @@
 1. matrix <-> flat matrix conversions specializations
 2. Extend conversion template tests
 3. Extend hgl -> gl conversion tests
+4. Extend common graph/io/algorithm/topology tests

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,0 @@
-1. matrix <-> flat matrix conversions specializations
-2. Extend conversion template tests
-3. Extend hgl -> gl conversion tests
-4. Extend common graph/io/algorithm/topology tests


### PR DESCRIPTION
- Defined a new graph implementation tag: `flat_matrix_t`
- Aligned the implementation-tag-related constraints and generic type aliases
- Created a new internal implementation class: `flat_adjacency_matrix`
- Aligned the existing adjacency matrix implementation classes to properly utilize the new flat model class
- Implemented `to_impl` conversion type specializations for matrix - flat-matrix model conversions