### PR TITLE
NONE: Prepare the library benchmarking subproject layout (v1)

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,47 @@
+CompileFlags:
+  CompilationDatabase: build
+  Add:
+    - -std=c++23
+    - -xc++-header
+    - -Iinclude
+    - -Wall
+    - -Wextra
+    - -Wcast-align
+    - -Wconversion
+    - -Wsign-conversion
+    - -Wunreachable-code
+    - -Wuninitialized
+    - -Wunused
+    - -pedantic
+    - -ftemplate-depth=512
+
+Diagnostics:
+  UnusedIncludes: None
+  ClangTidy:
+    Add:
+      - bugprone-*
+      - modernize-*
+      - performance-*
+    Remove:
+      - modernize-use-trailing-return-type
+
+Index:
+  Background: Build
+
+---
+
+If:
+  PathMatch: tests/.*
+CompileFlags:
+  Add:
+    - -Itests/include
+    - -Itests/external
+
+---
+
+If:
+  PathMatch: benchmarks/.*
+CompileFlags:
+  CompilationDatabase: build_bench
+  Add:
+    - -Ibenchmarks/include

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,45 @@
+name: benchmarks
+on:
+  push:
+    branches:
+      - "*"
+    paths:
+      - .github/workflows/benchmarks.yaml
+      - CMakeLists.txt
+      - cmake/
+      - include/**
+      - benchmarks/**
+
+jobs:
+  build:
+    name: Build and run benchmarks
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies (Boost)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-graph-dev
+
+      - name: Prepare
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: |
+          cmake -B build_bench \
+            -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+        continue-on-error: false
+
+      - name: Build the benchmarks
+        run: |
+          cmake --build build_bench/ -j$(nproc)
+        continue-on-error: false
+
+      - name: Execute the smoke test
+        run: |
+          ./build_bench/benchmarks/gl_benchmarks \
+            --benchmark_repetitions=1 --benchmark_display_aggregates_only=true \
+            --bip-v 100

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -19,11 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Dependencies (Boost)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libboost-graph-dev
-
       - name: Prepare
         env:
           CC: gcc-13

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -5,6 +5,8 @@ on:
       - '*'
     paths:
       - .github/workflows/clang.yaml
+      - CMakeLists.txt
+      - cmake/
       - include/**
       - tests/**
 
@@ -22,7 +24,7 @@ jobs:
           CC:  clang-17
           CXX: clang++-17
         run: |
-          cmake -B build -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+          cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
       - name: Build test executable

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -5,11 +5,13 @@ on:
       - '*'
     paths:
       - .github/workflows/format.yaml
+      - scripts/common.py
       - scripts/format.py
       - include/**
       - tests/include/**
       - tests/source/**
       - tests/app/**
+      - benchmarks/**
 
 
 jobs:

--- a/.github/workflows/gpp.yaml
+++ b/.github/workflows/gpp.yaml
@@ -5,6 +5,8 @@ on:
       - '*'
     paths:
       - .github/workflows/gpp.yaml
+      - CMakeLists.txt
+      - cmake/
       - include/**
       - tests/**
 
@@ -23,7 +25,7 @@ jobs:
           CC:  gcc-13
           CXX: g++-13
         run: |
-          cmake -B build -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+          cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
       - name: Build test executable

--- a/.github/workflows/licence.yaml
+++ b/.github/workflows/licence.yaml
@@ -5,6 +5,7 @@ on:
       - '*'
     paths:
       - .github/workflows/licence.yaml
+      - scripts/common.py
       - scripts/check_licence.py
       - include/**
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,17 @@ project(cpp-gl
     LANGUAGES CXX
 )
 
-option(BUILD_TESTS "Build project tests" ON)
+set(MIN_CXX_STANDARD 20)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+option(BUILD_TESTS "Build project tests" OFF)
+option(BUILD_BENCHMARKS "Build project benchmarks" OFF)
 
 # Set the proper cxx standard
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 20)
-elseif(CMAKE_CXX_STANDARD LESS 20)
+    set(CMAKE_CXX_STANDARD ${MIN_CXX_STANDARD})
+elseif(CMAKE_CXX_STANDARD LESS ${MIN_CXX_STANDARD})
     message(WARNING "The defined C++ standard (${CMAKE_CXX_STANDARD}) is too low - overriding!")
-    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD ${MIN_CXX_STANDARD})
 endif()
 message(STATUS "The C++ standard is set to ${CMAKE_CXX_STANDARD}")
 
@@ -83,4 +86,9 @@ export(PACKAGE cpp-gl)
 # Include test directory if cpp-gl is a top level project
 if (CPP_GL_IS_TOP_LEVEL_PROJECT AND BUILD_TESTS)
     add_subdirectory(tests)
+endif()
+
+# Include test directory if cpp-gl is a top level project
+if (CPP_GL_IS_TOP_LEVEL_PROJECT AND BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -28,9 +28,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cpp-argon)
 
-# Find Boost for BGL comparisons
-find_package(Boost CONFIG REQUIRED)
-
 add_executable(gl_benchmarks
     source/main.cpp
     source/runner.cpp
@@ -38,12 +35,10 @@ add_executable(gl_benchmarks
 )
 
 target_compile_options(gl_benchmarks PRIVATE
-    -Werror
     -Wall
     -Wextra
     -Wcast-align
     -Wconversion
-    -Wsign-conversion
     -Wunreachable-code
     -Wuninitialized
     -Wunused
@@ -56,7 +51,6 @@ target_link_libraries(gl_benchmarks PRIVATE
     benchmark::benchmark
     cpp-argon
     cpp-gl
-    Boost::headers
 )
 
 if(BENCH_GL_DEFS)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.14)
+project(gl_benchmarks LANGUAGES CXX)
+
+include(FetchContent)
+
+# Build options
+set(BENCH_GL_DEFS "" CACHE STRING "Additional compile definitions for the CPP-GL target")
+set(BENCH_OPT_MODE "3" CACHE STRING "The optimisation mode used to build the project benchmarks (default: 3)")
+
+message(STATUS "Build options:")
+message(STATUS "[BENCH_GL_DEFS = ${BENCH_GL_DEFS}]")
+message(STATUS "[BENCH_OPT_MODE = ${BENCH_OPT_MODE}]")
+
+# Fetch Google Benchmark
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.8.3
+)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark tests" FORCE)
+FetchContent_MakeAvailable(googlebenchmark)
+
+# Fetch CPP-ARGON
+FetchContent_Declare(
+    cpp-argon
+    GIT_REPOSITORY https://github.com/SpectraL519/cpp-argon.git
+    GIT_TAG v4.0.0
+)
+FetchContent_MakeAvailable(cpp-argon)
+
+# Find Boost for BGL comparisons
+find_package(Boost CONFIG REQUIRED)
+
+add_executable(gl_benchmarks
+    source/main.cpp
+    source/runner.cpp
+    suites/is_bipartite.cpp
+)
+
+target_compile_options(gl_benchmarks PRIVATE
+    -Werror
+    -Wall
+    -Wextra
+    -Wcast-align
+    -Wconversion
+    -Wsign-conversion
+    -Wunreachable-code
+    -Wuninitialized
+    -Wunused
+    -pedantic
+    -O${BENCH_OPT_MODE}
+)
+
+target_include_directories(gl_benchmarks PRIVATE include)
+target_link_libraries(gl_benchmarks PRIVATE
+    benchmark::benchmark
+    cpp-argon
+    cpp-gl
+    Boost::headers
+)
+
+if(BENCH_GL_DEFS)
+    separate_arguments(BENCH_GL_DEFS_LIST NATIVE_COMMAND "${BENCH_GL_DEFS}")
+    target_compile_definitions(gl_benchmarks PRIVATE ${BENCH_GL_DEFS_LIST})
+endif()

--- a/benchmarks/include/runner.hpp
+++ b/benchmarks/include/runner.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "suite.hpp"
+
+#include <argon/argument_parser.hpp>
+#include <benchmark/benchmark.h>
+
+#include <vector>
+
+namespace gl_bench {
+
+class runner {
+public:
+    runner();
+
+    void add_suite(suite suite);
+    int run(int argc, char** argv);
+
+private:
+    argon::argument_parser _parser;
+    std::vector<suite> _suites;
+};
+
+} // namespace gl_bench

--- a/benchmarks/include/suite.hpp
+++ b/benchmarks/include/suite.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <argon/argument_parser.hpp>
+
+namespace gl_bench {
+
+struct suite {
+    void (*add_args)(argon::argument_parser& parser);
+    void (*register_benchmarks)(const argon::argument_parser& parser);
+};
+
+} // namespace gl_bench

--- a/benchmarks/source/main.cpp
+++ b/benchmarks/source/main.cpp
@@ -1,0 +1,11 @@
+#include "runner.hpp"
+
+namespace gl_bench::is_bipartite {
+extern suite get_suite();
+} // namespace gl_bench::is_bipartite
+
+int main(int argc, char** argv) {
+    gl_bench::runner runner;
+    runner.add_suite(gl_bench::is_bipartite::get_suite());
+    return runner.run(argc, argv);
+}

--- a/benchmarks/source/runner.cpp
+++ b/benchmarks/source/runner.cpp
@@ -1,0 +1,69 @@
+#include "runner.hpp"
+
+#include <filesystem>
+#include <format>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+namespace gl_bench {
+
+runner::runner() : _parser("gl_benchmarks") {
+    auto& glob_args = this->_parser.add_group("Global Benchmark Options");
+    this->_parser.add_optional_argument<argon::none_type>(glob_args, "help", "h")
+        .help("Display the help message")
+        .action<argon::action_type::on_flag>(argon::action::print_help(this->_parser, 0));
+    this->_parser.add_optional_argument<argon::none_type>(glob_args, "gbench-help")
+        .help("Display the Google Benchmar help message")
+        .action<argon::action_type::on_flag>([]() {
+            benchmark::PrintDefaultHelp();
+            std::exit(0);
+        });
+    this->_parser.add_optional_argument<fs::path>(glob_args, "output", "o")
+        .help("Path to the output JSON file")
+        .nargs(argon::nargs::up_to(static_cast<std::size_t>(1)))
+        .action<argon::action_type::observe>([](const fs::path& path) {
+            if (not fs::is_regular_file(path) or path.extension() != ".json")
+                throw std::runtime_error(std::format(
+                    "Invlid output file path (must be a .json file, got: {})", path.string()
+                ));
+        });
+}
+
+void runner::add_suite(suite suite) {
+    this->_suites.push_back(suite);
+    if (suite.add_args)
+        suite.add_args(this->_parser);
+}
+
+int runner::run(int argc, char** argv) {
+    std::vector<std::string> gbench_args = this->_parser.try_parse_known_args(argc, argv);
+
+    // Register benchmark suites
+    for (const auto& suite : this->_suites)
+        if (suite.register_benchmarks)
+            suite.register_benchmarks(this->_parser);
+
+    // Handle JSON export if requested
+    if (this->_parser.has_value("output")) {
+        auto out_path = this->_parser.value<fs::path>("output");
+        gbench_args.push_back("--benchmark_out=" + out_path.string());
+        gbench_args.push_back("--benchmark_out_format=json");
+    }
+
+    // Reconstruct argv for Google Benchmark
+    std::vector<char*> gbench_argv;
+    gbench_argv.push_back(argv[0]);
+    for (auto& arg : gbench_args)
+        gbench_argv.push_back(arg.data());
+
+    int gbench_argc = static_cast<int>(gbench_argv.size());
+
+    benchmark::Initialize(&gbench_argc, gbench_argv.data());
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+
+    return 0;
+}
+
+} // namespace gl_bench

--- a/benchmarks/source/runner.cpp
+++ b/benchmarks/source/runner.cpp
@@ -23,10 +23,17 @@ runner::runner() : _parser("gl_benchmarks") {
         .help("Path to the output JSON file")
         .nargs(argon::nargs::up_to(static_cast<std::size_t>(1)))
         .action<argon::action_type::observe>([](const fs::path& path) {
-            if (not fs::is_regular_file(path) or path.extension() != ".json")
+            if (path.extension() != ".json") {
                 throw std::runtime_error(std::format(
-                    "Invlid output file path (must be a .json file, got: {})", path.string()
+                    "Invalid output file path (must be a .json file, got: {})", path.string()
                 ));
+            }
+
+            if (path.has_parent_path() and not fs::exists(path.parent_path())) {
+                throw std::runtime_error(
+                    std::format("Output directory does not exist: {}", path.parent_path().string())
+                );
+            }
         });
 }
 

--- a/benchmarks/suites/is_bipartite.cpp
+++ b/benchmarks/suites/is_bipartite.cpp
@@ -6,9 +6,6 @@
 #include <gl/topologies.hpp>
 
 #include <benchmark/benchmark.h>
-#include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/adjacency_matrix.hpp>
-#include <boost/graph/bipartite.hpp>
 
 namespace gl_bench::is_bipartite {
 
@@ -26,38 +23,6 @@ void bm_gl_is_bipartite(benchmark::State& state) {
 
     state.counters["Vertices"] = static_cast<double>(graph.n_vertices());
     state.counters["Edges"] = static_cast<double>(graph.n_unique_edges());
-}
-
-// BGL Benchmark
-
-template <typename GraphType>
-GraphType gen_bgl_biclique(const std::size_t n_vertices_a, const std::size_t n_vertices_b) {
-    using directed_category = typename boost::graph_traits<GraphType>::directed_category;
-    const auto n_vertices = n_vertices_a + n_vertices_b;
-    GraphType graph{n_vertices};
-
-    for (std::size_t source_id = 0ull; source_id < n_vertices_a; ++source_id) {
-        for (std::size_t target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
-            boost::add_edge(source_id, target_id, graph);
-            if constexpr (std::is_same_v<directed_category, boost::directed_tag>)
-                boost::add_edge(target_id, source_id, graph);
-        }
-    }
-    return graph;
-}
-
-template <typename GraphType>
-void bm_bgl_is_bipartite(benchmark::State& state) {
-    const auto n_vertices = static_cast<std::size_t>(state.range(0));
-    auto graph = gen_bgl_biclique<GraphType>(n_vertices, n_vertices);
-
-    for (auto _ : state) {
-        bool is_bip = boost::is_bipartite(graph);
-        benchmark::DoNotOptimize(is_bip);
-    }
-
-    state.counters["Vertices"] = static_cast<double>(boost::num_vertices(graph));
-    state.counters["Edges"] = static_cast<double>(boost::num_edges(graph));
 }
 
 void add_args(argon::argument_parser& parser) {
@@ -78,18 +43,6 @@ void register_benchmarks(const argon::argument_parser& parser) {
         ->Arg(n_vertices)
         ->Unit(benchmark::kMillisecond);
     benchmark::RegisterBenchmark("is_bipartite/CPP-GL/matrix", bm_gl_is_bipartite<gl_matrix>)
-        ->Arg(n_vertices)
-        ->Unit(benchmark::kMillisecond);
-
-    // BGL Benchmarks
-    using bgl_list = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
-    using bgl_matrix =
-        boost::adjacency_matrix<boost::directedS, boost::no_property, boost::no_property>;
-
-    benchmark::RegisterBenchmark("is_bipartite/BGL/list", bm_bgl_is_bipartite<bgl_list>)
-        ->Arg(n_vertices)
-        ->Unit(benchmark::kMillisecond);
-    benchmark::RegisterBenchmark("is_bipartite/BGL/matrix", bm_bgl_is_bipartite<bgl_matrix>)
         ->Arg(n_vertices)
         ->Unit(benchmark::kMillisecond);
 }

--- a/benchmarks/suites/is_bipartite.cpp
+++ b/benchmarks/suites/is_bipartite.cpp
@@ -1,0 +1,101 @@
+#include "runner.hpp"
+#include "suite.hpp"
+
+#include <gl/algorithms.hpp>
+#include <gl/graph.hpp>
+#include <gl/topologies.hpp>
+
+#include <benchmark/benchmark.h>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/adjacency_matrix.hpp>
+#include <boost/graph/bipartite.hpp>
+
+namespace gl_bench::is_bipartite {
+
+// CPP-GL Benchmark
+
+template <gl::type_traits::c_undirected_graph Graph>
+void bm_gl_is_bipartite(benchmark::State& state) {
+    const auto n_vertices = static_cast<gl::types::size_type>(state.range(0));
+    auto graph = gl::topology::biclique<Graph>(n_vertices, n_vertices);
+
+    for (auto _ : state) {
+        bool is_bip = gl::algorithm::is_bipartite(graph);
+        benchmark::DoNotOptimize(is_bip);
+    }
+
+    state.counters["Vertices"] = static_cast<double>(graph.n_vertices());
+    state.counters["Edges"] = static_cast<double>(graph.n_unique_edges());
+}
+
+// BGL Benchmark
+
+template <typename GraphType>
+GraphType gen_bgl_biclique(const std::size_t n_vertices_a, const std::size_t n_vertices_b) {
+    using directed_category = typename boost::graph_traits<GraphType>::directed_category;
+    const auto n_vertices = n_vertices_a + n_vertices_b;
+    GraphType graph{n_vertices};
+
+    for (std::size_t source_id = 0ull; source_id < n_vertices_a; ++source_id) {
+        for (std::size_t target_id = n_vertices_a; target_id < n_vertices; ++target_id) {
+            boost::add_edge(source_id, target_id, graph);
+            if constexpr (std::is_same_v<directed_category, boost::directed_tag>)
+                boost::add_edge(target_id, source_id, graph);
+        }
+    }
+    return graph;
+}
+
+template <typename GraphType>
+void bm_bgl_is_bipartite(benchmark::State& state) {
+    const auto n_vertices = static_cast<std::size_t>(state.range(0));
+    auto graph = gen_bgl_biclique<GraphType>(n_vertices, n_vertices);
+
+    for (auto _ : state) {
+        bool is_bip = boost::is_bipartite(graph);
+        benchmark::DoNotOptimize(is_bip);
+    }
+
+    state.counters["Vertices"] = static_cast<double>(boost::num_vertices(graph));
+    state.counters["Edges"] = static_cast<double>(boost::num_edges(graph));
+}
+
+void add_args(argon::argument_parser& parser) {
+    auto& group = parser.add_group("Is-Bipartite Benchmark Options");
+    parser.add_optional_argument<std::size_t>(group, "bip-v")
+        .default_values(static_cast<std::size_t>(1000))
+        .help("Number of vertices for a single set in bipartite generation");
+}
+
+void register_benchmarks(const argon::argument_parser& parser) {
+    const auto n_vertices = static_cast<int64_t>(parser.value<std::size_t>("bip-v"));
+
+    // CPP-GL Benchmarks
+    using gl_list = gl::graph<gl::list_graph_traits<gl::undirected_t>>;
+    using gl_matrix = gl::graph<gl::matrix_graph_traits<gl::undirected_t>>;
+
+    benchmark::RegisterBenchmark("is_bipartite/CPP-GL/list", bm_gl_is_bipartite<gl_list>)
+        ->Arg(n_vertices)
+        ->Unit(benchmark::kMillisecond);
+    benchmark::RegisterBenchmark("is_bipartite/CPP-GL/matrix", bm_gl_is_bipartite<gl_matrix>)
+        ->Arg(n_vertices)
+        ->Unit(benchmark::kMillisecond);
+
+    // BGL Benchmarks
+    using bgl_list = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
+    using bgl_matrix =
+        boost::adjacency_matrix<boost::directedS, boost::no_property, boost::no_property>;
+
+    // benchmark::RegisterBenchmark("is_bipartite/BGL/list", bm_bgl_is_bipartite<bgl_list>)
+    //     ->Arg(n_vertices)
+    //     ->Unit(benchmark::kMillisecond);
+    // benchmark::RegisterBenchmark("is_bipartite/BGL/matrix", bm_bgl_is_bipartite<bgl_matrix>)
+    //     ->Arg(n_vertices)
+    //     ->Unit(benchmark::kMillisecond);
+}
+
+suite get_suite() {
+    return suite{add_args, register_benchmarks};
+}
+
+} // namespace gl_bench::is_bipartite

--- a/benchmarks/suites/is_bipartite.cpp
+++ b/benchmarks/suites/is_bipartite.cpp
@@ -86,12 +86,12 @@ void register_benchmarks(const argon::argument_parser& parser) {
     using bgl_matrix =
         boost::adjacency_matrix<boost::directedS, boost::no_property, boost::no_property>;
 
-    // benchmark::RegisterBenchmark("is_bipartite/BGL/list", bm_bgl_is_bipartite<bgl_list>)
-    //     ->Arg(n_vertices)
-    //     ->Unit(benchmark::kMillisecond);
-    // benchmark::RegisterBenchmark("is_bipartite/BGL/matrix", bm_bgl_is_bipartite<bgl_matrix>)
-    //     ->Arg(n_vertices)
-    //     ->Unit(benchmark::kMillisecond);
+    benchmark::RegisterBenchmark("is_bipartite/BGL/list", bm_bgl_is_bipartite<bgl_list>)
+        ->Arg(n_vertices)
+        ->Unit(benchmark::kMillisecond);
+    benchmark::RegisterBenchmark("is_bipartite/BGL/matrix", bm_bgl_is_bipartite<bgl_matrix>)
+        ->Arg(n_vertices)
+        ->Unit(benchmark::kMillisecond);
 }
 
 suite get_suite() {

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -31,7 +31,17 @@ cd build
 
 ### Running project benchmarks
 
-TODO
+Building the benchmarks:
+
+```shell
+cmake -B build_bench -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release $cmake_gcc15
+```
+
+Executing the benchmarks (example):
+
+```shell
+./build_bench/benchmarks/gl_benchmarks --bip-v 9000 --benchmark_repetitions=10 --benchmark_display_aggregates_only=true
+```
 
 <br />
 

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -12,7 +12,7 @@ Here you can find the necessery information to be able to work on the project
 ### Build the testing executable
 
 ```shell
-cmake -B build
+cmake -B build -DBUILD_TESTS=ON
 cd build
 make # -j <n>
 ```
@@ -28,6 +28,10 @@ cd build
 
 > [!NOTE]
 > Test suites in the project have the same names as the files they're in except for the `test_extarnal_libs_config.cpp` file which defines the `test_doctest_config` test suite.
+
+### Running project benchmarks
+
+TODO
 
 <br />
 

--- a/include/gl/algorithm/breadth_first_search.hpp
+++ b/include/gl/algorithm/breadth_first_search.hpp
@@ -23,9 +23,6 @@ impl::alg_return_type<AlgReturnType, predecessors_descriptor> breadth_first_sear
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 

--- a/include/gl/algorithm/deapth_first_search.hpp
+++ b/include/gl/algorithm/deapth_first_search.hpp
@@ -22,9 +22,6 @@ impl::alg_return_type<AlgReturnType, predecessors_descriptor> depth_first_search
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 
@@ -71,9 +68,6 @@ impl::alg_return_type<AlgReturnType, predecessors_descriptor> recursive_depth_fi
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_type = typename GraphType::vertex_type;
-    using edge_type = typename GraphType::edge_type;
-
     std::vector<bool> visited(graph.n_vertices(), false);
     std::vector<types::id_type> sources(graph.n_vertices());
 

--- a/include/gl/algorithm/mst.hpp
+++ b/include/gl/algorithm/mst.hpp
@@ -40,10 +40,8 @@ template <
 ) {
     // type definitions
 
-    using vertex_type = typename GraphType::vertex_type;
     using edge_type = typename GraphType::edge_type;
     using edge_info_type = algorithm::edge_info<edge_type>;
-    using distance_type = types::vertex_distance_type<GraphType>;
 
     struct edge_info_comparator {
         [[nodiscard]] gl_attr_force_inline bool operator()(

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -8,7 +8,7 @@ from common import find_files
 
 class DefaultParameters:
     modified_files: bool = False
-    search_paths: list[str] = ["include", "tests"]
+    search_paths: list[str] = ["include", "tests", "benchmarks"]
     file_patterns: list[str] = ["*.cpp", "*.hpp", "*.c", "*.h"]
     exclude_paths: list[str] = ["tests/external"]
     check: bool = False
@@ -18,7 +18,6 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-m", "--modified-files",
-        type=bool,
         default=DefaultParameters.modified_files,
         action=argparse.BooleanOptionalAction,
         help="run clang-format only on the files modified since last pushed commit"
@@ -49,7 +48,6 @@ def parse_args():
     )
     parser.add_argument(
         "-c", "--check",
-        type=bool,
         default=DefaultParameters.check,
         action=argparse.BooleanOptionalAction,
         help="run format check"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ endforeach()
 if(NOT DEFINED CMAKE_CXX_FLAGS)
     set(
         CMAKE_CXX_FLAGS
-        "-Wall -Wextra -Wcast-align -Wconversion -Wunreachable-code -Wuninitialized -Wunused -pedantic -g -O3"
+        "-Wall -Wextra -Wcast-align -Wconversion -Wunreachable-code -Wuninitialized -Wunused -pedantic -g -O2"
         CACHE STRING "Default C++ compile flags" FORCE
     )
 endif()


### PR DESCRIPTION
- Added the `benchmarks` directory containing the initial library benchmarks implementation
- Defined the benchmark suite and runner classes responsible for proper setup and execution of CPP-GL benchmarks
- Implemented a simple benchmark: bipartiteness verification of a K_n,n biclique
- Added the `benchmarks` smoke test workflow