### PR TITLE
YT-CPPHGL-18: Implement hypergraph traversal algorithms

### DIFF
--- a/include/gl/algorithm.hpp
+++ b/include/gl/algorithm.hpp
@@ -10,18 +10,18 @@
 #include "gl/algorithm/traits.hpp"
 #include "gl/algorithm/util.hpp"
 
-#include "algorithm/templates/bfs.hpp"
-#include "algorithm/templates/dfs.hpp"
-#include "algorithm/templates/pfs.hpp"
+#include "gl/algorithm/templates/bfs.hpp"
+#include "gl/algorithm/templates/dfs.hpp"
+#include "gl/algorithm/templates/pfs.hpp"
 
-#include "algorithm/traversal/breadth_first_search.hpp"
-#include "algorithm/traversal/depth_first_search.hpp"
+#include "gl/algorithm/traversal/breadth_first_search.hpp"
+#include "gl/algorithm/traversal/depth_first_search.hpp"
 
-#include "algorithm/topology/coloring.hpp"
-#include "algorithm/topology/topological_sort.hpp"
+#include "gl/algorithm/topology/coloring.hpp"
+#include "gl/algorithm/topology/topological_sort.hpp"
 
-#include "algorithm/pathfinding/dijkstra.hpp"
+#include "gl/algorithm/pathfinding/dijkstra.hpp"
 
-#include "algorithm/spanning_tree/prim_mst.hpp"
+#include "gl/algorithm/spanning_tree/prim_mst.hpp"
 
 // clang-format on

--- a/include/gl/algorithm/core.hpp
+++ b/include/gl/algorithm/core.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/attributes/force_inline.hpp"
 #include "gl/constants.hpp"
 #include "gl/graph.hpp"
 #include "gl/types/core.hpp"
@@ -12,27 +13,9 @@
 
 namespace gl::algorithm {
 
-// --- types ---
+// --- general types ---
 
-enum class result_discriminator : bool { ret = true, noret = false };
-using enum result_discriminator;
-
-template <traits::c_graph GraphType>
-using predecessors_map = std::vector<typename GraphType::id_type>;
-
-// TODO: rename to traversal_context
-template <traits::c_graph GraphType>
-struct vertex_info {
-    using id_type = typename GraphType::id_type;
-
-    vertex_info(id_type id) : id(id), pred_id(id) {}
-
-    vertex_info(id_type id, id_type pred_id) : id(id), pred_id(pred_id) {}
-
-    // if id == pred_id then id is the id of the root vertex
-    id_type id;
-    id_type pred_id;
-};
+struct empty_callback {};
 
 struct decision {
     enum class eval : std::uint8_t { accept, reject, abort };
@@ -58,14 +41,36 @@ struct decision {
     eval value;
 };
 
-struct empty_callback {};
+enum class result_discriminator : bool { ret = true, noret = false };
+using enum result_discriminator;
 
-template <result_discriminator ResultDiscriminator, typename ReturnType>
-using return_type = std::conditional_t<ResultDiscriminator == algorithm::ret, ReturnType, void>;
+template <result_discriminator Result, typename ReturnType>
+using return_type = std::conditional_t<Result == algorithm::ret, ReturnType, void>;
 
-template <result_discriminator ResultDiscriminator, typename ReturnType>
+template <result_discriminator Result, typename ReturnType>
 using non_void_return_type =
-    std::conditional_t<ResultDiscriminator == algorithm::ret, ReturnType, std::monostate>;
+    std::conditional_t<Result == algorithm::ret, ReturnType, std::monostate>;
+
+// --- traversal types ---
+
+template <traits::c_graph GraphType>
+using predecessors_map = std::vector<typename GraphType::id_type>;
+
+template <traits::c_graph GraphType>
+struct search_node {
+    using id_type = typename GraphType::id_type;
+
+    search_node(id_type vertex_id) : vertex_id(vertex_id), pred_id(vertex_id) {}
+
+    search_node(id_type vertex_id, id_type pred_id) : vertex_id(vertex_id), pred_id(pred_id) {}
+
+    [[nodiscard]] gl_attr_force_inline bool is_root() const noexcept {
+        return this->vertex_id != invalid_id and this->vertex_id == this->pred_id;
+    }
+
+    id_type vertex_id;
+    id_type pred_id;
+};
 
 // --- constants ---
 

--- a/include/gl/algorithm/core.hpp
+++ b/include/gl/algorithm/core.hpp
@@ -20,6 +20,7 @@ using enum result_discriminator;
 template <traits::c_graph GraphType>
 using predecessors_map = std::vector<typename GraphType::id_type>;
 
+// TODO: rename to traversal_context
 template <traits::c_graph GraphType>
 struct vertex_info {
     using id_type = typename GraphType::id_type;
@@ -28,7 +29,7 @@ struct vertex_info {
 
     vertex_info(id_type id, id_type pred_id) : id(id), pred_id(pred_id) {}
 
-    // if id == pred_id then vertex_id is the id of the starting vertex
+    // if id == pred_id then id is the id of the root vertex
     id_type id;
     id_type pred_id;
 };

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -38,10 +38,9 @@ template <traits::c_graph GraphType>
 
 template <
     traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 [[nodiscard]] paths_descriptor_type<GraphType> dijkstra_shortest_paths(
     const GraphType& graph,
     typename GraphType::id_type source_id,
@@ -61,13 +60,12 @@ template <
 
     pfs(
         graph,
-        [&paths](
-            const algorithm::vertex_info<GraphType>& lhs,
-            const algorithm::vertex_info<GraphType>& rhs
-        ) { return paths.distances[lhs.id] > paths.distances[rhs.id]; },
+        [&paths](const vertex_info<GraphType>& lhs, const vertex_info<GraphType>& rhs) {
+            return paths.distances[lhs.id] > paths.distances[rhs.id];
+        },
         init_range<GraphType>(source_id),
-        algorithm::empty_callback{}, // visit predicate
-        algorithm::empty_callback{}, // visit callback
+        empty_callback{}, // visit predicate
+        empty_callback{}, // visit callback
         [&paths, &negative_edge](id_type vertex_id, const edge_type& in_edge)
             -> decision { // enqueue predicate
             const auto pred_id = in_edge.incident_vertex(vertex_id);

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -14,44 +14,41 @@
 
 namespace gl::algorithm {
 
-template <traits::c_graph GraphType, traits::c_arithmetic VertexDistanceType>
+template <traits::c_graph G, traits::c_arithmetic VertexDistanceType>
 struct paths_descriptor {
-    using id_type = typename GraphType::id_type;
+    using id_type = typename G::id_type;
     using distance_type = VertexDistanceType;
 
     paths_descriptor(const size_type n_vertices)
     : predecessors(n_vertices, invalid_id), distances(n_vertices) {}
 
-    predecessors_map<GraphType> predecessors;
+    predecessors_map<G> predecessors;
     std::vector<distance_type> distances;
 };
 
-template <traits::c_graph GraphType>
-using paths_descriptor_type = paths_descriptor<GraphType, vertex_distance_type<GraphType>>;
+template <traits::c_graph G>
+using paths_descriptor_type = paths_descriptor<G, vertex_distance_type<G>>;
 
-template <traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline paths_descriptor_type<GraphType> make_paths_descriptor(
-    const GraphType& graph
-) {
-    return paths_descriptor_type<GraphType>{graph.order()};
+template <traits::c_graph G>
+[[nodiscard]] gl_attr_force_inline paths_descriptor_type<G> make_paths_descriptor(const G& graph) {
+    return paths_descriptor_type<G>{graph.order()};
 }
 
 template <
-    traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-[[nodiscard]] paths_descriptor_type<GraphType> dijkstra_shortest_paths(
-    const GraphType& graph,
-    typename GraphType::id_type source_id,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    traits::c_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+[[nodiscard]] paths_descriptor_type<G> dijkstra_shortest_paths(
+    const G& graph,
+    typename G::id_type source_id,
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
-    using id_type = typename GraphType::id_type;
-    using edge_type = typename GraphType::edge_type;
-    using distance_type = vertex_distance_type<GraphType>;
+    using id_type = typename G::id_type;
+    using edge_type = typename G::edge_type;
+    using distance_type = vertex_distance_type<G>;
 
-    auto paths = make_paths_descriptor<GraphType>(graph);
+    auto paths = make_paths_descriptor<G>(graph);
 
     paths.predecessors[source_id] = source_id;
     paths.distances[source_id] = distance_type{};
@@ -60,17 +57,17 @@ template <
 
     pfs(
         graph,
-        [&paths](const vertex_info<GraphType>& lhs, const vertex_info<GraphType>& rhs) {
-            return paths.distances[lhs.id] > paths.distances[rhs.id];
+        [&paths](const search_node<G>& lhs, const search_node<G>& rhs) {
+            return paths.distances[lhs.vertex_id] > paths.distances[rhs.vertex_id];
         },
-        init_range<GraphType>(source_id),
+        init_range<G>(source_id),
         empty_callback{}, // visit predicate
         empty_callback{}, // visit callback
         [&paths, &negative_edge](id_type vertex_id, const edge_type& in_edge)
             -> decision { // enqueue predicate
             const auto pred_id = in_edge.incident_vertex(vertex_id);
 
-            const auto edge_weight = get_weight<GraphType>(in_edge);
+            const auto edge_weight = get_weight<G>(in_edge);
             if (edge_weight < 0) {
                 negative_edge.emplace(in_edge);
                 return decision::abort;
@@ -98,7 +95,7 @@ template <
             "[alg::dijkstra_shortest_paths] Found an edge with a negative weight: [{}, {} | w={}]",
             edge.source(),
             edge.target(),
-            get_weight<GraphType>(edge)
+            get_weight<G>(edge)
         ));
     }
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -12,9 +12,9 @@
 
 namespace gl::algorithm {
 
-template <traits::c_undirected_graph GraphType>
+template <traits::c_undirected_graph G>
 struct mst_descriptor {
-    using graph_type = GraphType;
+    using graph_type = G;
     using edge_type = typename graph_type::edge_type;
     using weight_type = vertex_distance_type<graph_type>;
 
@@ -26,18 +26,16 @@ struct mst_descriptor {
     weight_type weight = static_cast<weight_type>(0);
 };
 
-template <traits::c_undirected_graph GraphType>
-[[nodiscard]] mst_descriptor<GraphType> edge_heap_prim_mst(
-    const GraphType& graph, typename GraphType::id_type root_id
-) {
+template <traits::c_undirected_graph G>
+[[nodiscard]] mst_descriptor<G> edge_heap_prim_mst(const G& graph, typename G::id_type root_id) {
     // type definitions
-    using edge_type = typename GraphType::edge_type;
+    using edge_type = typename G::edge_type;
 
     struct edge_comparator {
         [[nodiscard]] gl_attr_force_inline bool operator()(
             const edge_type& lhs, const edge_type& rhs
         ) const {
-            return get_weight<GraphType>(lhs) > get_weight<GraphType>(rhs);
+            return get_weight<G>(lhs) > get_weight<G>(rhs);
         }
     };
 
@@ -45,7 +43,7 @@ template <traits::c_undirected_graph GraphType>
 
     // prepare the necessary utility
     const auto n_vertices = graph.order();
-    mst_descriptor<GraphType> mst(n_vertices);
+    mst_descriptor<G> mst(n_vertices);
     std::vector<bool> visited(n_vertices, false);
     queue_type edge_queue;
 
@@ -71,7 +69,7 @@ template <traits::c_undirected_graph GraphType>
 
         // add the minimum weight edge to the mst
         mst.edges.emplace_back(min_edge);
-        mst.weight += get_weight<GraphType>(min_edge);
+        mst.weight += get_weight<G>(min_edge);
 
         visited[min_edge_tgt] = true;
         ++n_vertices_in_mst;
@@ -85,19 +83,17 @@ template <traits::c_undirected_graph GraphType>
     return mst;
 }
 
-template <traits::c_undirected_graph GraphType>
-requires traits::c_has_numeric_limits_max<vertex_distance_type<GraphType>>
-[[nodiscard]] mst_descriptor<GraphType> vertex_heap_prim_mst(
-    const GraphType& graph, typename GraphType::id_type root_id
-) {
+template <traits::c_undirected_graph G>
+requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
+[[nodiscard]] mst_descriptor<G> vertex_heap_prim_mst(const G& graph, typename G::id_type root_id) {
     // type definitions
-    using id_type = typename GraphType::id_type;
-    using edge_type = typename GraphType::edge_type;
-    using distance_type = vertex_distance_type<GraphType>;
+    using id_type = typename G::id_type;
+    using edge_type = typename G::edge_type;
+    using distance_type = vertex_distance_type<G>;
 
     // Prepare the necessary utility
     const auto n_vertices = graph.order();
-    mst_descriptor<GraphType> mst(n_vertices);
+    mst_descriptor<G> mst(n_vertices);
 
     std::vector<bool> in_mst(n_vertices, false);
     std::vector<distance_type> min_cost(n_vertices, std::numeric_limits<distance_type>::max());
@@ -137,7 +133,7 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<GraphType>>
 
         // Update adjacent vertices
         for (const auto& edge : graph.adjacent_edges(vertex_id)) {
-            const auto edge_weight = get_weight<GraphType>(edge);
+            const auto edge_weight = get_weight<G>(edge);
             const auto incident_vertex_idx = to_idx(edge.incident_vertex(vertex_id));
 
             if (not in_mst[incident_vertex_idx] and edge_weight < min_cost[incident_vertex_idx]) {

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -13,65 +13,61 @@
 namespace gl::algorithm {
 
 template <
-    traits::c_graph GraphType,
-    traits::c_forward_range_of<vertex_info<GraphType>> InitQueueRangeType =
-        std::vector<vertex_info<GraphType>>,
-    traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
-    traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
-        VisitCallback,
-    traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
+    traits::c_graph G,
+    traits::c_forward_range_of<search_node<G>> InitQueueRangeType = std::vector<search_node<G>>,
+    traits::c_optional_predicate<typename G::id_type> VisitVertexPredicate = empty_callback,
+    traits::c_optional_predicate<typename G::id_type, typename G::id_type> VisitCallback =
+        empty_callback,
+    traits::c_decision_predicate<typename G::id_type, const typename G::edge_type&>
+        EnqueueVertexPred = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
 bool bfs(
-    const GraphType& graph,
+    const G& graph,
     const InitQueueRangeType& initial_queue_content,
-    const VisitVertexPredicate& visit_vertex_pred = {},
-    const VisitCallback& visit = {},
-    const EnqueueVertexPred& enqueue_vertex_pred = {},
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    VisitVertexPredicate visit_vertex_pred = {},
+    VisitCallback visit = {},
+    EnqueueVertexPred enqueue_vertex_pred = {},
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     if (std::ranges::empty(initial_queue_content))
         return false;
 
     // prepare the vertex queue
-    using vertex_queue_type = std::queue<vertex_info<GraphType>>;
-    vertex_queue_type vertex_queue;
-
-    for (const auto& vinfo : initial_queue_content)
-        vertex_queue.push(vinfo);
+    std::queue<search_node<G>> q;
+    for (const auto& node : initial_queue_content)
+        q.push(node);
 
     // search the graph
-    while (not vertex_queue.empty()) {
-        const vertex_info vinfo = vertex_queue.front();
-        vertex_queue.pop();
+    while (not q.empty()) {
+        const search_node node = q.front();
+        q.pop();
 
         if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vinfo.id))
+            if (not visit_vertex_pred(node.vertex_id))
                 continue;
 
         if constexpr (not traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vinfo.id);
+            pre_visit(node.vertex_id);
 
         if constexpr (not traits::c_empty_callback<VisitCallback>)
-            if (not visit(vinfo.id, vinfo.pred_id))
+            if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
+        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;
 
             if (enqueue)
-                vertex_queue.emplace(incident_vertex_id, vinfo.id);
+                q.emplace(incident_vertex_id, node.vertex_id);
         }
 
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vinfo.id);
+            post_visit(node.vertex_id);
     }
 
     return true;

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -34,7 +34,7 @@ bool bfs(
     if (std::ranges::empty(initial_queue_content))
         return false;
 
-    // prepare the vertex queue
+    // prepare the node queue
     std::queue<search_node<G>> q;
     for (const auto& node : initial_queue_content)
         q.push(node);

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -14,17 +14,16 @@ namespace gl::algorithm {
 
 template <
     traits::c_graph GraphType,
-    traits::c_forward_range_of<algorithm::vertex_info<GraphType>> InitQueueRangeType =
-        std::vector<algorithm::vertex_info<GraphType>>,
+    traits::c_forward_range_of<vertex_info<GraphType>> InitQueueRangeType =
+        std::vector<vertex_info<GraphType>>,
     traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
     traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
         VisitCallback,
     traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
         EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 bool bfs(
     const GraphType& graph,
     const InitQueueRangeType& initial_queue_content,
@@ -38,7 +37,7 @@ bool bfs(
         return false;
 
     // prepare the vertex queue
-    using vertex_queue_type = std::queue<algorithm::vertex_info<GraphType>>;
+    using vertex_queue_type = std::queue<vertex_info<GraphType>>;
     vertex_queue_type vertex_queue;
 
     for (const auto& vinfo : initial_queue_content)
@@ -46,7 +45,7 @@ bool bfs(
 
     // search the graph
     while (not vertex_queue.empty()) {
-        const algorithm::vertex_info vinfo = vertex_queue.front();
+        const vertex_info vinfo = vertex_queue.front();
         vertex_queue.pop();
 
         if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -18,10 +18,9 @@ template <
         VisitCallback,
     traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
         EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 void dfs(
     const GraphType& graph,
     const typename GraphType::id_type root_id,
@@ -31,7 +30,7 @@ void dfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using vertex_stack_type = std::stack<algorithm::vertex_info<GraphType>>;
+    using vertex_stack_type = std::stack<vertex_info<GraphType>>;
 
     if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
         if (not visit_vertex_pred(root_id))
@@ -73,10 +72,9 @@ template <
         VisitCallback,
     traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
         EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 void r_dfs(
     const GraphType& graph,
     const typename GraphType::id_type vertex_id,

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -24,7 +24,7 @@ template <
     traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
 bool dfs(
     const G& graph,
-    const InitStackRangeType initial_stack_content,
+    const InitStackRangeType& initial_stack_content,
     VisitVertexPredicate visit_vertex_pred = {},
     VisitCallback visit = {},
     EnqueueVertexPred enqueue_vertex_pred = {},
@@ -34,7 +34,7 @@ bool dfs(
     if (std::ranges::empty(initial_stack_content))
         return false;
 
-    // prepare the vertex queue
+    // prepare the node stack
     std::stack<search_node<G>> s;
     for (const auto& node : initial_stack_content)
         s.push(node);

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/algorithm/core.hpp"
 #include "gl/algorithm/traits.hpp"
 #include "gl/algorithm/util.hpp"
 
@@ -12,78 +13,78 @@
 namespace gl::algorithm {
 
 template <
-    traits::c_graph GraphType,
-    traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
-    traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
-        VisitCallback,
-    traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-void dfs(
-    const GraphType& graph,
-    const typename GraphType::id_type root_id,
-    const VisitVertexPredicate& visit_vertex_pred,
-    const VisitCallback& visit,
-    const EnqueueVertexPred& enqueue_vertex_pred,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    traits::c_graph G,
+    traits::c_forward_range_of<search_node<G>> InitStackRangeType = std::vector<search_node<G>>,
+    traits::c_optional_predicate<typename G::id_type> VisitVertexPredicate = empty_callback,
+    traits::c_optional_predicate<typename G::id_type, typename G::id_type> VisitCallback =
+        empty_callback,
+    traits::c_decision_predicate<typename G::id_type, const typename G::edge_type&>
+        EnqueueVertexPred = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+bool dfs(
+    const G& graph,
+    const InitStackRangeType initial_stack_content,
+    VisitVertexPredicate visit_vertex_pred = {},
+    VisitCallback visit = {},
+    EnqueueVertexPred enqueue_vertex_pred = {},
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
-    using vertex_stack_type = std::stack<vertex_info<GraphType>>;
+    if (std::ranges::empty(initial_stack_content))
+        return false;
 
-    if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
-        if (not visit_vertex_pred(root_id))
-            return;
-
-    // prepare the vertex stack
-    vertex_stack_type vertex_stack;
-    vertex_stack.emplace(root_id);
+    // prepare the vertex queue
+    std::stack<search_node<G>> s;
+    for (const auto& node : initial_stack_content)
+        s.push(node);
 
     // search the graph
-    while (not vertex_stack.empty()) {
-        const auto vinfo = vertex_stack.top();
-        vertex_stack.pop();
+    while (not s.empty()) {
+        const auto node = s.top();
+        s.pop();
 
         if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vinfo.id))
+            if (not visit_vertex_pred(node.vertex_id))
                 continue;
 
         if constexpr (not traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vinfo.id);
+            pre_visit(node.vertex_id);
 
-        visit(vinfo.id, vinfo.pred_id);
+        if constexpr (not traits::c_empty_callback<VisitCallback>)
+            if (not visit(node.vertex_id, node.pred_id))
+                return false;
 
-        for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
+        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
             if (enqueue_vertex_pred(incident_vertex_id, edge))
-                vertex_stack.emplace(incident_vertex_id, vinfo.id);
+                s.emplace(incident_vertex_id, node.vertex_id);
         }
 
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vinfo.id);
+            post_visit(node.vertex_id);
     }
+
+    return true;
 }
 
 template <
-    traits::c_graph GraphType,
-    traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
-    traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
-        VisitCallback,
-    traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
+    traits::c_graph G,
+    traits::c_optional_predicate<typename G::id_type> VisitVertexPredicate,
+    traits::c_optional_predicate<typename G::id_type, typename G::id_type> VisitCallback,
+    traits::c_decision_predicate<typename G::id_type, const typename G::edge_type&>
         EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
 void r_dfs(
-    const GraphType& graph,
-    const typename GraphType::id_type vertex_id,
-    const typename GraphType::id_type pred_id,
-    const VisitVertexPredicate& visit_vertex_pred,
-    const VisitCallback& visit,
-    const EnqueueVertexPred& enqueue_vertex_pred,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    const G& graph,
+    const typename G::id_type vertex_id,
+    const typename G::id_type pred_id,
+    VisitVertexPredicate visit_vertex_pred,
+    VisitCallback visit,
+    EnqueueVertexPred enqueue_vertex_pred,
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
         if (not visit_vertex_pred(vertex_id))

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -36,7 +36,7 @@ bool pfs(
     if (std::ranges::empty(initial_queue_content))
         return false;
 
-    // prepare the vertex queue
+    // prepare the node queue
     using queue_type = std::priority_queue<search_node<G>, std::vector<search_node<G>>, PQCompare>;
     queue_type q(pq_compare);
 

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -13,67 +13,64 @@
 namespace gl::algorithm {
 
 template <
-    traits::c_graph GraphType,
-    traits::c_predicate<vertex_info<GraphType>, vertex_info<GraphType>> PQCompare,
-    traits::c_forward_range_of<vertex_info<GraphType>> InitQueueRangeType =
-        std::vector<vertex_info<GraphType>>,
-    traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
-    traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
-        VisitCallback,
-    traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
-        EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
+    traits::c_graph G,
+    traits::c_predicate<search_node<G>, search_node<G>> PQCompare,
+    traits::c_forward_range_of<search_node<G>> InitQueueRangeType = std::vector<search_node<G>>,
+    traits::c_optional_predicate<typename G::id_type> VisitVertexPredicate = empty_callback,
+    traits::c_optional_predicate<typename G::id_type, typename G::id_type> VisitCallback =
+        empty_callback,
+    traits::c_decision_predicate<typename G::id_type, const typename G::edge_type&>
+        EnqueueVertexPred = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
 bool pfs(
-    const GraphType& graph,
+    const G& graph,
     const PQCompare& pq_compare,
     const InitQueueRangeType& initial_queue_content,
-    const VisitVertexPredicate& visit_vertex_pred,
-    const VisitCallback& visit,
-    const EnqueueVertexPred& enqueue_vertex_pred,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    VisitVertexPredicate visit_vertex_pred = {},
+    VisitCallback visit = {},
+    EnqueueVertexPred enqueue_vertex_pred = {},
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     if (std::ranges::empty(initial_queue_content))
         return false;
 
     // prepare the vertex queue
-    using vertex_queue_type =
-        std::priority_queue<vertex_info<GraphType>, std::vector<vertex_info<GraphType>>, PQCompare>;
-    vertex_queue_type vertex_queue(pq_compare);
+    using queue_type = std::priority_queue<search_node<G>, std::vector<search_node<G>>, PQCompare>;
+    queue_type q(pq_compare);
 
-    for (const auto& vinfo : initial_queue_content)
-        vertex_queue.push(vinfo);
+    for (const auto& node : initial_queue_content)
+        q.push(node);
 
     // search the graph
-    while (not vertex_queue.empty()) {
-        const auto vinfo = vertex_queue.top();
-        vertex_queue.pop();
+    while (not q.empty()) {
+        const auto node = q.top();
+        q.pop();
 
         if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(vinfo.id))
+            if (not visit_vertex_pred(node.vertex_id))
                 continue;
 
         if constexpr (not traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(vinfo.id);
+            pre_visit(node.vertex_id);
 
         if constexpr (not traits::c_empty_callback<VisitCallback>)
-            if (not visit(vinfo.id, vinfo.pred_id))
+            if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.adjacent_edges(vinfo.id)) {
-            const auto incident_vertex_id = edge.incident_vertex(vinfo.id);
+        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;
 
             if (enqueue)
-                vertex_queue.emplace(incident_vertex_id, vinfo.id);
+                q.emplace(incident_vertex_id, node.vertex_id);
         }
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)
-            post_visit(vinfo.id);
+            post_visit(node.vertex_id);
     }
 
     return true;

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -14,19 +14,17 @@ namespace gl::algorithm {
 
 template <
     traits::c_graph GraphType,
-    traits::c_predicate<algorithm::vertex_info<GraphType>, algorithm::vertex_info<GraphType>>
-        PQCompare,
-    traits::c_forward_range_of<algorithm::vertex_info<GraphType>> InitQueueRangeType =
-        std::vector<algorithm::vertex_info<GraphType>>,
+    traits::c_predicate<vertex_info<GraphType>, vertex_info<GraphType>> PQCompare,
+    traits::c_forward_range_of<vertex_info<GraphType>> InitQueueRangeType =
+        std::vector<vertex_info<GraphType>>,
     traits::c_optional_predicate<typename GraphType::id_type> VisitVertexPredicate,
     traits::c_optional_predicate<typename GraphType::id_type, typename GraphType::id_type>
         VisitCallback,
     traits::c_decision_predicate<typename GraphType::id_type, const typename GraphType::edge_type&>
         EnqueueVertexPred,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 bool pfs(
     const GraphType& graph,
     const PQCompare& pq_compare,
@@ -41,10 +39,8 @@ bool pfs(
         return false;
 
     // prepare the vertex queue
-    using vertex_queue_type = std::priority_queue<
-        algorithm::vertex_info<GraphType>,
-        std::vector<algorithm::vertex_info<GraphType>>,
-        PQCompare>;
+    using vertex_queue_type =
+        std::priority_queue<vertex_info<GraphType>, std::vector<vertex_info<GraphType>>, PQCompare>;
     vertex_queue_type vertex_queue(pq_compare);
 
     for (const auto& vinfo : initial_queue_content)

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -13,10 +13,9 @@ using bicoloring_type = std::vector<binary_color>;
 
 template <
     traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 [[nodiscard]] std::optional<bicoloring_type> bipartite_coloring(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -35,8 +34,8 @@ template <
         const bool is_bipartite = bfs(
             graph,
             init_range<GraphType>(root_id),
-            algorithm::empty_callback{}, // visit predicate
-            algorithm::empty_callback{}, // visit callback
+            empty_callback{}, // visit predicate
+            empty_callback{}, // visit callback
             [&coloring](const typename GraphType::id_type vertex_id, const edge_type& in_edge)
                 -> decision { // enqueue predicate
                 if (in_edge.is_loop())

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -12,16 +12,13 @@ namespace gl::algorithm {
 using bicoloring_type = std::vector<binary_color>;
 
 template <
-    traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
+    traits::c_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
 [[nodiscard]] std::optional<bicoloring_type> bipartite_coloring(
-    const GraphType& graph,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    const G& graph, PreVisitCallback pre_visit = {}, PostVisitCallback post_visit = {}
 ) {
-    using edge_type = typename GraphType::edge_type;
+    using edge_type = typename G::edge_type;
 
     bicoloring_type coloring(graph.order(), binary_color::value::unset);
     for (const auto root_id : graph.vertex_ids()) {
@@ -33,10 +30,10 @@ template <
 
         const bool is_bipartite = bfs(
             graph,
-            init_range<GraphType>(root_id),
+            init_range<G>(root_id),
             empty_callback{}, // visit predicate
             empty_callback{}, // visit callback
-            [&coloring](const typename GraphType::id_type vertex_id, const edge_type& in_edge)
+            [&coloring](typename G::id_type vertex_id, const edge_type& in_edge)
                 -> decision { // enqueue predicate
                 if (in_edge.is_loop())
                     return decision::abort; // graph is not bipartite
@@ -71,9 +68,9 @@ template <
     return bipartite_coloring(graph).has_value();
 }
 
-template <traits::c_graph GraphType, traits::c_sized_range_of<binary_color> ColorRange>
-requires(traits::c_binary_color_properties_type<typename GraphType::vertex_properties_type>)
-bool apply_coloring(GraphType& graph, const ColorRange& color_range) {
+template <traits::c_graph G, traits::c_sized_range_of<binary_color> ColorRange>
+requires(traits::c_binary_color_properties_type<typename G::vertex_properties_type>)
+bool apply_coloring(G& graph, const ColorRange& color_range) {
     if (std::ranges::size(color_range) != graph.order())
         return false;
 

--- a/include/gl/algorithm/topology/topological_sort.hpp
+++ b/include/gl/algorithm/topology/topological_sort.hpp
@@ -11,10 +11,9 @@ namespace gl::algorithm {
 
 template <
     traits::c_directed_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 [[nodiscard]] std::optional<std::vector<typename GraphType::id_type>> topological_sort(
     const GraphType& graph,
     const PreVisitCallback& pre_visit = {},
@@ -27,7 +26,7 @@ template <
     std::vector<size_type> in_degree_map = graph.in_degree_map();
 
     // prepare the initial queue content (source vertices)
-    std::vector<algorithm::vertex_info<GraphType>> source_vertex_list;
+    std::vector<vertex_info<GraphType>> source_vertex_list;
     source_vertex_list.reserve(graph.order());
     for (const auto id : graph.vertex_ids())
         if (in_degree_map[to_idx(id)] == 0uz)
@@ -39,7 +38,7 @@ template <
     bfs(
         graph,
         source_vertex_list,
-        algorithm::empty_callback{}, // visit predicate
+        empty_callback{}, // visit predicate
         [&topological_order](
             const id_type vertex_id, [[maybe_unused]] const id_type source_id
         ) { // visit callback

--- a/include/gl/algorithm/topology/topological_sort.hpp
+++ b/include/gl/algorithm/topology/topological_sort.hpp
@@ -10,23 +10,20 @@
 namespace gl::algorithm {
 
 template <
-    traits::c_directed_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-[[nodiscard]] std::optional<std::vector<typename GraphType::id_type>> topological_sort(
-    const GraphType& graph,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    traits::c_directed_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+[[nodiscard]] std::optional<std::vector<typename G::id_type>> topological_sort(
+    const G& graph, PreVisitCallback pre_visit = {}, PostVisitCallback post_visit = {}
 ) {
-    using id_type = typename GraphType::id_type;
-    using edge_type = typename GraphType::edge_type;
+    using id_type = typename G::id_type;
+    using edge_type = typename G::edge_type;
 
     // prepare the vertex in degree map
     std::vector<size_type> in_degree_map = graph.in_degree_map();
 
     // prepare the initial queue content (source vertices)
-    std::vector<vertex_info<GraphType>> source_vertex_list;
+    std::vector<search_node<G>> source_vertex_list;
     source_vertex_list.reserve(graph.order());
     for (const auto id : graph.vertex_ids())
         if (in_degree_map[to_idx(id)] == 0uz)
@@ -39,13 +36,11 @@ template <
         graph,
         source_vertex_list,
         empty_callback{}, // visit predicate
-        [&topological_order](
-            const id_type vertex_id, [[maybe_unused]] const id_type source_id
-        ) { // visit callback
+        [&topological_order](id_type vertex_id, id_type) { // visit callback
             topological_order.push_back(vertex_id);
             return true;
         },
-        [&in_degree_map](const id_type vertex_id, const edge_type& in_edge)
+        [&in_degree_map](id_type vertex_id, const edge_type& in_edge)
             -> decision { // enqueue predicate
             if (in_edge.is_loop())
                 return false;

--- a/include/gl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/gl/algorithm/traversal/breadth_first_search.hpp
@@ -12,12 +12,11 @@
 namespace gl::algorithm {
 
 template <
-    result_discriminator ResultDiscriminator = algorithm::ret,
+    result_discriminator ResultDiscriminator = ret,
     traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 return_type<ResultDiscriminator, predecessors_map<GraphType>> breadth_first_search(
     const GraphType& graph,
     const typename GraphType::id_type root_vertex_id = no_root,
@@ -57,7 +56,7 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> breadth_first_sear
 
     // clang-format on
 
-    if constexpr (ResultDiscriminator == algorithm::ret)
+    if constexpr (ResultDiscriminator == ret)
         return pred_map;
 }
 

--- a/include/gl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/gl/algorithm/traversal/breadth_first_search.hpp
@@ -12,31 +12,30 @@
 namespace gl::algorithm {
 
 template <
-    result_discriminator ResultDiscriminator = ret,
-    traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-return_type<ResultDiscriminator, predecessors_map<GraphType>> breadth_first_search(
-    const GraphType& graph,
-    const typename GraphType::id_type root_vertex_id = no_root,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    result_discriminator Result = ret,
+    traits::c_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+return_type<Result, predecessors_map<G>> breadth_first_search(
+    const G& graph,
+    const typename G::id_type root_vertex_id = no_root,
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<typename GraphType::id_type> sources(graph.order());
+    std::vector<typename G::id_type> sources(graph.order());
 
-    auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
+    auto pred_map = init_predecessors_map<Result>(graph);
 
     // clang-format off
 
     if (root_vertex_id != no_root) {
         bfs(
             graph,
-            init_range<GraphType>(root_vertex_id),
+            init_range<G>(root_vertex_id),
             default_visit_vertex_predicate(visited),
-            default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-            default_enqueue_vertex_predicate<GraphType, true>(visited),
+            default_visit_callback<G, Result>(visited, pred_map),
+            default_enqueue_vertex_predicate<G, true>(visited),
             pre_visit,
             post_visit
         );
@@ -45,10 +44,10 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> breadth_first_sear
         for (const auto root_id : graph.vertex_ids())
             bfs(
                 graph,
-                init_range<GraphType>(root_id),
+                init_range<G>(root_id),
                 default_visit_vertex_predicate(visited),
-                default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-                default_enqueue_vertex_predicate<GraphType, true>(visited),
+                default_visit_callback<G, Result>(visited, pred_map),
+                default_enqueue_vertex_predicate<G, true>(visited),
                 pre_visit,
                 post_visit
             );
@@ -56,7 +55,7 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> breadth_first_sear
 
     // clang-format on
 
-    if constexpr (ResultDiscriminator == ret)
+    if constexpr (Result == ret)
         return pred_map;
 }
 

--- a/include/gl/algorithm/traversal/depth_first_search.hpp
+++ b/include/gl/algorithm/traversal/depth_first_search.hpp
@@ -6,48 +6,48 @@
 
 #include "gl/algorithm/core.hpp"
 #include "gl/algorithm/templates/dfs.hpp"
+#include "gl/algorithm/util.hpp"
 #include "gl/constants.hpp"
 
 namespace gl::algorithm {
 
 template <
-    result_discriminator ResultDiscriminator = ret,
-    traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-return_type<ResultDiscriminator, predecessors_map<GraphType>> depth_first_search(
-    const GraphType& graph,
-    const typename GraphType::id_type root_vertex_id = no_root,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    result_discriminator Result = ret,
+    traits::c_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+return_type<Result, predecessors_map<G>> depth_first_search(
+    const G& graph,
+    const typename G::id_type root_vertex_id = no_root,
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<typename GraphType::id_type> sources(graph.order());
+    std::vector<typename G::id_type> sources(graph.order());
 
-    auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
+    auto pred_map = init_predecessors_map<Result>(graph);
 
     // clang-format off
 
     if (root_vertex_id != no_root) {
         dfs(
             graph,
-            root_vertex_id,
+            init_range<G>(root_vertex_id),
             default_visit_vertex_predicate(visited),
-            default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-            default_enqueue_vertex_predicate<GraphType>(visited),
+            default_visit_callback<G, Result>(visited, pred_map),
+            default_enqueue_vertex_predicate<G>(visited),
             pre_visit,
             post_visit
         );
     }
     else {
-        for (const auto root_vertex_id : graph.vertex_ids())
+        for (const auto root_id : graph.vertex_ids())
             dfs(
                 graph,
-                root_vertex_id,
+                init_range<G>(root_id),
                 default_visit_vertex_predicate(visited),
-                default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-                default_enqueue_vertex_predicate<GraphType>(visited),
+                default_visit_callback<G, Result>(visited, pred_map),
+                default_enqueue_vertex_predicate<G>(visited),
                 pre_visit,
                 post_visit
             );
@@ -55,26 +55,25 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> depth_first_search
 
     // clang-format on
 
-    if constexpr (ResultDiscriminator == ret)
+    if constexpr (Result == ret)
         return pred_map;
 }
 
 template <
-    result_discriminator ResultDiscriminator = ret,
-    traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
-    traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        empty_callback>
-return_type<ResultDiscriminator, predecessors_map<GraphType>> recursive_depth_first_search(
-    const GraphType& graph,
-    const typename GraphType::id_type root_vertex_id = no_root,
-    const PreVisitCallback& pre_visit = {},
-    const PostVisitCallback& post_visit = {}
+    result_discriminator Result = ret,
+    traits::c_graph G,
+    traits::c_optional_callback<void, typename G::id_type> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, typename G::id_type> PostVisitCallback = empty_callback>
+return_type<Result, predecessors_map<G>> recursive_depth_first_search(
+    const G& graph,
+    const typename G::id_type root_vertex_id = no_root,
+    PreVisitCallback pre_visit = {},
+    PostVisitCallback post_visit = {}
 ) {
     std::vector<bool> visited(graph.order(), false);
-    std::vector<typename GraphType::id_type> sources(graph.order());
+    std::vector<typename G::id_type> sources(graph.order());
 
-    auto pred_map = init_predecessors_map<ResultDiscriminator>(graph);
+    auto pred_map = init_predecessors_map<Result>(graph);
 
     if (root_vertex_id != no_root) {
         r_dfs(
@@ -82,8 +81,8 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> recursive_depth_fi
             root_vertex_id,
             root_vertex_id, // pred_id
             default_visit_vertex_predicate(visited),
-            default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-            default_enqueue_vertex_predicate<GraphType>(visited),
+            default_visit_callback<G, Result>(visited, pred_map),
+            default_enqueue_vertex_predicate<G>(visited),
             pre_visit,
             post_visit
         );
@@ -95,14 +94,14 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> recursive_depth_fi
                 root_id,
                 root_id, // pred_id
                 default_visit_vertex_predicate(visited),
-                default_visit_callback<GraphType, ResultDiscriminator>(visited, pred_map),
-                default_enqueue_vertex_predicate<GraphType>(visited),
+                default_visit_callback<G, Result>(visited, pred_map),
+                default_enqueue_vertex_predicate<G>(visited),
                 pre_visit,
                 post_visit
             );
     }
 
-    if constexpr (ResultDiscriminator == ret)
+    if constexpr (Result == ret)
         return pred_map;
 }
 

--- a/include/gl/algorithm/traversal/depth_first_search.hpp
+++ b/include/gl/algorithm/traversal/depth_first_search.hpp
@@ -11,12 +11,11 @@
 namespace gl::algorithm {
 
 template <
-    result_discriminator ResultDiscriminator = algorithm::ret,
+    result_discriminator ResultDiscriminator = ret,
     traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 return_type<ResultDiscriminator, predecessors_map<GraphType>> depth_first_search(
     const GraphType& graph,
     const typename GraphType::id_type root_vertex_id = no_root,
@@ -56,17 +55,16 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> depth_first_search
 
     // clang-format on
 
-    if constexpr (ResultDiscriminator == algorithm::ret)
+    if constexpr (ResultDiscriminator == ret)
         return pred_map;
 }
 
 template <
-    result_discriminator ResultDiscriminator = algorithm::ret,
+    result_discriminator ResultDiscriminator = ret,
     traits::c_graph GraphType,
-    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback =
-        algorithm::empty_callback,
+    traits::c_optional_callback<void, typename GraphType::id_type> PreVisitCallback = empty_callback,
     traits::c_optional_callback<void, typename GraphType::id_type> PostVisitCallback =
-        algorithm::empty_callback>
+        empty_callback>
 return_type<ResultDiscriminator, predecessors_map<GraphType>> recursive_depth_first_search(
     const GraphType& graph,
     const typename GraphType::id_type root_vertex_id = no_root,
@@ -104,7 +102,7 @@ return_type<ResultDiscriminator, predecessors_map<GraphType>> recursive_depth_fi
             );
     }
 
-    if constexpr (ResultDiscriminator == algorithm::ret)
+    if constexpr (ResultDiscriminator == ret)
         return pred_map;
 }
 

--- a/include/gl/algorithm/util.hpp
+++ b/include/gl/algorithm/util.hpp
@@ -14,11 +14,11 @@ namespace gl::algorithm {
 template <result_discriminator Result, traits::c_graph G>
 [[nodiscard]] gl_attr_force_inline non_void_return_type<Result, predecessors_map<G>>
 init_predecessors_map(const G& graph) {
-    using return_type = non_void_return_type<Result, predecessors_map<G>>;
+    using return_t = non_void_return_type<Result, predecessors_map<G>>;
     if constexpr (Result == ret)
-        return return_type(graph.order(), invalid_id);
+        return return_t(graph.order(), invalid_id);
     else
-        return return_type();
+        return return_t();
 }
 
 template <traits::c_id_type IdType>
@@ -56,9 +56,10 @@ template <traits::c_graph G, result_discriminator Result>
 template <traits::c_graph G, bool AsResult = false>
 [[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(std::vector<bool>& visited
 ) {
-    using return_type = std::conditional_t<AsResult, decision, bool>;
-    return [&](typename G::id_type vertex_id, [[maybe_unused]] const typename G::edge_type& in_edge
-           ) -> return_type { return not visited[to_idx(vertex_id)]; };
+    using return_t = std::conditional_t<AsResult, decision, bool>;
+    return [&](typename G::id_type vertex_id, const typename G::edge_type&) -> return_t {
+        return not visited[to_idx(vertex_id)];
+    };
 }
 
 } // namespace gl::algorithm

--- a/include/gl/algorithm/util.hpp
+++ b/include/gl/algorithm/util.hpp
@@ -16,7 +16,7 @@ template <result_discriminator ResultDiscriminator, traits::c_graph GraphType>
     non_void_return_type<ResultDiscriminator, predecessors_map<GraphType>>
     init_predecessors_map(const GraphType& graph) {
     using return_type = non_void_return_type<ResultDiscriminator, predecessors_map<GraphType>>;
-    if constexpr (ResultDiscriminator == algorithm::ret)
+    if constexpr (ResultDiscriminator == ret)
         return return_type(graph.order(), invalid_id);
     else
         return return_type();
@@ -31,11 +31,11 @@ template <traits::c_id_type IdType>
 
 template <
     traits::c_graph GraphType,
-    traits::c_forward_range_of<algorithm::vertex_info<GraphType>> InitRangeType =
-        std::vector<algorithm::vertex_info<GraphType>>>
+    traits::c_forward_range_of<vertex_info<GraphType>> InitRangeType =
+        std::vector<vertex_info<GraphType>>>
 [[nodiscard]] gl_attr_force_inline InitRangeType
 init_range(typename GraphType::id_type root_vertex_id) {
-    return InitRangeType{algorithm::vertex_info<GraphType>{root_vertex_id}};
+    return InitRangeType{vertex_info<GraphType>{root_vertex_id}};
 }
 
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited) {
@@ -51,7 +51,7 @@ template <traits::c_graph GraphType, result_discriminator ResultDiscriminator>
     return [&](id_type vertex_id, id_type pred_id) {
         const auto vertex_idx = to_idx(vertex_id);
         visited[vertex_idx] = true;
-        if constexpr (ResultDiscriminator == algorithm::ret)
+        if constexpr (ResultDiscriminator == ret)
             pred_map[vertex_idx] = pred_id;
         return true;
     };

--- a/include/gl/algorithm/util.hpp
+++ b/include/gl/algorithm/util.hpp
@@ -11,12 +11,11 @@
 
 namespace gl::algorithm {
 
-template <result_discriminator ResultDiscriminator, traits::c_graph GraphType>
-[[nodiscard]] gl_attr_force_inline
-    non_void_return_type<ResultDiscriminator, predecessors_map<GraphType>>
-    init_predecessors_map(const GraphType& graph) {
-    using return_type = non_void_return_type<ResultDiscriminator, predecessors_map<GraphType>>;
-    if constexpr (ResultDiscriminator == ret)
+template <result_discriminator Result, traits::c_graph G>
+[[nodiscard]] gl_attr_force_inline non_void_return_type<Result, predecessors_map<G>>
+init_predecessors_map(const G& graph) {
+    using return_type = non_void_return_type<Result, predecessors_map<G>>;
+    if constexpr (Result == ret)
         return return_type(graph.order(), invalid_id);
     else
         return return_type();
@@ -30,41 +29,36 @@ template <traits::c_id_type IdType>
 }
 
 template <
-    traits::c_graph GraphType,
-    traits::c_forward_range_of<vertex_info<GraphType>> InitRangeType =
-        std::vector<vertex_info<GraphType>>>
-[[nodiscard]] gl_attr_force_inline InitRangeType
-init_range(typename GraphType::id_type root_vertex_id) {
-    return InitRangeType{vertex_info<GraphType>{root_vertex_id}};
+    traits::c_graph G,
+    traits::c_forward_range_of<search_node<G>> InitRangeType = std::vector<search_node<G>>>
+[[nodiscard]] gl_attr_force_inline InitRangeType init_range(typename G::id_type root_vertex_id) {
+    return InitRangeType{search_node<G>{root_vertex_id}};
 }
 
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited) {
     return [&](traits::c_id_type auto vertex_id) -> bool { return not visited[to_idx(vertex_id)]; };
 }
 
-template <traits::c_graph GraphType, result_discriminator ResultDiscriminator>
+template <traits::c_graph G, result_discriminator Result>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
-    std::vector<bool>& visited,
-    non_void_return_type<ResultDiscriminator, predecessors_map<GraphType>>& pred_map
+    std::vector<bool>& visited, non_void_return_type<Result, predecessors_map<G>>& pred_map
 ) {
-    using id_type = typename GraphType::id_type;
+    using id_type = typename G::id_type;
     return [&](id_type vertex_id, id_type pred_id) {
         const auto vertex_idx = to_idx(vertex_id);
         visited[vertex_idx] = true;
-        if constexpr (ResultDiscriminator == ret)
+        if constexpr (Result == ret)
             pred_map[vertex_idx] = pred_id;
         return true;
     };
 }
 
-template <traits::c_graph GraphType, bool AsResult = false>
+template <traits::c_graph G, bool AsResult = false>
 [[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(std::vector<bool>& visited
 ) {
     using return_type = std::conditional_t<AsResult, decision, bool>;
-    return [&](typename GraphType::id_type vertex_id,
-               [[maybe_unused]] const typename GraphType::edge_type& in_edge) -> return_type {
-        return not visited[to_idx(vertex_id)];
-    };
+    return [&](typename G::id_type vertex_id, [[maybe_unused]] const typename G::edge_type& in_edge
+           ) -> return_type { return not visited[to_idx(vertex_id)]; };
 }
 
 } // namespace gl::algorithm

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -293,6 +293,7 @@ public:
         return this->at(vertex.id());
     }
 
+    // TODO: rename to incident_edges
     [[nodiscard]] inline auto adjacent_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
@@ -301,6 +302,7 @@ public:
             return this->_impl.adjacent_edges(vertex_id);
     }
 
+    // TODO: rename to incident_edges
     [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const vertex_type& vertex) const {
         return this->adjacent_edges(vertex.id());
     }

--- a/include/hgl/algorithm.hpp
+++ b/include/hgl/algorithm.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+// clang-format off
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/algorithm/util.hpp"
+
+#include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/templates/dfs.hpp"
+
+#include "hgl/algorithm/traversal/breadth_first_search.hpp"
+#include "hgl/algorithm/traversal/depth_first_search.hpp"
+#include "hgl/algorithm/traversal/backward_search.hpp"
+#include "hgl/algorithm/traversal/forward_search.hpp"
+
+// clang-format on

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -7,11 +7,16 @@
 #include "gl/algorithm/core.hpp"
 #include "gl/algorithm/traits.hpp"
 #include "gl/algorithm/util.hpp"
+#include "gl/traits.hpp"
 #include "hgl/hypergraph.hpp"
 #include "hgl/traits.hpp"
 #include "hgl/types.hpp"
 
-namespace hgl::algorithm {
+#include <ranges>
+
+namespace hgl {
+
+namespace algorithm {
 
 // -- GL core ---
 
@@ -55,6 +60,19 @@ struct search_node {
 template <hgl::traits::c_hypergraph H>
 using search_tree = std::vector<search_node<H>>;
 
+} // namespace algorithm
+
+namespace traits {
+
+template <typename T>
+concept c_search_tree =
+    c_random_access_range<T>
+    and c_instantiation_of<std::ranges::range_value_t<T>, algorithm::search_node>;
+
+} // namespace traits
+
+namespace algorithm {
+
 // --- generic algorithm traits ---
 
 enum class traversal_direction : bool { forward, backward };
@@ -95,6 +113,5 @@ struct traversal_policy<H, traversal_direction::backward> {
     }
 };
 
-} // namespace hgl::algorithm
-
-// TODO! Validate `const Callback&` vs `Callback&&` in alg templates
+} // namespace algorithm
+} // namespace hgl

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -62,7 +62,7 @@ struct traversal_policy;
 
 template <hgl::traits::c_undirected_hypergraph H>
 struct traversal_policy<H> {
-    static auto out_hyperedges(const H& h, typename H::id_type v_id) {
+    static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.incident_hyperedge_ids(v_id);
     }
 
@@ -73,7 +73,7 @@ struct traversal_policy<H> {
 
 template <hgl::traits::c_bf_directed_hypergraph H>
 struct traversal_policy<H> {
-    static auto out_hyperedges(const H& h, typename H::id_type v_id) {
+    static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.out_hyperedge_ids(v_id);
     }
 

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -30,3 +30,5 @@ using gl::algorithm::no_root_v;
 using gl::algorithm::is_reachable;
 
 } // namespace hgl::algorithm
+
+// TODO! Validate `const Callback&` vs `Callback&&` in alg templates

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -57,11 +57,13 @@ using search_tree = std::vector<search_node<H>>;
 
 // --- generic algorithm traits ---
 
-template <hgl::traits::c_hypergraph H>
+enum class traversal_direction : bool { forward, backward };
+
+template <hgl::traits::c_hypergraph H, traversal_direction Dir = traversal_direction::forward>
 struct traversal_policy;
 
-template <hgl::traits::c_undirected_hypergraph H>
-struct traversal_policy<H> {
+template <hgl::traits::c_undirected_hypergraph H, traversal_direction Dir>
+struct traversal_policy<H, Dir> {
     static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.incident_hyperedge_ids(v_id);
     }
@@ -72,13 +74,24 @@ struct traversal_policy<H> {
 };
 
 template <hgl::traits::c_bf_directed_hypergraph H>
-struct traversal_policy<H> {
+struct traversal_policy<H, traversal_direction::forward> {
     static auto target_hyperedges(const H& h, typename H::id_type v_id) {
-        return h.out_hyperedge_ids(v_id);
+        return h.out_hyperedge_ids(v_id); // forward star
     }
 
     static auto target_vertices(const H& h, typename H::id_type he_id) {
         return h.head_vertex_ids(he_id);
+    }
+};
+
+template <hgl::traits::c_bf_directed_hypergraph H>
+struct traversal_policy<H, traversal_direction::backward> {
+    static auto target_hyperedges(const H& h, typename H::id_type v_id) {
+        return h.in_hyperedge_ids(v_id); // backward star
+    }
+
+    static auto target_vertices(const H& h, typename H::id_type he_id) {
+        return h.tail_vertex_ids(he_id);
     }
 };
 

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "gl/algorithm/core.hpp"
+#include "gl/algorithm/traits.hpp"
+#include "gl/algorithm/util.hpp"
+#include "hgl/traits.hpp"
+#include "hgl/types.hpp"
+
+namespace hgl::algorithm {
+
+// -- core ---
+
+using gl::algorithm::decision;
+using gl::algorithm::result_discriminator;
+
+using gl::algorithm::empty_callback;
+using gl::algorithm::non_void_return_type;
+using gl::algorithm::return_type;
+
+using gl::algorithm::no_root;
+using gl::algorithm::no_root_t;
+using gl::algorithm::no_root_v;
+
+// --- util ---
+
+using gl::algorithm::is_reachable;
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -57,7 +57,7 @@ struct search_node {
     id_type hyperedge_id = invalid_id;
 };
 
-template <hgl::traits::c_hypergraph H>
+template <traits::c_hypergraph H>
 using search_tree = std::vector<search_node<H>>;
 
 } // namespace algorithm
@@ -77,10 +77,10 @@ namespace algorithm {
 
 enum class traversal_direction : bool { forward, backward };
 
-template <hgl::traits::c_hypergraph H, traversal_direction Dir = traversal_direction::forward>
+template <traits::c_hypergraph H, traversal_direction Dir>
 struct traversal_policy;
 
-template <hgl::traits::c_undirected_hypergraph H, traversal_direction Dir>
+template <traits::c_undirected_hypergraph H, traversal_direction Dir>
 struct traversal_policy<H, Dir> {
     static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.incident_hyperedge_ids(v_id);
@@ -91,7 +91,7 @@ struct traversal_policy<H, Dir> {
     }
 };
 
-template <hgl::traits::c_bf_directed_hypergraph H>
+template <traits::c_bf_directed_hypergraph H>
 struct traversal_policy<H, traversal_direction::forward> {
     static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.out_hyperedge_ids(v_id); // forward star
@@ -102,7 +102,7 @@ struct traversal_policy<H, traversal_direction::forward> {
     }
 };
 
-template <hgl::traits::c_bf_directed_hypergraph H>
+template <traits::c_bf_directed_hypergraph H>
 struct traversal_policy<H, traversal_direction::backward> {
     static auto target_hyperedges(const H& h, typename H::id_type v_id) {
         return h.in_hyperedge_ids(v_id); // backward star

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -31,9 +31,9 @@ using gl::algorithm::no_root_v;
 
 // --- traversal types ---
 
-template <traits::c_hypergraph HypergraphType>
+template <traits::c_hypergraph H>
 struct search_node {
-    using id_type = typename HypergraphType::id_type;
+    using id_type = typename H::id_type;
 
     search_node() = default;
 
@@ -52,32 +52,32 @@ struct search_node {
     id_type hyperedge_id = invalid_id;
 };
 
-template <hgl::traits::c_hypergraph HypergraphType>
-using search_tree = std::vector<search_node<HypergraphType>>;
+template <hgl::traits::c_hypergraph H>
+using search_tree = std::vector<search_node<H>>;
 
 // --- generic algorithm traits ---
 
-template <hgl::traits::c_hypergraph HypergraphType>
-struct traversal_traits;
+template <hgl::traits::c_hypergraph H>
+struct traversal_policy;
 
-template <hgl::traits::c_undirected_hypergraph HypergraphType>
-struct traversal_traits<HypergraphType> {
-    static auto out_hyperedges(const HypergraphType& h, typename HypergraphType::id_type v_id) {
+template <hgl::traits::c_undirected_hypergraph H>
+struct traversal_policy<H> {
+    static auto out_hyperedges(const H& h, typename H::id_type v_id) {
         return h.incident_hyperedge_ids(v_id);
     }
 
-    static auto target_vertices(const HypergraphType& h, typename HypergraphType::id_type he_id) {
+    static auto target_vertices(const H& h, typename H::id_type he_id) {
         return h.incident_vertex_ids(he_id);
     }
 };
 
-template <hgl::traits::c_bf_directed_hypergraph HypergraphType>
-struct traversal_traits<HypergraphType> {
-    static auto out_hyperedges(const HypergraphType& h, typename HypergraphType::id_type v_id) {
+template <hgl::traits::c_bf_directed_hypergraph H>
+struct traversal_policy<H> {
+    static auto out_hyperedges(const H& h, typename H::id_type v_id) {
         return h.out_hyperedge_ids(v_id);
     }
 
-    static auto target_vertices(const HypergraphType& h, typename HypergraphType::id_type he_id) {
+    static auto target_vertices(const H& h, typename H::id_type he_id) {
         return h.head_vertex_ids(he_id);
     }
 };

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -15,11 +15,13 @@ namespace hgl::algorithm {
 
 // -- GL core ---
 
+using gl::algorithm::empty_callback;
+
 using gl::algorithm::decision;
+
 using gl::algorithm::result_discriminator;
 using enum result_discriminator;
 
-using gl::algorithm::empty_callback;
 using gl::algorithm::non_void_return_type;
 using gl::algorithm::return_type;
 
@@ -27,25 +29,31 @@ using gl::algorithm::no_root;
 using gl::algorithm::no_root_t;
 using gl::algorithm::no_root_v;
 
-// --- basic types ---
+// --- traversal types ---
 
 template <traits::c_hypergraph HypergraphType>
-struct traversal_context {
+struct search_node {
     using id_type = typename HypergraphType::id_type;
 
-    traversal_context(id_type id) : id(id), pred_id(id), hyperedge_id(invalid_id) {}
+    search_node() = default;
 
-    traversal_context(id_type id, id_type pred_id, id_type hyperedge_id)
-    : id(id), pred_id(pred_id), hyperedge_id(hyperedge_id) {}
+    search_node(id_type vertex_id)
+    : vertex_id(vertex_id), pred_id(vertex_id), hyperedge_id(invalid_id) {}
 
-    // if id == pred_id and hyperedge_id is invalid then id is the id of the root vertex
-    id_type id;
-    id_type pred_id;
-    id_type hyperedge_id;
+    search_node(id_type vertex_id, id_type pred_id, id_type hyperedge_id)
+    : vertex_id(vertex_id), pred_id(pred_id), hyperedge_id(hyperedge_id) {}
+
+    [[nodiscard]] gl_attr_force_inline bool is_root() const noexcept {
+        return this->vertex_id != invalid_id and this->vertex_id == this->pred_id;
+    }
+
+    id_type vertex_id = invalid_id;
+    id_type pred_id = invalid_id;
+    id_type hyperedge_id = invalid_id;
 };
 
 template <hgl::traits::c_hypergraph HypergraphType>
-using predecessors_map = std::vector<traversal_context<HypergraphType>>;
+using search_tree = std::vector<search_node<HypergraphType>>;
 
 // --- generic algorithm traits ---
 

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -7,15 +7,17 @@
 #include "gl/algorithm/core.hpp"
 #include "gl/algorithm/traits.hpp"
 #include "gl/algorithm/util.hpp"
+#include "hgl/hypergraph.hpp"
 #include "hgl/traits.hpp"
 #include "hgl/types.hpp"
 
 namespace hgl::algorithm {
 
-// -- core ---
+// -- GL core ---
 
 using gl::algorithm::decision;
 using gl::algorithm::result_discriminator;
+using enum result_discriminator;
 
 using gl::algorithm::empty_callback;
 using gl::algorithm::non_void_return_type;
@@ -25,9 +27,52 @@ using gl::algorithm::no_root;
 using gl::algorithm::no_root_t;
 using gl::algorithm::no_root_v;
 
-// --- util ---
+// --- basic types ---
 
-using gl::algorithm::is_reachable;
+template <traits::c_hypergraph HypergraphType>
+struct traversal_context {
+    using id_type = typename HypergraphType::id_type;
+
+    traversal_context(id_type id) : id(id), pred_id(id), hyperedge_id(invalid_id) {}
+
+    traversal_context(id_type id, id_type pred_id, id_type hyperedge_id)
+    : id(id), pred_id(pred_id), hyperedge_id(hyperedge_id) {}
+
+    // if id == pred_id and hyperedge_id is invalid then id is the id of the root vertex
+    id_type id;
+    id_type pred_id;
+    id_type hyperedge_id;
+};
+
+template <hgl::traits::c_hypergraph HypergraphType>
+using predecessors_map = std::vector<traversal_context<HypergraphType>>;
+
+// --- generic algorithm traits ---
+
+template <hgl::traits::c_hypergraph HypergraphType>
+struct traversal_traits;
+
+template <hgl::traits::c_undirected_hypergraph HypergraphType>
+struct traversal_traits<HypergraphType> {
+    static auto out_hyperedges(const HypergraphType& h, typename HypergraphType::id_type v_id) {
+        return h.incident_hyperedge_ids(v_id);
+    }
+
+    static auto target_vertices(const HypergraphType& h, typename HypergraphType::id_type he_id) {
+        return h.incident_vertex_ids(he_id);
+    }
+};
+
+template <hgl::traits::c_bf_directed_hypergraph HypergraphType>
+struct traversal_traits<HypergraphType> {
+    static auto out_hyperedges(const HypergraphType& h, typename HypergraphType::id_type v_id) {
+        return h.out_hyperedge_ids(v_id);
+    }
+
+    static auto target_vertices(const HypergraphType& h, typename HypergraphType::id_type he_id) {
+        return h.head_vertex_ids(he_id);
+    }
+};
 
 } // namespace hgl::algorithm
 

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -11,24 +11,17 @@
 namespace hgl::algorithm {
 
 template <
-    hgl::traits::c_hypergraph HypergraphType,
-    gl::traits::c_forward_range_of<traversal_context<HypergraphType>> InitQueueRangeType =
-        std::vector<traversal_context<HypergraphType>>,
-    gl::traits::c_optional_predicate<const traversal_context<HypergraphType>&>
-        VisitVertexPredicate = gl::algorithm::empty_callback,
-    gl::traits::c_optional_predicate<const traversal_context<HypergraphType>&> VisitCallback =
-        gl::algorithm::empty_callback,
-    gl::traits::c_optional_decision_predicate<
-        typename HypergraphType::id_type,
-        typename HypergraphType::id_type> TraverseHyperedgePred = gl::algorithm::empty_callback,
-    gl::traits::c_decision_predicate<const traversal_context<HypergraphType>&> EnqueueVertexPred =
-        gl::algorithm::empty_callback,
-    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
-        PreVisitCallback = gl::algorithm::empty_callback,
-    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
-        PostVisitCallback = gl::algorithm::empty_callback>
+    hgl::traits::c_hypergraph H,
+    traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
+    traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
+    traits::c_optional_predicate<const search_node<H>&> VisitCallback = empty_callback,
+    traits::c_optional_decision_predicate<typename H::id_type, typename H::id_type>
+        TraverseHyperedgePred = empty_callback,
+    traits::c_decision_predicate<const search_node<H>&> EnqueueVertexPred = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 bool bfs(
-    const HypergraphType& hypergraph,
+    const H& hypergraph,
     const InitQueueRangeType& initial_queue_content,
     const VisitVertexPredicate& visit_vertex_pred = {},
     const VisitCallback& visit = {},
@@ -37,56 +30,55 @@ bool bfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using router = traversal_traits<HypergraphType>;
-    using ctx_queue_type = std::queue<traversal_context<HypergraphType>>;
+    using router = traversal_traits<H>;
 
     if (std::ranges::empty(initial_queue_content))
         return false;
 
-    ctx_queue_type ctx_queue;
+    std::queue<search_node<H>> q;
 
     for (const auto& ctx : initial_queue_content)
-        ctx_queue.push(ctx);
+        q.push(ctx);
 
-    while (not ctx_queue.empty()) {
-        const traversal_context current_ctx = ctx_queue.front();
-        ctx_queue.pop();
+    while (not q.empty()) {
+        const search_node curr_node = q.front();
+        q.pop();
 
-        if constexpr (not gl::traits::c_empty_callback<VisitVertexPredicate>)
-            if (not visit_vertex_pred(current_ctx))
+        if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
+            if (not visit_vertex_pred(curr_node))
                 continue;
 
-        if constexpr (not gl::traits::c_empty_callback<PreVisitCallback>)
-            pre_visit(current_ctx);
+        if constexpr (not traits::c_empty_callback<PreVisitCallback>)
+            pre_visit(curr_node);
 
-        if constexpr (not gl::traits::c_empty_callback<VisitCallback>)
-            if (not visit(current_ctx))
+        if constexpr (not traits::c_empty_callback<VisitCallback>)
+            if (not visit(curr_node))
                 return false;
 
-        for (const auto he_id : router::out_hyperedges(hypergraph, current_ctx.id)) {
-            if constexpr (not gl::traits::c_empty_callback<TraverseHyperedgePred>) {
-                const auto traverse = traverse_he_pred(he_id, current_ctx.id);
-                if (traverse == gl::algorithm::decision::abort)
+        for (const auto he_id : router::out_hyperedges(hypergraph, curr_node.vertex_id)) {
+            if constexpr (not traits::c_empty_callback<TraverseHyperedgePred>) {
+                const auto traverse = traverse_he_pred(he_id, curr_node.vertex_id);
+                if (traverse == decision::abort)
                     return false;
-                if (traverse == gl::algorithm::decision::reject)
+                if (traverse == decision::reject)
                     continue;
             }
 
             for (const auto target_id : router::target_vertices(hypergraph, he_id)) {
-                if (target_id == current_ctx.id)
+                if (target_id == curr_node.vertex_id)
                     continue; // Skip the source vertex
 
-                traversal_context<HypergraphType> target_ctx{target_id, current_ctx.id, he_id};
-                const auto enqueue = enqueue_vertex_pred(target_ctx);
-                if (enqueue == gl::algorithm::decision::abort)
+                search_node<H> tgt_node{target_id, curr_node.vertex_id, he_id};
+                const auto enqueue = enqueue_vertex_pred(tgt_node);
+                if (enqueue == decision::abort)
                     return false;
                 if (enqueue)
-                    ctx_queue.push(target_ctx);
+                    q.push(tgt_node);
             }
         }
 
-        if constexpr (not gl::traits::c_empty_callback<PostVisitCallback>)
-            post_visit(current_ctx);
+        if constexpr (not traits::c_empty_callback<PostVisitCallback>)
+            post_visit(curr_node);
     }
 
     return true;

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -5,12 +5,91 @@
 #pragma once
 
 #include "hgl/algorithm/core.hpp"
-#include "hgl/hypergraph.hpp"
 
-#include <stack>
+#include <queue>
 
 namespace hgl::algorithm {
 
-// TODO, bfs
+template <
+    hgl::traits::c_hypergraph HypergraphType,
+    gl::traits::c_forward_range_of<traversal_context<HypergraphType>> InitQueueRangeType =
+        std::vector<traversal_context<HypergraphType>>,
+    gl::traits::c_optional_predicate<const traversal_context<HypergraphType>&>
+        VisitVertexPredicate = gl::algorithm::empty_callback,
+    gl::traits::c_optional_predicate<const traversal_context<HypergraphType>&> VisitCallback =
+        gl::algorithm::empty_callback,
+    gl::traits::c_optional_decision_predicate<
+        typename HypergraphType::id_type,
+        typename HypergraphType::id_type> TraverseHyperedgePred = gl::algorithm::empty_callback,
+    gl::traits::c_decision_predicate<const traversal_context<HypergraphType>&> EnqueueVertexPred =
+        gl::algorithm::empty_callback,
+    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
+        PreVisitCallback = gl::algorithm::empty_callback,
+    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
+        PostVisitCallback = gl::algorithm::empty_callback>
+bool bfs(
+    const HypergraphType& hypergraph,
+    const InitQueueRangeType& initial_queue_content,
+    const VisitVertexPredicate& visit_vertex_pred = {},
+    const VisitCallback& visit = {},
+    const TraverseHyperedgePred& traverse_he_pred = {},
+    const EnqueueVertexPred& enqueue_vertex_pred = {},
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using router = traversal_traits<HypergraphType>;
+    using ctx_queue_type = std::queue<traversal_context<HypergraphType>>;
+
+    if (std::ranges::empty(initial_queue_content))
+        return false;
+
+    ctx_queue_type ctx_queue;
+
+    for (const auto& ctx : initial_queue_content)
+        ctx_queue.push(ctx);
+
+    while (not ctx_queue.empty()) {
+        const traversal_context current_ctx = ctx_queue.front();
+        ctx_queue.pop();
+
+        if constexpr (not gl::traits::c_empty_callback<VisitVertexPredicate>)
+            if (not visit_vertex_pred(current_ctx))
+                continue;
+
+        if constexpr (not gl::traits::c_empty_callback<PreVisitCallback>)
+            pre_visit(current_ctx);
+
+        if constexpr (not gl::traits::c_empty_callback<VisitCallback>)
+            if (not visit(current_ctx))
+                return false;
+
+        for (const auto he_id : router::out_hyperedges(hypergraph, current_ctx.id)) {
+            if constexpr (not gl::traits::c_empty_callback<TraverseHyperedgePred>) {
+                const auto traverse = traverse_he_pred(he_id, current_ctx.id);
+                if (traverse == gl::algorithm::decision::abort)
+                    return false;
+                if (traverse == gl::algorithm::decision::reject)
+                    continue;
+            }
+
+            for (const auto target_id : router::target_vertices(hypergraph, he_id)) {
+                if (target_id == current_ctx.id)
+                    continue; // Skip the source vertex
+
+                traversal_context<HypergraphType> target_ctx{target_id, current_ctx.id, he_id};
+                const auto enqueue = enqueue_vertex_pred(target_ctx);
+                if (enqueue == gl::algorithm::decision::abort)
+                    return false;
+                if (enqueue)
+                    ctx_queue.push(target_ctx);
+            }
+        }
+
+        if constexpr (not gl::traits::c_empty_callback<PostVisitCallback>)
+            post_visit(current_ctx);
+    }
+
+    return true;
+}
 
 } // namespace hgl::algorithm

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -12,7 +12,7 @@ namespace hgl::algorithm {
 
 template <
     traversal_direction Dir = traversal_direction::forward,
-    hgl::traits::c_hypergraph H,
+    traits::c_hypergraph H,
     traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
     traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
     traits::c_optional_predicate<const search_node<H>&> VisitCallback = empty_callback,
@@ -66,7 +66,7 @@ bool bfs(
 
             for (const auto target_id : policy::target_vertices(hypergraph, he_id)) {
                 if (target_id == curr_node.vertex_id)
-                    continue; // Skip the source vertex
+                    continue;
 
                 search_node<H> tgt_node{target_id, curr_node.vertex_id, he_id};
                 const auto enqueue = enqueue_vertex_pred(tgt_node);

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -30,15 +30,14 @@ bool bfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using router = traversal_traits<H>;
+    using policy = traversal_policy<H>;
 
     if (std::ranges::empty(initial_queue_content))
         return false;
 
     std::queue<search_node<H>> q;
-
-    for (const auto& ctx : initial_queue_content)
-        q.push(ctx);
+    for (const auto& node : initial_queue_content)
+        q.push(node);
 
     while (not q.empty()) {
         const search_node curr_node = q.front();
@@ -55,7 +54,7 @@ bool bfs(
             if (not visit(curr_node))
                 return false;
 
-        for (const auto he_id : router::out_hyperedges(hypergraph, curr_node.vertex_id)) {
+        for (const auto he_id : policy::out_hyperedges(hypergraph, curr_node.vertex_id)) {
             if constexpr (not traits::c_empty_callback<TraverseHyperedgePred>) {
                 const auto traverse = traverse_he_pred(he_id, curr_node.vertex_id);
                 if (traverse == decision::abort)
@@ -64,7 +63,7 @@ bool bfs(
                     continue;
             }
 
-            for (const auto target_id : router::target_vertices(hypergraph, he_id)) {
+            for (const auto target_id : policy::target_vertices(hypergraph, he_id)) {
                 if (target_id == curr_node.vertex_id)
                     continue; // Skip the source vertex
 

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/hypergraph.hpp"
+
+#include <stack>
+
+namespace hgl::algorithm {
+
+// TODO, bfs
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -54,7 +54,7 @@ bool bfs(
             if (not visit(curr_node))
                 return false;
 
-        for (const auto he_id : policy::out_hyperedges(hypergraph, curr_node.vertex_id)) {
+        for (const auto he_id : policy::target_hyperedges(hypergraph, curr_node.vertex_id)) {
             if constexpr (not traits::c_empty_callback<TraverseHyperedgePred>) {
                 const auto traverse = traverse_he_pred(he_id, curr_node.vertex_id);
                 if (traverse == decision::abort)

--- a/include/hgl/algorithm/templates/bfs.hpp
+++ b/include/hgl/algorithm/templates/bfs.hpp
@@ -11,6 +11,7 @@
 namespace hgl::algorithm {
 
 template <
+    traversal_direction Dir = traversal_direction::forward,
     hgl::traits::c_hypergraph H,
     traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
     traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
@@ -30,7 +31,7 @@ bool bfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using policy = traversal_policy<H>;
+    using policy = traversal_policy<H, Dir>;
 
     if (std::ranges::empty(initial_queue_content))
         return false;

--- a/include/hgl/algorithm/templates/dfs.hpp
+++ b/include/hgl/algorithm/templates/dfs.hpp
@@ -12,7 +12,7 @@ namespace hgl::algorithm {
 
 template <
     traversal_direction Dir = traversal_direction::forward,
-    hgl::traits::c_hypergraph H,
+    traits::c_hypergraph H,
     traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
     traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
     traits::c_optional_predicate<const search_node<H>&> VisitCallback = empty_callback,
@@ -66,7 +66,7 @@ bool dfs(
 
             for (const auto target_id : policy::target_vertices(hypergraph, he_id)) {
                 if (target_id == curr_node.vertex_id)
-                    continue; // Skip the source vertex
+                    continue;
 
                 search_node<H> tgt_node{target_id, curr_node.vertex_id, he_id};
                 const auto enqueue = enqueue_vertex_pred(tgt_node);

--- a/include/hgl/algorithm/templates/dfs.hpp
+++ b/include/hgl/algorithm/templates/dfs.hpp
@@ -5,12 +5,82 @@
 #pragma once
 
 #include "hgl/algorithm/core.hpp"
-#include "hgl/hypergraph.hpp"
 
 #include <stack>
 
 namespace hgl::algorithm {
 
-// TODO, dfs, r_dfs
+template <
+    hgl::traits::c_hypergraph H,
+    traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
+    traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
+    traits::c_optional_predicate<const search_node<H>&> VisitCallback = empty_callback,
+    traits::c_optional_decision_predicate<typename H::id_type, typename H::id_type>
+        TraverseHyperedgePred = empty_callback,
+    traits::c_decision_predicate<const search_node<H>&> EnqueueVertexPred = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+bool dfs(
+    const H& hypergraph,
+    const InitQueueRangeType& initial_queue_content,
+    const VisitVertexPredicate& visit_vertex_pred = {},
+    const VisitCallback& visit = {},
+    const TraverseHyperedgePred& traverse_he_pred = {},
+    const EnqueueVertexPred& enqueue_vertex_pred = {},
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using policy = traversal_policy<H>;
+
+    if (std::ranges::empty(initial_queue_content))
+        return false;
+
+    std::stack<search_node<H>> s;
+    for (const auto& node : initial_queue_content)
+        s.push(node);
+
+    while (not s.empty()) {
+        const search_node curr_node = s.top();
+        s.pop();
+
+        if constexpr (not traits::c_empty_callback<VisitVertexPredicate>)
+            if (not visit_vertex_pred(curr_node))
+                continue;
+
+        if constexpr (not traits::c_empty_callback<PreVisitCallback>)
+            pre_visit(curr_node);
+
+        if constexpr (not traits::c_empty_callback<VisitCallback>)
+            if (not visit(curr_node))
+                return false;
+
+        for (const auto he_id : policy::out_hyperedges(hypergraph, curr_node.vertex_id)) {
+            if constexpr (not traits::c_empty_callback<TraverseHyperedgePred>) {
+                const auto traverse = traverse_he_pred(he_id, curr_node.vertex_id);
+                if (traverse == decision::abort)
+                    return false;
+                if (traverse == decision::reject)
+                    continue;
+            }
+
+            for (const auto target_id : policy::target_vertices(hypergraph, he_id)) {
+                if (target_id == curr_node.vertex_id)
+                    continue; // Skip the source vertex
+
+                search_node<H> tgt_node{target_id, curr_node.vertex_id, he_id};
+                const auto enqueue = enqueue_vertex_pred(tgt_node);
+                if (enqueue == decision::abort)
+                    return false;
+                if (enqueue)
+                    s.push(tgt_node);
+            }
+        }
+
+        if constexpr (not traits::c_empty_callback<PostVisitCallback>)
+            post_visit(curr_node);
+    }
+
+    return true;
+}
 
 } // namespace hgl::algorithm

--- a/include/hgl/algorithm/templates/dfs.hpp
+++ b/include/hgl/algorithm/templates/dfs.hpp
@@ -54,7 +54,7 @@ bool dfs(
             if (not visit(curr_node))
                 return false;
 
-        for (const auto he_id : policy::out_hyperedges(hypergraph, curr_node.vertex_id)) {
+        for (const auto he_id : policy::target_hyperedges(hypergraph, curr_node.vertex_id)) {
             if constexpr (not traits::c_empty_callback<TraverseHyperedgePred>) {
                 const auto traverse = traverse_he_pred(he_id, curr_node.vertex_id);
                 if (traverse == decision::abort)

--- a/include/hgl/algorithm/templates/dfs.hpp
+++ b/include/hgl/algorithm/templates/dfs.hpp
@@ -11,6 +11,7 @@
 namespace hgl::algorithm {
 
 template <
+    traversal_direction Dir = traversal_direction::forward,
     hgl::traits::c_hypergraph H,
     traits::c_forward_range_of<search_node<H>> InitQueueRangeType = std::vector<search_node<H>>,
     traits::c_optional_predicate<const search_node<H>&> VisitVertexPredicate = empty_callback,
@@ -30,7 +31,7 @@ bool dfs(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    using policy = traversal_policy<H>;
+    using policy = traversal_policy<H, Dir>;
 
     if (std::ranges::empty(initial_queue_content))
         return false;

--- a/include/hgl/algorithm/templates/dfs.hpp
+++ b/include/hgl/algorithm/templates/dfs.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/hypergraph.hpp"
+
+#include <stack>
+
+namespace hgl::algorithm {
+
+// TODO, dfs, r_dfs
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/traversal/backward_search.hpp
+++ b/include/hgl/algorithm/traversal/backward_search.hpp
@@ -14,10 +14,10 @@ namespace hgl::algorithm {
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_bf_directed_hypergraph H,
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> backward_bfs(
     const H& hypergraph,
     const RootRange& root_vertices,
@@ -34,10 +34,6 @@ return_type<Result, search_tree<H>> backward_bfs(
         root_vertices
         | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
 
-    const auto traverse_hyperedge_pred = [&tail_unvisited](id_type he_id, id_type) {
-        return static_cast<decision>(--tail_unvisited[gl::to_idx(he_id)] == 0uz);
-    };
-
     // clang-format off
 
     bfs<traversal_direction::forward>(
@@ -45,7 +41,7 @@ return_type<Result, search_tree<H>> backward_bfs(
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),
         default_visit_callback<H, Result>(visited_vertices, stree),
-        traverse_hyperedge_pred,
+        blocking_traverse_hyperedge_predicate(tail_unvisited),
         default_enqueue_vertex_predicate<H, true>(visited_vertices),
         pre_visit,
         post_visit
@@ -59,10 +55,10 @@ return_type<Result, search_tree<H>> backward_bfs(
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_bf_directed_hypergraph H,
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> backward_dfs(
     const H& hypergraph,
     const RootRange& root_vertices,
@@ -79,10 +75,6 @@ return_type<Result, search_tree<H>> backward_dfs(
         root_vertices
         | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
 
-    const auto traverse_hyperedge_pred = [&tail_unvisited](id_type he_id, id_type) {
-        return static_cast<decision>(--tail_unvisited[gl::to_idx(he_id)] == 0uz);
-    };
-
     // clang-format off
 
     dfs<traversal_direction::forward>(
@@ -90,7 +82,7 @@ return_type<Result, search_tree<H>> backward_dfs(
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),
         default_visit_callback<H, Result>(visited_vertices, stree),
-        traverse_hyperedge_pred,
+        blocking_traverse_hyperedge_predicate(tail_unvisited),
         default_enqueue_vertex_predicate<H, true>(visited_vertices),
         pre_visit,
         post_visit

--- a/include/hgl/algorithm/traversal/backward_search.hpp
+++ b/include/hgl/algorithm/traversal/backward_search.hpp
@@ -6,6 +6,7 @@
 
 #include "hgl/algorithm/core.hpp"
 #include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/templates/dfs.hpp"
 #include "hgl/algorithm/util.hpp"
 #include "hgl/hypergraph.hpp"
 
@@ -17,7 +18,7 @@ template <
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
     gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
     gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
-return_type<Result, search_tree<H>> backward_search(
+return_type<Result, search_tree<H>> backward_bfs(
     const H& hypergraph,
     const RootRange& root_vertices,
     const PreVisitCallback& pre_visit = {},
@@ -39,7 +40,7 @@ return_type<Result, search_tree<H>> backward_search(
 
     // clang-format off
 
-    bfs(
+    bfs<traversal_direction::forward>(
         hypergraph,
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),
@@ -62,7 +63,7 @@ template <
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
     gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
     gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
-return_type<Result, search_tree<H>> forward_search(
+return_type<Result, search_tree<H>> backward_dfs(
     const H& hypergraph,
     const RootRange& root_vertices,
     const PreVisitCallback& pre_visit = {},
@@ -71,20 +72,20 @@ return_type<Result, search_tree<H>> forward_search(
     using id_type = typename H::id_type;
 
     std::vector<bool> visited_vertices(hypergraph.order(), false);
-    auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
+    auto tail_unvisited = hypergraph.tail_size_map() | std::ranges::to<std::vector>();
 
     auto stree = init_search_tree<Result>(hypergraph);
     auto root_queue =
         root_vertices
         | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
 
-    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
-        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
+    const auto traverse_hyperedge_pred = [&tail_unvisited](id_type he_id, id_type) {
+        return static_cast<decision>(--tail_unvisited[gl::to_idx(he_id)] == 0uz);
     };
 
     // clang-format off
 
-    bfs<traversal_direction::backward>(
+    dfs<traversal_direction::forward>(
         hypergraph,
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),

--- a/include/hgl/algorithm/traversal/bf_search.hpp
+++ b/include/hgl/algorithm/traversal/bf_search.hpp
@@ -84,7 +84,7 @@ return_type<Result, search_tree<H>> forward_search(
 
     // clang-format off
 
-    bfs(
+    bfs<traversal_direction::backward>(
         hypergraph,
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),

--- a/include/hgl/algorithm/traversal/bf_search.hpp
+++ b/include/hgl/algorithm/traversal/bf_search.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/util.hpp"
+#include "hgl/hypergraph.hpp"
+
+namespace hgl::algorithm {
+
+template <
+    result_discriminator Result = ret,
+    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+return_type<Result, search_tree<H>> backward_search(
+    const H& hypergraph,
+    const RootRange& root_vertices,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using id_type = typename H::id_type;
+
+    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    auto tail_unvisited = hypergraph.tail_size_map() | std::ranges::to<std::vector>();
+
+    auto stree = init_search_tree<Result>(hypergraph);
+    auto root_queue =
+        root_vertices
+        | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
+
+    const auto traverse_hyperedge_pred = [&tail_unvisited](id_type he_id, id_type) {
+        return static_cast<decision>(--tail_unvisited[gl::to_idx(he_id)] == 0uz);
+    };
+
+    // clang-format off
+
+    bfs(
+        hypergraph,
+        root_queue,
+        default_visit_vertex_predicate<H>(visited_vertices),
+        default_visit_callback<H, Result>(visited_vertices, stree),
+        traverse_hyperedge_pred,
+        default_enqueue_vertex_predicate<H, true>(visited_vertices),
+        pre_visit,
+        post_visit
+    );
+
+    // clang-format on
+
+    if constexpr (Result == ret)
+        return stree;
+}
+
+template <
+    result_discriminator Result = ret,
+    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+return_type<Result, search_tree<H>> forward_search(
+    const H& hypergraph,
+    const RootRange& root_vertices,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using id_type = typename H::id_type;
+
+    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
+
+    auto stree = init_search_tree<Result>(hypergraph);
+    auto root_queue =
+        root_vertices
+        | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
+
+    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
+        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
+    };
+
+    // clang-format off
+
+    bfs(
+        hypergraph,
+        root_queue,
+        default_visit_vertex_predicate<H>(visited_vertices),
+        default_visit_callback<H, Result>(visited_vertices, stree),
+        traverse_hyperedge_pred,
+        default_enqueue_vertex_predicate<H, true>(visited_vertices),
+        pre_visit,
+        post_visit
+    );
+
+    // clang-format on
+
+    if constexpr (Result == ret)
+        return stree;
+}
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/breadth_first_search.hpp
@@ -23,11 +23,10 @@ return_type<ResultDiscriminator, search_tree<HypergraphType>> breadth_first_sear
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    // Two state vectors required for efficient hypergraph traversal
     std::vector<bool> visited_vertices(hypergraph.order(), false);
     std::vector<bool> visited_hyperedges(hypergraph.size(), false);
 
-    auto pred_map = init_predecessors_map<ResultDiscriminator>(hypergraph);
+    auto stree = init_search_tree<ResultDiscriminator>(hypergraph);
 
     // clang-format off
 
@@ -36,7 +35,7 @@ return_type<ResultDiscriminator, search_tree<HypergraphType>> breadth_first_sear
             hypergraph,
             init_range<HypergraphType>(root_vertex_id),
             default_visit_vertex_predicate<HypergraphType>(visited_vertices),
-            default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
+            default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, stree),
             default_traverse_hyperedge_predicate(visited_hyperedges),
             default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
             pre_visit,
@@ -49,7 +48,7 @@ return_type<ResultDiscriminator, search_tree<HypergraphType>> breadth_first_sear
                 hypergraph,
                 init_range<HypergraphType>(root_id),
                 default_visit_vertex_predicate<HypergraphType>(visited_vertices),
-                default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
+                default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, stree),
                 default_traverse_hyperedge_predicate(visited_hyperedges),
                 default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
                 pre_visit,
@@ -60,7 +59,7 @@ return_type<ResultDiscriminator, search_tree<HypergraphType>> breadth_first_sear
     // clang-format on
 
     if constexpr (ResultDiscriminator == ret)
-        return pred_map;
+        return stree;
 }
 
 } // namespace hgl::algorithm

--- a/include/hgl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/breadth_first_search.hpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/util.hpp"
+
+namespace hgl::algorithm {
+
+template <
+    result_discriminator ResultDiscriminator = ret,
+    hgl::traits::c_hypergraph HypergraphType,
+    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
+        PreVisitCallback = empty_callback,
+    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
+        PostVisitCallback = empty_callback>
+return_type<ResultDiscriminator, predecessors_map<HypergraphType>> breadth_first_search(
+    const HypergraphType& hypergraph,
+    const typename HypergraphType::id_type root_vertex_id = no_root,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    // Two state vectors required for efficient hypergraph traversal
+    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    std::vector<bool> visited_hyperedges(hypergraph.size(), false);
+
+    auto pred_map = init_predecessors_map<ResultDiscriminator>(hypergraph);
+
+    // clang-format off
+
+    if (root_vertex_id != no_root) {
+        bfs(
+            hypergraph,
+            init_range<HypergraphType>(root_vertex_id),
+            default_visit_vertex_predicate<HypergraphType>(visited_vertices),
+            default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
+            default_traverse_hyperedge_predicate(visited_hyperedges), // Pass the hyperedge state!
+            default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
+            pre_visit,
+            post_visit
+        );
+    }
+    else {
+        for (const auto root_id : hypergraph.vertex_ids())
+            bfs(
+                hypergraph,
+                init_range<HypergraphType>(root_id),
+                default_visit_vertex_predicate<HypergraphType>(visited_vertices),
+                default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
+                default_traverse_hyperedge_predicate(visited_hyperedges), // Pass the hyperedge state!
+                default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
+                pre_visit,
+                post_visit
+            );
+    }
+
+    // clang-format on
+
+    if constexpr (ResultDiscriminator == ret)
+        return pred_map;
+}
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/breadth_first_search.hpp
@@ -13,11 +13,11 @@ namespace hgl::algorithm {
 template <
     result_discriminator ResultDiscriminator = ret,
     hgl::traits::c_hypergraph HypergraphType,
-    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
-        PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const traversal_context<HypergraphType>&>
-        PostVisitCallback = empty_callback>
-return_type<ResultDiscriminator, predecessors_map<HypergraphType>> breadth_first_search(
+    gl::traits::c_optional_callback<void, const search_node<HypergraphType>&> PreVisitCallback =
+        empty_callback,
+    gl::traits::c_optional_callback<void, const search_node<HypergraphType>&> PostVisitCallback =
+        empty_callback>
+return_type<ResultDiscriminator, search_tree<HypergraphType>> breadth_first_search(
     const HypergraphType& hypergraph,
     const typename HypergraphType::id_type root_vertex_id = no_root,
     const PreVisitCallback& pre_visit = {},
@@ -37,7 +37,7 @@ return_type<ResultDiscriminator, predecessors_map<HypergraphType>> breadth_first
             init_range<HypergraphType>(root_vertex_id),
             default_visit_vertex_predicate<HypergraphType>(visited_vertices),
             default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
-            default_traverse_hyperedge_predicate(visited_hyperedges), // Pass the hyperedge state!
+            default_traverse_hyperedge_predicate(visited_hyperedges),
             default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
             pre_visit,
             post_visit
@@ -50,7 +50,7 @@ return_type<ResultDiscriminator, predecessors_map<HypergraphType>> breadth_first
                 init_range<HypergraphType>(root_id),
                 default_visit_vertex_predicate<HypergraphType>(visited_vertices),
                 default_visit_callback<HypergraphType, ResultDiscriminator>(visited_vertices, pred_map),
-                default_traverse_hyperedge_predicate(visited_hyperedges), // Pass the hyperedge state!
+                default_traverse_hyperedge_predicate(visited_hyperedges),
                 default_enqueue_vertex_predicate<HypergraphType, true>(visited_vertices),
                 pre_visit,
                 post_visit

--- a/include/hgl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/breadth_first_search.hpp
@@ -12,9 +12,9 @@ namespace hgl::algorithm {
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_hypergraph H,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_hypergraph H,
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> breadth_first_search(
     const H& hypergraph,
     const typename H::id_type root_vertex_id = no_root,

--- a/include/hgl/algorithm/traversal/depth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/depth_first_search.hpp
@@ -12,9 +12,9 @@ namespace hgl::algorithm {
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_hypergraph H,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_hypergraph H,
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> depth_first_search(
     const H& hypergraph,
     const typename H::id_type root_vertex_id = no_root,

--- a/include/hgl/algorithm/traversal/depth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/depth_first_search.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "hgl/algorithm/core.hpp"
-#include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/templates/dfs.hpp"
 #include "hgl/algorithm/util.hpp"
 
 namespace hgl::algorithm {
@@ -15,7 +15,7 @@ template <
     hgl::traits::c_hypergraph H,
     gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
     gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
-return_type<Result, search_tree<H>> breadth_first_search(
+return_type<Result, search_tree<H>> depth_first_search(
     const H& hypergraph,
     const typename H::id_type root_vertex_id = no_root,
     const PreVisitCallback& pre_visit = {},
@@ -29,7 +29,7 @@ return_type<Result, search_tree<H>> breadth_first_search(
     // clang-format off
 
     if (root_vertex_id != no_root) {
-        bfs(
+        dfs(
             hypergraph,
             init_range<H>(root_vertex_id),
             default_visit_vertex_predicate<H>(visited_vertices),
@@ -42,7 +42,7 @@ return_type<Result, search_tree<H>> breadth_first_search(
     }
     else {
         for (const auto root_id : hypergraph.vertex_ids())
-            bfs(
+            dfs(
                 hypergraph,
                 init_range<H>(root_id),
                 default_visit_vertex_predicate<H>(visited_vertices),

--- a/include/hgl/algorithm/traversal/forward_search.hpp
+++ b/include/hgl/algorithm/traversal/forward_search.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "hgl/algorithm/core.hpp"
+#include "hgl/algorithm/templates/bfs.hpp"
+#include "hgl/algorithm/templates/dfs.hpp"
+#include "hgl/algorithm/util.hpp"
+#include "hgl/hypergraph.hpp"
+
+namespace hgl::algorithm {
+
+template <
+    result_discriminator Result = ret,
+    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+return_type<Result, search_tree<H>> forward_bfs(
+    const H& hypergraph,
+    const RootRange& root_vertices,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using id_type = typename H::id_type;
+
+    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
+
+    auto stree = init_search_tree<Result>(hypergraph);
+    auto root_queue =
+        root_vertices
+        | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
+
+    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
+        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
+    };
+
+    // clang-format off
+
+    bfs<traversal_direction::backward>(
+        hypergraph,
+        root_queue,
+        default_visit_vertex_predicate<H>(visited_vertices),
+        default_visit_callback<H, Result>(visited_vertices, stree),
+        traverse_hyperedge_pred,
+        default_enqueue_vertex_predicate<H, true>(visited_vertices),
+        pre_visit,
+        post_visit
+    );
+
+    // clang-format on
+
+    if constexpr (Result == ret)
+        return stree;
+}
+
+template <
+    result_discriminator Result = ret,
+    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+return_type<Result, search_tree<H>> forward_dfs(
+    const H& hypergraph,
+    const RootRange& root_vertices,
+    const PreVisitCallback& pre_visit = {},
+    const PostVisitCallback& post_visit = {}
+) {
+    using id_type = typename H::id_type;
+
+    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
+
+    auto stree = init_search_tree<Result>(hypergraph);
+    auto root_queue =
+        root_vertices
+        | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
+
+    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
+        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
+    };
+
+    // clang-format off
+
+    dfs<traversal_direction::backward>(
+        hypergraph,
+        root_queue,
+        default_visit_vertex_predicate<H>(visited_vertices),
+        default_visit_callback<H, Result>(visited_vertices, stree),
+        traverse_hyperedge_pred,
+        default_enqueue_vertex_predicate<H, true>(visited_vertices),
+        pre_visit,
+        post_visit
+    );
+
+    // clang-format on
+
+    if constexpr (Result == ret)
+        return stree;
+}
+
+} // namespace hgl::algorithm

--- a/include/hgl/algorithm/traversal/forward_search.hpp
+++ b/include/hgl/algorithm/traversal/forward_search.hpp
@@ -14,10 +14,10 @@ namespace hgl::algorithm {
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_bf_directed_hypergraph H,
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> forward_bfs(
     const H& hypergraph,
     const RootRange& root_vertices,
@@ -34,10 +34,6 @@ return_type<Result, search_tree<H>> forward_bfs(
         root_vertices
         | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
 
-    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
-        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
-    };
-
     // clang-format off
 
     bfs<traversal_direction::backward>(
@@ -45,7 +41,7 @@ return_type<Result, search_tree<H>> forward_bfs(
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),
         default_visit_callback<H, Result>(visited_vertices, stree),
-        traverse_hyperedge_pred,
+        blocking_traverse_hyperedge_predicate(head_unvisited),
         default_enqueue_vertex_predicate<H, true>(visited_vertices),
         pre_visit,
         post_visit
@@ -59,10 +55,10 @@ return_type<Result, search_tree<H>> forward_bfs(
 
 template <
     result_discriminator Result = ret,
-    hgl::traits::c_bf_directed_hypergraph H,
+    traits::c_bf_directed_hypergraph H,
     traits::c_forward_range_of<typename H::id_type> RootRange = std::vector<typename H::id_type>,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
-    gl::traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
+    traits::c_optional_callback<void, const search_node<H>&> PreVisitCallback = empty_callback,
+    traits::c_optional_callback<void, const search_node<H>&> PostVisitCallback = empty_callback>
 return_type<Result, search_tree<H>> forward_dfs(
     const H& hypergraph,
     const RootRange& root_vertices,
@@ -79,10 +75,6 @@ return_type<Result, search_tree<H>> forward_dfs(
         root_vertices
         | std::views::transform([](const id_type root_id) { return search_node<H>{root_id}; });
 
-    const auto traverse_hyperedge_pred = [&head_unvisited](id_type he_id, id_type) {
-        return static_cast<decision>(--head_unvisited[gl::to_idx(he_id)] == 0uz);
-    };
-
     // clang-format off
 
     dfs<traversal_direction::backward>(
@@ -90,7 +82,7 @@ return_type<Result, search_tree<H>> forward_dfs(
         root_queue,
         default_visit_vertex_predicate<H>(visited_vertices),
         default_visit_callback<H, Result>(visited_vertices, stree),
-        traverse_hyperedge_pred,
+        blocking_traverse_hyperedge_predicate(head_unvisited),
         default_enqueue_vertex_predicate<H, true>(visited_vertices),
         pre_visit,
         post_visit

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -9,12 +9,12 @@
 
 namespace hgl::algorithm {
 
-template <result_discriminator ResultDiscriminator, traits::c_hypergraph HypergraphType>
-[[nodiscard]] gl_attr_force_inline
-    non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>
-    init_search_tree(const HypergraphType& hypergraph) {
-    using return_t = non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>;
-    if constexpr (ResultDiscriminator == ret)
+template <result_discriminator Result, traits::c_hypergraph H>
+[[nodiscard]] gl_attr_force_inline non_void_return_type<Result, search_tree<H>> init_search_tree(
+    const H& hypergraph
+) {
+    using return_t = non_void_return_type<Result, search_tree<H>>;
+    if constexpr (Result == ret)
         return return_t(hypergraph.order());
     else
         return return_t();
@@ -26,30 +26,29 @@ template <result_discriminator ResultDiscriminator, traits::c_hypergraph Hypergr
     return tree[to_idx(vertex_id)].pred_id != invalid_id;
 }
 
-template <traits::c_hypergraph HypergraphType>
-[[nodiscard]] gl_attr_force_inline std::vector<search_node<HypergraphType>> init_range(
-    typename HypergraphType::id_type root_vertex_id
+template <traits::c_hypergraph H>
+[[nodiscard]] gl_attr_force_inline std::vector<search_node<H>> init_range(
+    typename H::id_type root_vertex_id
 ) {
-    return std::vector<search_node<HypergraphType>>{search_node<HypergraphType>{root_vertex_id}};
+    return std::vector<search_node<H>>{search_node<H>{root_vertex_id}};
 }
 
-template <traits::c_hypergraph HypergraphType>
+template <traits::c_hypergraph H>
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited_v
 ) {
-    return [&](const search_node<HypergraphType>& node) -> bool {
+    return [&](const search_node<H>& node) -> bool {
         return not visited_v[to_idx(node.vertex_id)];
     };
 }
 
-template <traits::c_hypergraph HypergraphType, result_discriminator ResultDiscriminator>
+template <traits::c_hypergraph H, result_discriminator Result>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
-    std::vector<bool>& visited_v,
-    non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>& pred_map
+    std::vector<bool>& visited_v, non_void_return_type<Result, search_tree<H>>& pred_map
 ) {
-    return [&](const search_node<HypergraphType>& node) {
+    return [&](const search_node<H>& node) {
         const auto vertex_idx = to_idx(node.vertex_id);
         visited_v[vertex_idx] = true;
-        if constexpr (ResultDiscriminator == ret)
+        if constexpr (Result == ret)
             pred_map[vertex_idx] = node;
         return true;
     };
@@ -76,12 +75,12 @@ template <traits::c_hypergraph HypergraphType, result_discriminator ResultDiscri
     };
 }
 
-template <traits::c_hypergraph HypergraphType, bool AsResult = false>
+template <traits::c_hypergraph H, bool AsResult = false>
 [[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(
     std::vector<bool>& visited_v
 ) {
     using return_t = std::conditional_t<AsResult, decision, bool>;
-    return [&](const search_node<HypergraphType>& node) -> return_t {
+    return [&](const search_node<H>& node) -> return_t {
         return return_t(not visited_v[to_idx(node.vertex_id)]);
     };
 }

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -11,11 +11,11 @@ namespace hgl::algorithm {
 
 template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline
-    non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>
-    init_predecessors_map(const HypergraphType& hypergraph) {
-    using return_t = non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>;
+    non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>
+    init_search_tree(const HypergraphType& hypergraph) {
+    using return_t = non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>;
     if constexpr (ResultDiscriminator == ret)
-        return return_t(hypergraph.order(), traversal_context<HypergraphType>{no_root});
+        return return_t(hypergraph.order());
     else
         return return_t();
 }
@@ -23,32 +23,30 @@ template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph Hy
 // TODO: is_reachable
 
 template <hgl::traits::c_hypergraph HypergraphType>
-[[nodiscard]] gl_attr_force_inline std::vector<traversal_context<HypergraphType>> init_range(
+[[nodiscard]] gl_attr_force_inline std::vector<search_node<HypergraphType>> init_range(
     typename HypergraphType::id_type root_vertex_id
 ) {
-    return std::vector<traversal_context<HypergraphType>>{
-        traversal_context<HypergraphType>{root_vertex_id}
-    };
+    return std::vector<search_node<HypergraphType>>{search_node<HypergraphType>{root_vertex_id}};
 }
 
 template <hgl::traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited_v
 ) {
-    return [&](const traversal_context<HypergraphType>& ctx) -> bool {
-        return not visited_v[to_idx(ctx.id)];
+    return [&](const search_node<HypergraphType>& node) -> bool {
+        return not visited_v[to_idx(node.vertex_id)];
     };
 }
 
 template <hgl::traits::c_hypergraph HypergraphType, result_discriminator ResultDiscriminator>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
     std::vector<bool>& visited_v,
-    non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>& pred_map
+    non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>& pred_map
 ) {
-    return [&](const traversal_context<HypergraphType>& ctx) {
-        const auto vertex_idx = to_idx(ctx.id);
+    return [&](const search_node<HypergraphType>& node) {
+        const auto vertex_idx = to_idx(node.vertex_id);
         visited_v[vertex_idx] = true;
         if constexpr (ResultDiscriminator == ret)
-            pred_map[vertex_idx] = ctx;
+            pred_map[vertex_idx] = node;
         return true;
     };
 }
@@ -71,8 +69,8 @@ template <hgl::traits::c_hypergraph HypergraphType, bool AsResult = false>
     std::vector<bool>& visited_v
 ) {
     using return_t = std::conditional_t<AsResult, decision, bool>;
-    return [&](const traversal_context<HypergraphType>& ctx) -> return_t {
-        return return_t(not visited_v[gl::to_idx(ctx.id)]);
+    return [&](const search_node<HypergraphType>& node) -> return_t {
+        return return_t(not visited_v[gl::to_idx(node.id)]);
     };
 }
 

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-2026 Jakub Musiał
+// This file is part of the CPP-GL project (https://github.com/SpectraL519/cpp-gl).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "gl/algorithm/util.hpp"
+#include "hgl/algorithm/core.hpp"
+
+namespace hgl::algorithm {
+
+template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph HypergraphType>
+[[nodiscard]] gl_attr_force_inline
+    non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>
+    init_predecessors_map(const HypergraphType& hypergraph) {
+    using return_t = non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>;
+    if constexpr (ResultDiscriminator == ret)
+        return return_t(hypergraph.order(), traversal_context<HypergraphType>{no_root});
+    else
+        return return_t();
+}
+
+// TODO: is_reachable
+
+template <hgl::traits::c_hypergraph HypergraphType>
+[[nodiscard]] gl_attr_force_inline std::vector<traversal_context<HypergraphType>> init_range(
+    typename HypergraphType::id_type root_vertex_id
+) {
+    return std::vector<traversal_context<HypergraphType>>{
+        traversal_context<HypergraphType>{root_vertex_id}
+    };
+}
+
+template <hgl::traits::c_hypergraph HypergraphType>
+[[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited_v
+) {
+    return [&](const traversal_context<HypergraphType>& ctx) -> bool {
+        return not visited_v[to_idx(ctx.id)];
+    };
+}
+
+template <hgl::traits::c_hypergraph HypergraphType, result_discriminator ResultDiscriminator>
+[[nodiscard]] gl_attr_force_inline auto default_visit_callback(
+    std::vector<bool>& visited_v,
+    non_void_return_type<ResultDiscriminator, predecessors_map<HypergraphType>>& pred_map
+) {
+    return [&](const traversal_context<HypergraphType>& ctx) {
+        const auto vertex_idx = to_idx(ctx.id);
+        visited_v[vertex_idx] = true;
+        if constexpr (ResultDiscriminator == ret)
+            pred_map[vertex_idx] = ctx;
+        return true;
+    };
+}
+
+[[nodiscard]] gl_attr_force_inline auto default_traverse_hyperedge_predicate(
+    std::vector<bool>& visited_he
+) {
+    return [&](auto he_id, auto /*source_id*/) {
+        const auto he_idx = gl::to_idx(he_id);
+        if (visited_he[he_idx])
+            return decision::reject;
+
+        visited_he[he_idx] = true;
+        return decision::accept;
+    };
+}
+
+template <hgl::traits::c_hypergraph HypergraphType, bool AsResult = false>
+[[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(
+    std::vector<bool>& visited_v
+) {
+    using return_t = std::conditional_t<AsResult, decision, bool>;
+    return [&](const traversal_context<HypergraphType>& ctx) -> return_t {
+        return return_t(not visited_v[gl::to_idx(ctx.id)]);
+    };
+}
+
+} // namespace hgl::algorithm
+
+// TODO! Validate `const Callback&` vs `Callback&&` in alg templates

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -20,7 +20,11 @@ template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph Hy
         return return_t();
 }
 
-// TODO: is_reachable
+[[nodiscard]] gl_attr_force_inline bool is_reachable(
+    const traits::c_search_tree auto& tree, traits::c_id_type auto vertex_id
+) noexcept {
+    return tree[gl::to_idx(vertex_id)].pred_id != invalid_id;
+}
 
 template <hgl::traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline std::vector<search_node<HypergraphType>> init_range(

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -70,7 +70,7 @@ template <hgl::traits::c_hypergraph HypergraphType, bool AsResult = false>
 ) {
     using return_t = std::conditional_t<AsResult, decision, bool>;
     return [&](const search_node<HypergraphType>& node) -> return_t {
-        return return_t(not visited_v[gl::to_idx(node.id)]);
+        return return_t(not visited_v[gl::to_idx(node.vertex_id)]);
     };
 }
 

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -9,7 +9,7 @@
 
 namespace hgl::algorithm {
 
-template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph HypergraphType>
+template <result_discriminator ResultDiscriminator, traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline
     non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>
     init_search_tree(const HypergraphType& hypergraph) {
@@ -23,17 +23,17 @@ template <result_discriminator ResultDiscriminator, hgl::traits::c_hypergraph Hy
 [[nodiscard]] gl_attr_force_inline bool is_reachable(
     const traits::c_search_tree auto& tree, traits::c_id_type auto vertex_id
 ) noexcept {
-    return tree[gl::to_idx(vertex_id)].pred_id != invalid_id;
+    return tree[to_idx(vertex_id)].pred_id != invalid_id;
 }
 
-template <hgl::traits::c_hypergraph HypergraphType>
+template <traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline std::vector<search_node<HypergraphType>> init_range(
     typename HypergraphType::id_type root_vertex_id
 ) {
     return std::vector<search_node<HypergraphType>>{search_node<HypergraphType>{root_vertex_id}};
 }
 
-template <hgl::traits::c_hypergraph HypergraphType>
+template <traits::c_hypergraph HypergraphType>
 [[nodiscard]] gl_attr_force_inline auto default_visit_vertex_predicate(std::vector<bool>& visited_v
 ) {
     return [&](const search_node<HypergraphType>& node) -> bool {
@@ -41,7 +41,7 @@ template <hgl::traits::c_hypergraph HypergraphType>
     };
 }
 
-template <hgl::traits::c_hypergraph HypergraphType, result_discriminator ResultDiscriminator>
+template <traits::c_hypergraph HypergraphType, result_discriminator ResultDiscriminator>
 [[nodiscard]] gl_attr_force_inline auto default_visit_callback(
     std::vector<bool>& visited_v,
     non_void_return_type<ResultDiscriminator, search_tree<HypergraphType>>& pred_map
@@ -58,8 +58,8 @@ template <hgl::traits::c_hypergraph HypergraphType, result_discriminator ResultD
 [[nodiscard]] gl_attr_force_inline auto default_traverse_hyperedge_predicate(
     std::vector<bool>& visited_he
 ) {
-    return [&](auto he_id, auto /*source_id*/) {
-        const auto he_idx = gl::to_idx(he_id);
+    return [&](traits::c_id_type auto he_id, traits::c_id_type auto /*source_id*/) {
+        const auto he_idx = to_idx(he_id);
         if (visited_he[he_idx])
             return decision::reject;
 
@@ -68,16 +68,22 @@ template <hgl::traits::c_hypergraph HypergraphType, result_discriminator ResultD
     };
 }
 
-template <hgl::traits::c_hypergraph HypergraphType, bool AsResult = false>
+[[nodiscard]] gl_attr_force_inline auto blocking_traverse_hyperedge_predicate(
+    std::vector<size_type>& counter_map
+) {
+    return [&](traits::c_id_type auto he_id, traits::c_id_type auto /*source_id*/) {
+        return static_cast<decision>(--counter_map[to_idx(he_id)] == 0uz);
+    };
+}
+
+template <traits::c_hypergraph HypergraphType, bool AsResult = false>
 [[nodiscard]] gl_attr_force_inline auto default_enqueue_vertex_predicate(
     std::vector<bool>& visited_v
 ) {
     using return_t = std::conditional_t<AsResult, decision, bool>;
     return [&](const search_node<HypergraphType>& node) -> return_t {
-        return return_t(not visited_v[gl::to_idx(node.vertex_id)]);
+        return return_t(not visited_v[to_idx(node.vertex_id)]);
     };
 }
 
 } // namespace hgl::algorithm
-
-// TODO! Validate `const Callback&` vs `Callback&&` in alg templates

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -530,12 +530,16 @@ public:
         return this->out_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto out_hyperedge_ids(const id_type vertex_id) const {
+    [[nodiscard]] auto out_hyperedge_ids(const id_type vertex_id) const
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.out_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto out_hyperedge_ids(const vertex_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline auto out_hyperedge_ids(const vertex_type& vertex) const
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
         return this->out_hyperedge_ids(vertex.id());
     }
 
@@ -571,12 +575,16 @@ public:
         return this->in_hyperedges(vertex.id());
     }
 
-    [[nodiscard]] auto in_hyperedge_ids(const id_type vertex_id) const {
+    [[nodiscard]] auto in_hyperedge_ids(const id_type vertex_id) const
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.in_hyperedges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto in_hyperedge_ids(const vertex_type& vertex) const {
+    [[nodiscard]] gl_attr_force_inline auto in_hyperedge_ids(const vertex_type& vertex) const
+    requires std::same_as<directional_tag, bf_directed_t>
+    {
         return this->in_hyperedge_ids(vertex.id());
     }
 

--- a/tests/include/testing/common/io.hpp
+++ b/tests/include/testing/common/io.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "doctest.h"
+
+#include <concepts>
+#include <ranges>
+#include <sstream>
+#include <string_view>
+
+namespace doctest {
+
+template <std::ranges::input_range R>
+requires(not std::convertible_to<R, std::string_view>)
+struct StringMaker<R> {
+    static String convert(const R& rng) {
+        std::ostringstream oss;
+        oss << "[ ";
+        for (const auto& v : rng)
+            oss << v << " ";
+        oss << "]";
+        return oss.str().c_str();
+    }
+};
+
+} // namespace doctest

--- a/tests/source/hgl/test_alg_backward_search.cpp
+++ b/tests/source/hgl/test_alg_backward_search.cpp
@@ -88,7 +88,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::backward_bfs<gl::algorithm::noret>(
+    hgl::algorithm::backward_bfs<hgl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -107,7 +107,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::backward_bfs<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::backward_bfs<hgl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -248,7 +248,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::backward_dfs<gl::algorithm::noret>(
+    hgl::algorithm::backward_dfs<hgl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -267,7 +267,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::backward_dfs<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::backward_dfs<hgl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();

--- a/tests/source/hgl/test_alg_backward_search.cpp
+++ b/tests/source/hgl/test_alg_backward_search.cpp
@@ -21,10 +21,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     std::vector<id_type> root_vertices;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     /* Topology:
        V = {v0, v1, v2, v3, v4}
@@ -58,28 +58,28 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("single root v0 (immediate halt)") {
         root_vertices = {0u};
-        expected_previsit_order = {0u};
-        expected_postvisit_order = {0u};
+        expected_visit_order = {0u};
         expected_pred_map.resize(order, hgl::invalid_id);
         expected_pred_map[0uz] = 0u;
         expected_in_hyperedges.resize(order, hgl::invalid_id);
+        unreachable_vertices = {1u, 2u, 3u, 4u};
     }
 
     SUBCASE("roots v0 and v1 (complete traversal)") {
         root_vertices = {0u, 1u};
-        expected_previsit_order = {0u, 1u, 2u, 4u, 3u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 2u, 4u, 3u};
         // v0->v0(root), v1->v1(root), v1->v2 (e0), v2->v3 (e1), v2->v4 (e2)
         expected_pred_map = {0u, 1u, 1u, 2u, 1u};
         expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertices);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret search ---
 
@@ -99,8 +99,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
@@ -117,6 +117,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK_EQ(ret_pred_map, expected_pred_map);
     CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -165,10 +171,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     std::vector<id_type> root_vertices;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     /* Topology:
        V = {v0, v1, v2, v3, v4}
@@ -202,11 +208,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("single root v0 (immediate halt)") {
         root_vertices = {0u};
-        expected_previsit_order = {0u};
-        expected_postvisit_order = {0u};
+        expected_visit_order = {0u};
         expected_pred_map.resize(order, hgl::invalid_id);
         expected_pred_map[0uz] = 0u;
         expected_in_hyperedges.resize(order, hgl::invalid_id);
+        unreachable_vertices = {1u, 2u, 3u, 4u};
     }
 
     SUBCASE("roots v0 and v1 (complete traversal)") {
@@ -219,21 +225,21 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Pop v0 -> unlocks e0 -> pushes v2.
         // Pop v2 -> unlocks e1 -> pushes v3, v4(visited).
         // Pop v3 -> no outgoing.
-        expected_previsit_order = {1u, 4u, 0u, 2u, 3u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {1u, 4u, 0u, 2u, 3u};
 
-        // Notice v2's pred is v0 now! (v0 was popped after v1, unlocking e0)
         // v0->v0(root), v1->v1(root), v2->v0 (via e0), v3->v2 (via e1), v4->v1 (via e2)
         expected_pred_map = {0u, 1u, 0u, 2u, 1u};
         expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
+
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertices);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret search ---
 
@@ -253,8 +259,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
@@ -271,6 +277,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK_EQ(ret_pred_map, expected_pred_map);
     CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/hgl/test_alg_backward_search.cpp
+++ b/tests/source/hgl/test_alg_backward_search.cpp
@@ -2,19 +2,17 @@
 #include "testing/common/io.hpp"
 #include "testing/hgl/constants.hpp"
 
-#include <hgl/algorithm/traversal/bf_search.hpp>
+#include <hgl/algorithm/traversal/backward_search.hpp>
 #include <hgl/constants.hpp>
-
-#include <algorithm>
 
 namespace hgl_testing {
 
-TEST_SUITE_BEGIN("test_alg_bfs");
+TEST_SUITE_BEGIN("test_alg_backward_search");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "backward_search should properly enforce tail dependencies during traversal",
+    "backward_bfs should properly enforce tail dependencies during traversal",
     HypergraphTraitsType,
-    backward_search_directed_hypergraph_template
+    backward_bfs_directed_hypergraph_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
@@ -90,7 +88,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::backward_search<gl::algorithm::noret>(
+    hgl::algorithm::backward_bfs<gl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -109,7 +107,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::backward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::backward_bfs<gl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -122,7 +120,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    backward_search_directed_hypergraph_template,
+    backward_bfs_directed_hypergraph_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list
@@ -156,9 +154,9 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "forward_search should properly enforce head dependencies during traversal",
+    "backward_dfs should properly enforce tail dependencies during traversal",
     HypergraphTraitsType,
-    forward_search_directed_hypergraph_template
+    backward_dfs_directed_hypergraph_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
@@ -202,53 +200,32 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph.bind_tail(1uz, e2);
     hypergraph.bind_head(4uz, e2);
 
-    SUBCASE("single root v4 (partial backward traversal)") {
-        // Rooting at v4. e1 cannot be traversed backwards because it also requires v3.
-        // e2 CAN be traversed because v4 is its only head.
-        root_vertices = {4u};
-
-        expected_previsit_order = {4u, 1u};
-        expected_postvisit_order = expected_previsit_order;
-
+    SUBCASE("single root v0 (immediate halt)") {
+        root_vertices = {0u};
+        expected_previsit_order = {0u};
+        expected_postvisit_order = {0u};
         expected_pred_map.resize(order, hgl::invalid_id);
-        expected_pred_map[4uz] = 4u; // Root
-        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
-
+        expected_pred_map[0uz] = 0u;
         expected_in_hyperedges.resize(order, hgl::invalid_id);
-        expected_in_hyperedges[1uz] = e2;
     }
 
-    SUBCASE("roots v3 and v4 (complete backward traversal)") {
-        // Rooting at v3 and v4 unlocks e1, which unlocks v2, which unlocks e0, which unlocks v0 and v1.
-        root_vertices = {3u, 4u};
+    SUBCASE("roots v0 and v1 (complete traversal)") {
+        root_vertices = {0u, 1u};
 
-        // Queue trace:
-        // Init: [v3, v4]
-        // Pop v3 -> sees e1 (needs v4, so wait)
-        // Pop v4 -> sees e1 (unlocked -> enqueues v2), sees e2 (unlocked -> enqueues v1)
-        // Queue: [v2, v1]
-        // Pop v2 -> sees e0 (unlocked -> enqueues v0, v1) - v1 is already visited
-        // Queue: [v1, v0]
-        // Pop v1 -> no incoming edges
-        // Pop v0 -> no incoming edges
-        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
+        // DFS Stack Trace (LIFO):
+        // Init: [v0, v1]
+        // Pop v1 -> unlocks e2 -> pushes v4. e0 wait (needs v0).
+        // Pop v4 -> no outgoing.
+        // Pop v0 -> unlocks e0 -> pushes v2.
+        // Pop v2 -> unlocks e1 -> pushes v3, v4(visited).
+        // Pop v3 -> no outgoing.
+        expected_previsit_order = {1u, 4u, 0u, 2u, 3u};
         expected_postvisit_order = expected_previsit_order;
 
-        expected_pred_map = {
-            2u, // v0 reached backward from v2 via e0
-            4u, // v1 reached backward from v4 via e2
-            4u, // v2 reached backward from v4 via e1
-            3u, // v3 is a root
-            4u // v4 is a root
-        };
-
-        expected_in_hyperedges = {
-            e0, // v0 reached via e0
-            e2, // v1 reached via e2
-            e1, // v2 reached via e1
-            hgl::invalid_id, // v3 root
-            hgl::invalid_id // v4 root
-        };
+        // Notice v2's pred is v0 now! (v0 was popped after v1, unlocking e0)
+        // v0->v0(root), v1->v1(root), v2->v0 (via e0), v3->v2 (via e1), v4->v1 (via e2)
+        expected_pred_map = {0u, 1u, 0u, 2u, 1u};
+        expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
     }
 
     CAPTURE(hypergraph);
@@ -265,7 +242,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::forward_search<gl::algorithm::noret>(
+    hgl::algorithm::backward_dfs<gl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -284,7 +261,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::forward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::backward_dfs<gl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -297,7 +274,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    forward_search_directed_hypergraph_template,
+    backward_dfs_directed_hypergraph_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list
@@ -330,6 +307,6 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::bf_directed_t> // vertex-major flat incidence matrix
 );
 
-TEST_SUITE_END(); // test_alg_bfs
+TEST_SUITE_END(); // test_alg_backward_search
 
 } // namespace hgl_testing

--- a/tests/source/hgl/test_alg_bf_search.cpp
+++ b/tests/source/hgl/test_alg_bf_search.cpp
@@ -1,0 +1,335 @@
+#include "doctest.h"
+#include "testing/common/io.hpp"
+#include "testing/hgl/constants.hpp"
+
+#include <hgl/algorithm/traversal/bf_search.hpp>
+#include <hgl/constants.hpp>
+
+#include <algorithm>
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_alg_bfs");
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "backward_search should properly enforce tail dependencies during traversal",
+    HypergraphTraitsType,
+    backward_search_directed_hypergraph_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    std::vector<id_type> root_vertices;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
+
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
+
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v0 (immediate halt)") {
+        root_vertices = {0u};
+        expected_previsit_order = {0u};
+        expected_postvisit_order = {0u};
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[0uz] = 0u;
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
+    }
+
+    SUBCASE("roots v0 and v1 (complete traversal)") {
+        root_vertices = {0u, 1u};
+        expected_previsit_order = {0u, 1u, 2u, 4u, 3u};
+        expected_postvisit_order = expected_previsit_order;
+        // v0->v0(root), v1->v1(root), v1->v2 (e0), v2->v3 (e1), v2->v4 (e2)
+        expected_pred_map = {0u, 1u, 1u, 2u, 1u};
+        expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertices);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret search ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::backward_search<gl::algorithm::noret>(
+        hypergraph,
+        root_vertices,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK_EQ(previsit_order, expected_previsit_order);
+    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+
+    // --- ret search ---
+
+    const auto search_tree =
+        hgl::algorithm::backward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK_EQ(ret_pred_map, expected_pred_map);
+    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    backward_search_directed_hypergraph_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "forward_search should properly enforce head dependencies during traversal",
+    HypergraphTraitsType,
+    forward_search_directed_hypergraph_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    std::vector<id_type> root_vertices;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
+
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
+
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v4 (partial backward traversal)") {
+        // Rooting at v4. e1 cannot be traversed backwards because it also requires v3.
+        // e2 CAN be traversed because v4 is its only head.
+        root_vertices = {4u};
+
+        expected_previsit_order = {4u, 1u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[4uz] = 4u; // Root
+        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
+
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges[1uz] = e2;
+    }
+
+    SUBCASE("roots v3 and v4 (complete backward traversal)") {
+        // Rooting at v3 and v4 unlocks e1, which unlocks v2, which unlocks e0, which unlocks v0 and v1.
+        root_vertices = {3u, 4u};
+
+        // Queue trace:
+        // Init: [v3, v4]
+        // Pop v3 -> sees e1 (needs v4, so wait)
+        // Pop v4 -> sees e1 (unlocked -> enqueues v2), sees e2 (unlocked -> enqueues v1)
+        // Queue: [v2, v1]
+        // Pop v2 -> sees e0 (unlocked -> enqueues v0, v1) - v1 is already visited
+        // Queue: [v1, v0]
+        // Pop v1 -> no incoming edges
+        // Pop v0 -> no incoming edges
+        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map = {
+            2u, // v0 reached backward from v2 via e0
+            4u, // v1 reached backward from v4 via e2
+            4u, // v2 reached backward from v4 via e1
+            3u, // v3 is a root
+            4u // v4 is a root
+        };
+
+        expected_in_hyperedges = {
+            e0, // v0 reached via e0
+            e2, // v1 reached via e2
+            e1, // v2 reached via e1
+            hgl::invalid_id, // v3 root
+            hgl::invalid_id // v4 root
+        };
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertices);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret search ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::forward_search<gl::algorithm::noret>(
+        hypergraph,
+        root_vertices,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK_EQ(previsit_order, expected_previsit_order);
+    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+
+    // --- ret search ---
+
+    const auto search_tree =
+        hgl::algorithm::forward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK_EQ(ret_pred_map, expected_pred_map);
+    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    forward_search_directed_hypergraph_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_SUITE_END(); // test_alg_bfs
+
+} // namespace hgl_testing

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -1,9 +1,8 @@
 #include "doctest.h"
-#include "testing/common/io.hpp"
+#include "hgl/constants.hpp"
 #include "testing/hgl/constants.hpp"
 
-#include <hgl/algorithm/traversal/bf_search.hpp>
-#include <hgl/constants.hpp>
+#include <hgl/algorithm/traversal/breadth_first_search.hpp>
 
 #include <algorithm>
 
@@ -12,87 +11,147 @@ namespace hgl_testing {
 TEST_SUITE_BEGIN("test_alg_bfs");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "backward_search should properly enforce tail dependencies during traversal",
+    "breadth_first_search should properly traverse the hypergraph and yield correct search trees",
     HypergraphTraitsType,
-    backward_search_directed_hypergraph_template
+    bfs_undirected_hypergraph_traits_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
     using node_type = hgl::algorithm::search_node<hypergraph_type>;
 
     hypergraph_type hypergraph;
-    std::vector<id_type> root_vertices;
+    id_type root_vertex_id;
 
     std::vector<id_type> expected_previsit_order;
     std::vector<id_type> expected_postvisit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    // TODO: unreachable vertices
 
-    /* Topology:
-       V = {v0, v1, v2, v3, v4}
-       e0 = {v0, v1} -> {v2}
-       e1 = {v2} -> {v3, v4}
-       e2 = {v1} -> {v4}
+    SUBCASE("hub (single hyperedge)") {
+        hypergraph.add_vertices(4uz);
+        const auto e = hypergraph.add_hyperedge().id();
+        for (const auto v : hypergraph.vertex_ids())
+            hypergraph.bind(v, e);
 
-       v0                v3
-         \              /
-          -->-- v2 -->--
-         /              \
-       v1 ------->------ v4
-    */
+        root_vertex_id = hgl::initial_id;
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
-
-    const auto e0 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(0uz, e0);
-    hypergraph.bind_tail(1uz, e0);
-    hypergraph.bind_head(2uz, e0);
-
-    const auto e1 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(2uz, e1);
-    hypergraph.bind_head(3uz, e1);
-    hypergraph.bind_head(4uz, e1);
-
-    const auto e2 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(1uz, e2);
-    hypergraph.bind_head(4uz, e2);
-
-    SUBCASE("single root v0 (immediate halt)") {
-        root_vertices = {0u};
-        expected_previsit_order = {0u};
-        expected_postvisit_order = {0u};
-        expected_pred_map.resize(order, hgl::invalid_id);
-        expected_pred_map[0uz] = 0u;
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 0u};
+        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
     }
 
-    SUBCASE("roots v0 and v1 (complete traversal)") {
-        root_vertices = {0u, 1u};
-        expected_previsit_order = {0u, 1u, 2u, 4u, 3u};
+    SUBCASE("chain") {
+        // E(H) = {{0, 1}, {1, 2, 3}, {3, 4, 5}}
+        hypergraph.add_vertices(6uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u, 5u})
+            hypergraph.bind(v, e2);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_postvisit_order = expected_previsit_order;
-        // v0->v0(root), v1->v1(root), v1->v2 (e0), v2->v3 (e1), v2->v4 (e2)
-        expected_pred_map = {0u, 1u, 1u, 2u, 1u};
-        expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
+        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+    }
+
+    SUBCASE("overlapping hyperedges (shortest path preference)") {
+        // E(H) = {{0, 1}, {1, 2, 3}, {0, 3}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 3u})
+            hypergraph.bind(v, e2);
+
+        const auto e3 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e3);
+
+        root_vertex_id = hgl::initial_id;
+
+        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
+        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+    }
+
+    SUBCASE("disconnected components (targeted root)") {
+        // E(H) = {{0, 1, 2}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u, 2u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e1);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = {0u, 1u, 2u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+    }
+
+    SUBCASE("full graph traversal (no_root)") {
+        // E(H) = {{0, 1, 2}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u, 2u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e1);
+
+        root_vertex_id = gl::algorithm::no_root;
+
+        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
     }
 
     CAPTURE(hypergraph);
-    CAPTURE(root_vertices);
+    CAPTURE(root_vertex_id);
     CAPTURE(expected_previsit_order);
     CAPTURE(expected_postvisit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
 
-    // --- noret search ---
+    // --- noret bfs ---
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::backward_search<gl::algorithm::noret>(
+    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
         hypergraph,
-        root_vertices,
+        root_vertex_id,
         [&](const auto& node) {
             previsit_order.push_back(node.vertex_id);
             noret_pred_map[node.vertex_id] = node.pred_id;
@@ -101,15 +160,15 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
-    CHECK_EQ(noret_pred_map, expected_pred_map);
-    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
 
-    // --- ret search ---
+    // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::backward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -117,157 +176,194 @@ TEST_CASE_TEMPLATE_DEFINE(
         search_tree | std::views::transform(&node_type::hyperedge_id)
         | std::ranges::to<std::vector>();
 
-    CHECK_EQ(ret_pred_map, expected_pred_map);
-    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    backward_search_directed_hypergraph_template,
+    bfs_undirected_hypergraph_traits_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
-        hgl::bf_directed_t>, // bidirectional incidence list
+        hgl::undirected_t>, // bidirectional incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
-        hgl::bf_directed_t>, // hyperedge-major incidence list
+        hgl::undirected_t>, // hyperedge-major incidence list
     hgl::list_hypergraph_traits<
         hgl::impl::vertex_major_t,
-        hgl::bf_directed_t>, // vertex-major incidence list
+        hgl::undirected_t>, // vertex-major incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::bidirectional_t,
-        hgl::bf_directed_t>, // bidirectional flat incidence list
+        hgl::undirected_t>, // bidirectional flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
-        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+        hgl::undirected_t>, // hyperedge-major flat incidence list
     hgl::flat_list_hypergraph_traits<
         hgl::impl::vertex_major_t,
-        hgl::bf_directed_t>, // vertex-major flat incidence list
+        hgl::undirected_t>, // vertex-major flat incidence list
     hgl::matrix_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
-        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+        hgl::undirected_t>, // hyperedge-major incidence matrix
     hgl::matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
-        hgl::bf_directed_t>, // vertex-major incidence matrix
+        hgl::undirected_t>, // vertex-major incidence matrix
     hgl::flat_matrix_hypergraph_traits<
         hgl::impl::hyperedge_major_t,
-        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+        hgl::undirected_t>, // hyperedge-major flat incidence matrix
     hgl::flat_matrix_hypergraph_traits<
         hgl::impl::vertex_major_t,
-        hgl::bf_directed_t> // vertex-major flat incidence matrix
+        hgl::undirected_t> // vertex-major flat incidence matrix
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "forward_search should properly enforce head dependencies during traversal",
+    "breadth_first_search should properly traverse the directed hypergraph and yield correct "
+    "search trees",
     HypergraphTraitsType,
-    forward_search_directed_hypergraph_template
+    bfs_bf_directed_hypergraph_traits_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
     using node_type = hgl::algorithm::search_node<hypergraph_type>;
 
     hypergraph_type hypergraph;
-    std::vector<id_type> root_vertices;
+    id_type root_vertex_id;
 
     std::vector<id_type> expected_previsit_order;
     std::vector<id_type> expected_postvisit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
 
-    /* Topology:
-       V = {v0, v1, v2, v3, v4}
-       e0 = {v0, v1} -> {v2}
-       e1 = {v2} -> {v3, v4}
-       e2 = {v1} -> {v4}
+    SUBCASE("forward star (single hyperedge)") {
+        // E(H) = {0->{1, 2, 3}}
+        hypergraph.add_vertices(4uz);
+        const auto e = hypergraph.add_hyperedge().id();
 
-       v0                v3
-         \              /
-          -->-- v2 -->--
-         /              \
-       v1 ------->------ v4
-    */
+        hypergraph.bind_tail(0uz, e);
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind_head(v, e);
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
+        root_vertex_id = hgl::initial_id;
 
-    const auto e0 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(0uz, e0);
-    hypergraph.bind_tail(1uz, e0);
-    hypergraph.bind_head(2uz, e0);
-
-    const auto e1 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(2uz, e1);
-    hypergraph.bind_head(3uz, e1);
-    hypergraph.bind_head(4uz, e1);
-
-    const auto e2 = hypergraph.add_hyperedge().id();
-    hypergraph.bind_tail(1uz, e2);
-    hypergraph.bind_head(4uz, e2);
-
-    SUBCASE("single root v4 (partial backward traversal)") {
-        // Rooting at v4. e1 cannot be traversed backwards because it also requires v3.
-        // e2 CAN be traversed because v4 is its only head.
-        root_vertices = {4u};
-
-        expected_previsit_order = {4u, 1u};
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_postvisit_order = expected_previsit_order;
-
-        expected_pred_map.resize(order, hgl::invalid_id);
-        expected_pred_map[4uz] = 4u; // Root
-        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
-
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
-        expected_in_hyperedges[1uz] = e2;
+        expected_pred_map = {0u, 0u, 0u, 0u};
+        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
     }
 
-    SUBCASE("roots v3 and v4 (complete backward traversal)") {
-        // Rooting at v3 and v4 unlocks e1, which unlocks v2, which unlocks e0, which unlocks v0 and v1.
-        root_vertices = {3u, 4u};
+    SUBCASE("chain") {
+        // E(H) = {0->1, 1->{2, 3}, 3->{4, 5}}
+        hypergraph.add_vertices(6uz);
 
-        // Queue trace:
-        // Init: [v3, v4]
-        // Pop v3 -> sees e1 (needs v4, so wait)
-        // Pop v4 -> sees e1 (unlocked -> enqueues v2), sees e2 (unlocked -> enqueues v1)
-        // Queue: [v2, v1]
-        // Pop v2 -> sees e0 (unlocked -> enqueues v0, v1) - v1 is already visited
-        // Queue: [v1, v0]
-        // Pop v1 -> no incoming edges
-        // Pop v0 -> no incoming edges
-        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        hypergraph.bind_head(1uz, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(1uz, e1);
+        for (const id_type v : {2u, 3u})
+            hypergraph.bind_head(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e2);
+        for (const id_type v : {4u, 5u})
+            hypergraph.bind_head(v, e2);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+    }
 
-        expected_pred_map = {
-            2u, // v0 reached backward from v2 via e0
-            4u, // v1 reached backward from v4 via e2
-            4u, // v2 reached backward from v4 via e1
-            3u, // v3 is a root
-            4u // v4 is a root
-        };
+    SUBCASE("overlapping hyperedges (shortest path preference)") {
+        // E(H) = {0->1, 1->{2, 3}, 0->3 (shortcut!), 3->4}
+        hypergraph.add_vertices(5uz);
 
-        expected_in_hyperedges = {
-            e0, // v0 reached via e0
-            e2, // v1 reached via e2
-            e1, // v2 reached via e1
-            hgl::invalid_id, // v3 root
-            hgl::invalid_id // v4 root
-        };
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        hypergraph.bind_head(1uz, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(1uz, e1);
+        for (const id_type v : {2u, 3u})
+            hypergraph.bind_head(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e2);
+        hypergraph.bind_head(3uz, e2);
+
+        const auto e3 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e3);
+        hypergraph.bind_head(4uz, e3);
+
+        root_vertex_id = hgl::initial_id;
+
+        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
+        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+    }
+
+    SUBCASE("disconnected components (targeted root)") {
+        // E(H) = {0->{1, 2}, 3->4}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        for (const id_type v : {1u, 2u})
+            hypergraph.bind_head(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e1);
+        hypergraph.bind_head(4uz, e1);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = {0u, 1u, 2u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+    }
+
+    SUBCASE("full graph traversal (no_root)") {
+        // E(H) = {0->{1, 2}, 3->4}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        for (const id_type v : {1u, 2u})
+            hypergraph.bind_head(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e1);
+        hypergraph.bind_head(4uz, e1);
+
+        root_vertex_id = gl::algorithm::no_root;
+
+        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
     }
 
     CAPTURE(hypergraph);
-    CAPTURE(root_vertices);
+    CAPTURE(root_vertex_id);
     CAPTURE(expected_previsit_order);
     CAPTURE(expected_postvisit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
 
-    // --- noret search ---
+    // --- noret bfs ---
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::forward_search<gl::algorithm::noret>(
+    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
         hypergraph,
-        root_vertices,
+        root_vertex_id,
         [&](const auto& node) {
             previsit_order.push_back(node.vertex_id);
             noret_pred_map[node.vertex_id] = node.pred_id;
@@ -276,15 +372,15 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
-    CHECK_EQ(noret_pred_map, expected_pred_map);
-    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
 
-    // --- ret search ---
+    // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::forward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -292,12 +388,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         search_tree | std::views::transform(&node_type::hyperedge_id)
         | std::ranges::to<std::vector>();
 
-    CHECK_EQ(ret_pred_map, expected_pred_map);
-    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    forward_search_directed_hypergraph_template,
+    bfs_bf_directed_hypergraph_traits_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -128,7 +128,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const id_type v : {3u, 4u})
             hypergraph.bind(v, e1);
 
-        root_vertex_id = gl::algorithm::no_root;
+        root_vertex_id = hgl::algorithm::no_root;
 
         expected_visit_order = {0u, 1u, 2u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
@@ -150,7 +150,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::breadth_first_search<hgl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -169,7 +169,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::breadth_first_search<hgl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -346,7 +346,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hypergraph.bind_tail(3uz, e1);
         hypergraph.bind_head(4uz, e1);
 
-        root_vertex_id = gl::algorithm::no_root;
+        root_vertex_id = hgl::algorithm::no_root;
 
         expected_visit_order = {0u, 1u, 2u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
@@ -368,7 +368,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::breadth_first_search<hgl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -387,7 +387,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::breadth_first_search<hgl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -58,7 +58,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph.bind_tail(1uz, e2);
     hypergraph.bind_head(4uz, e2);
 
-    SUBCASE("single root v1 (incomplete traversal)") {
+    SUBCASE("single root v0 (immediate halt)") {
         root_vertices = {0u};
         expected_previsit_order = {0u};
         expected_postvisit_order = {0u};
@@ -67,7 +67,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         expected_in_hyperedges.resize(order, hgl::invalid_id);
     }
 
-    SUBCASE("roots v1 and v2 (complete traversal)") {
+    SUBCASE("roots v0 and v1 (complete traversal)") {
         root_vertices = {0u, 1u};
         expected_previsit_order = {0u, 1u, 2u, 4u, 3u};
         expected_postvisit_order = expected_previsit_order;
@@ -123,6 +123,181 @@ TEST_CASE_TEMPLATE_DEFINE(
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
     backward_search_directed_hypergraph_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "forward_search should properly enforce head dependencies during traversal",
+    HypergraphTraitsType,
+    forward_search_directed_hypergraph_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    std::vector<id_type> root_vertices;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
+
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
+
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v4 (partial backward traversal)") {
+        // Rooting at v4. e1 cannot be traversed backwards because it also requires v3.
+        // e2 CAN be traversed because v4 is its only head.
+        root_vertices = {4u};
+
+        expected_previsit_order = {4u, 1u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[4uz] = 4u; // Root
+        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
+
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges[1uz] = e2;
+    }
+
+    SUBCASE("roots v3 and v4 (complete backward traversal)") {
+        // Rooting at v3 and v4 unlocks e1, which unlocks v2, which unlocks e0, which unlocks v0 and v1.
+        root_vertices = {3u, 4u};
+
+        // Queue trace:
+        // Init: [v3, v4]
+        // Pop v3 -> sees e1 (needs v4, so wait)
+        // Pop v4 -> sees e1 (unlocked -> enqueues v2), sees e2 (unlocked -> enqueues v1)
+        // Queue: [v2, v1]
+        // Pop v2 -> sees e0 (unlocked -> enqueues v0, v1) - v1 is already visited
+        // Queue: [v1, v0]
+        // Pop v1 -> no incoming edges
+        // Pop v0 -> no incoming edges
+        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map = {
+            2u, // v0 reached backward from v2 via e0
+            4u, // v1 reached backward from v4 via e2
+            4u, // v2 reached backward from v4 via e1
+            3u, // v3 is a root
+            4u // v4 is a root
+        };
+
+        expected_in_hyperedges = {
+            e0, // v0 reached via e0
+            e2, // v1 reached via e2
+            e1, // v2 reached via e1
+            hgl::invalid_id, // v3 root
+            hgl::invalid_id // v4 root
+        };
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertices);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret search ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::forward_search<gl::algorithm::noret>(
+        hypergraph,
+        root_vertices,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK_EQ(previsit_order, expected_previsit_order);
+    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+
+    // --- ret search ---
+
+    const auto search_tree =
+        hgl::algorithm::forward_search<gl::algorithm::ret>(hypergraph, root_vertices);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK_EQ(ret_pred_map, expected_pred_map);
+    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    forward_search_directed_hypergraph_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -2,7 +2,7 @@
 #include "testing/common/io.hpp"
 #include "testing/hgl/constants.hpp"
 
-#include <hgl/algorithm/traversal/breadth_first_search.hpp>
+#include <hgl/algorithm/traversal/bf_search.hpp>
 #include <hgl/constants.hpp>
 
 #include <algorithm>
@@ -12,147 +12,87 @@ namespace hgl_testing {
 TEST_SUITE_BEGIN("test_alg_bfs");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "breadth_first_search should properly traverse the hypergraph and yield correct search trees",
+    "backward_search should properly enforce tail dependencies during traversal",
     HypergraphTraitsType,
-    bfs_undirected_hypergraph_traits_template
+    backward_search_directed_hypergraph_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
     using node_type = hgl::algorithm::search_node<hypergraph_type>;
 
     hypergraph_type hypergraph;
-    id_type root_vertex_id;
+    std::vector<id_type> root_vertices;
 
     std::vector<id_type> expected_previsit_order;
     std::vector<id_type> expected_postvisit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
-    // TODO: unreachable vertices
 
-    SUBCASE("hub (single hyperedge)") {
-        hypergraph.add_vertices(4uz);
-        const auto e = hypergraph.add_hyperedge().id();
-        for (const auto v : hypergraph.vertex_ids())
-            hypergraph.bind(v, e);
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
 
-        root_vertex_id = hgl::initial_id;
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, 0u};
-        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v1 (incomplete traversal)") {
+        root_vertices = {0u};
+        expected_previsit_order = {0u};
+        expected_postvisit_order = {0u};
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[0uz] = 0u;
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
     }
 
-    SUBCASE("chain") {
-        // E(H) = {{0, 1}, {1, 2, 3}, {3, 4, 5}}
-        hypergraph.add_vertices(6uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {0u, 1u})
-            hypergraph.bind(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {1u, 2u, 3u})
-            hypergraph.bind(v, e1);
-
-        const auto e2 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {3u, 4u, 5u})
-            hypergraph.bind(v, e2);
-
-        root_vertex_id = hgl::initial_id;
-
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+    SUBCASE("roots v1 and v2 (complete traversal)") {
+        root_vertices = {0u, 1u};
+        expected_previsit_order = {0u, 1u, 2u, 4u, 3u};
         expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
-    }
-
-    SUBCASE("overlapping hyperedges (shortest path preference)") {
-        // E(H) = {{0, 1}, {1, 2, 3}, {0, 3}, {3, 4}}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {0u, 1u})
-            hypergraph.bind(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {1u, 2u, 3u})
-            hypergraph.bind(v, e1);
-
-        const auto e2 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {0u, 3u})
-            hypergraph.bind(v, e2);
-
-        const auto e3 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {3u, 4u})
-            hypergraph.bind(v, e3);
-
-        root_vertex_id = hgl::initial_id;
-
-        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
-    }
-
-    SUBCASE("disconnected components (targeted root)") {
-        // E(H) = {{0, 1, 2}, {3, 4}}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {0u, 1u, 2u})
-            hypergraph.bind(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {3u, 4u})
-            hypergraph.bind(v, e1);
-
-        root_vertex_id = hgl::initial_id;
-
-        expected_previsit_order = {0u, 1u, 2u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
-    }
-
-    SUBCASE("full graph traversal (no_root)") {
-        // E(H) = {{0, 1, 2}, {3, 4}}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {0u, 1u, 2u})
-            hypergraph.bind(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        for (const id_type v : {3u, 4u})
-            hypergraph.bind(v, e1);
-
-        root_vertex_id = gl::algorithm::no_root;
-
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+        // v0->v0(root), v1->v1(root), v1->v2 (e0), v2->v3 (e1), v2->v4 (e2)
+        expected_pred_map = {0u, 1u, 1u, 2u, 1u};
+        expected_in_hyperedges = {hgl::invalid_id, hgl::invalid_id, e0, e1, e2};
     }
 
     CAPTURE(hypergraph);
-    CAPTURE(root_vertex_id);
+    CAPTURE(root_vertices);
     CAPTURE(expected_previsit_order);
     CAPTURE(expected_postvisit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
 
-    // --- noret bfs ---
+    // --- noret search ---
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::backward_search<gl::algorithm::noret>(
         hypergraph,
-        root_vertex_id,
+        root_vertices,
         [&](const auto& node) {
             previsit_order.push_back(node.vertex_id);
             noret_pred_map[node.vertex_id] = node.pred_id;
@@ -166,10 +106,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
-    // --- ret bfs ---
+    // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::backward_search<gl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -182,219 +122,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    bfs_undirected_hypergraph_traits_template,
-    hgl::list_hypergraph_traits<
-        hgl::impl::bidirectional_t,
-        hgl::undirected_t>, // bidirectional incidence list
-    hgl::list_hypergraph_traits<
-        hgl::impl::hyperedge_major_t,
-        hgl::undirected_t>, // hyperedge-major incidence list
-    hgl::list_hypergraph_traits<
-        hgl::impl::vertex_major_t,
-        hgl::undirected_t>, // vertex-major incidence list
-    hgl::flat_list_hypergraph_traits<
-        hgl::impl::bidirectional_t,
-        hgl::undirected_t>, // bidirectional flat incidence list
-    hgl::flat_list_hypergraph_traits<
-        hgl::impl::hyperedge_major_t,
-        hgl::undirected_t>, // hyperedge-major flat incidence list
-    hgl::flat_list_hypergraph_traits<
-        hgl::impl::vertex_major_t,
-        hgl::undirected_t>, // vertex-major flat incidence list
-    hgl::matrix_hypergraph_traits<
-        hgl::impl::hyperedge_major_t,
-        hgl::undirected_t>, // hyperedge-major incidence matrix
-    hgl::matrix_hypergraph_traits<
-        hgl::impl::vertex_major_t,
-        hgl::undirected_t>, // vertex-major incidence matrix
-    hgl::flat_matrix_hypergraph_traits<
-        hgl::impl::hyperedge_major_t,
-        hgl::undirected_t>, // hyperedge-major flat incidence matrix
-    hgl::flat_matrix_hypergraph_traits<
-        hgl::impl::vertex_major_t,
-        hgl::undirected_t> // vertex-major flat incidence matrix
-);
-
-TEST_CASE_TEMPLATE_DEFINE(
-    "breadth_first_search should properly traverse the directed hypergraph and yield correct "
-    "search trees",
-    HypergraphTraitsType,
-    bfs_bf_directed_hypergraph_traits_template
-) {
-    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
-    using id_type = typename hypergraph_type::id_type;
-    using node_type = hgl::algorithm::search_node<hypergraph_type>;
-
-    hypergraph_type hypergraph;
-    id_type root_vertex_id;
-
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
-    std::vector<id_type> expected_pred_map;
-    std::vector<id_type> expected_in_hyperedges;
-
-    SUBCASE("forward star (single hyperedge)") {
-        // E(H) = {0->{1, 2, 3}}
-        hypergraph.add_vertices(4uz);
-        const auto e = hypergraph.add_hyperedge().id();
-
-        hypergraph.bind_tail(0uz, e);
-        for (const id_type v : {1u, 2u, 3u})
-            hypergraph.bind_head(v, e);
-
-        root_vertex_id = hgl::initial_id;
-
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, 0u};
-        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
-    }
-
-    SUBCASE("chain") {
-        // E(H) = {0->1, 1->{2, 3}, 3->{4, 5}}
-        hypergraph.add_vertices(6uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(0uz, e0);
-        hypergraph.bind_head(1uz, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(1uz, e1);
-        for (const id_type v : {2u, 3u})
-            hypergraph.bind_head(v, e1);
-
-        const auto e2 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(3uz, e2);
-        for (const id_type v : {4u, 5u})
-            hypergraph.bind_head(v, e2);
-
-        root_vertex_id = hgl::initial_id;
-
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
-    }
-
-    SUBCASE("overlapping hyperedges (shortest path preference)") {
-        // E(H) = {0->1, 1->{2, 3}, 0->3 (shortcut!), 3->4}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(0uz, e0);
-        hypergraph.bind_head(1uz, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(1uz, e1);
-        for (const id_type v : {2u, 3u})
-            hypergraph.bind_head(v, e1);
-
-        const auto e2 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(0uz, e2);
-        hypergraph.bind_head(3uz, e2);
-
-        const auto e3 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(3uz, e3);
-        hypergraph.bind_head(4uz, e3);
-
-        root_vertex_id = hgl::initial_id;
-
-        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
-    }
-
-    SUBCASE("disconnected components (targeted root)") {
-        // E(H) = {0->{1, 2}, 3->4}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(0uz, e0);
-        for (const id_type v : {1u, 2u})
-            hypergraph.bind_head(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(3uz, e1);
-        hypergraph.bind_head(4uz, e1);
-
-        root_vertex_id = hgl::initial_id;
-
-        expected_previsit_order = {0u, 1u, 2u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
-    }
-
-    SUBCASE("full graph traversal (no_root)") {
-        // E(H) = {0->{1, 2}, 3->4}
-        hypergraph.add_vertices(5uz);
-
-        const auto e0 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(0uz, e0);
-        for (const id_type v : {1u, 2u})
-            hypergraph.bind_head(v, e0);
-
-        const auto e1 = hypergraph.add_hyperedge().id();
-        hypergraph.bind_tail(3uz, e1);
-        hypergraph.bind_head(4uz, e1);
-
-        root_vertex_id = gl::algorithm::no_root;
-
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
-    }
-
-    CAPTURE(hypergraph);
-    CAPTURE(root_vertex_id);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
-    CAPTURE(expected_pred_map);
-    CAPTURE(expected_in_hyperedges);
-
-    // --- noret bfs ---
-
-    std::vector<id_type> previsit_order;
-    std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
-
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
-        hypergraph,
-        root_vertex_id,
-        [&](const auto& node) {
-            previsit_order.push_back(node.vertex_id);
-            noret_pred_map[node.vertex_id] = node.pred_id;
-            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
-        },
-        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
-    );
-
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
-    CHECK_EQ(noret_pred_map, expected_pred_map);
-    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
-
-    // --- ret bfs ---
-
-    const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
-
-    const auto ret_pred_map =
-        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
-    const auto ret_in_hyperedges =
-        search_tree | std::views::transform(&node_type::hyperedge_id)
-        | std::ranges::to<std::vector>();
-
-    CHECK_EQ(ret_pred_map, expected_pred_map);
-    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
-}
-
-TEST_CASE_TEMPLATE_INSTANTIATE(
-    bfs_bf_directed_hypergraph_traits_template,
+    backward_search_directed_hypergraph_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -1,0 +1,431 @@
+#include "doctest.h"
+#include "hgl/constants.hpp"
+#include "testing/hgl/constants.hpp"
+
+#include <hgl/algorithm/traversal/breadth_first_search.hpp>
+
+#include <algorithm>
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_alg_bfs");
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search should properly traverse the hypergraph and yield correct search trees",
+    HypergraphTraitsType,
+    bfs_undirected_hypergraph_traits_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    id_type root_vertex_id;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+    // TODO: unreachable vertices
+
+    SUBCASE("hub (single hyperedge)") {
+        hypergraph.add_vertices(4uz);
+        const auto e = hypergraph.add_hyperedge().id();
+        for (const auto v : hypergraph.vertex_ids())
+            hypergraph.bind(v, e);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 0u};
+        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+    }
+
+    SUBCASE("chain") {
+        // E(H) = {{0, 1}, {1, 2, 3}, {3, 4, 5}}
+        hypergraph.add_vertices(6uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u, 5u})
+            hypergraph.bind(v, e2);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+    }
+
+    SUBCASE("overlapping hyperedges (shortest path preference)") {
+        // E(H) = {{0, 1}, {1, 2, 3}, {0, 3}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 3u})
+            hypergraph.bind(v, e2);
+
+        const auto e3 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e3);
+
+        root_vertex_id = hgl::initial_id;
+
+        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
+        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+    }
+
+    SUBCASE("disconnected components (targeted root)") {
+        // E(H) = {{0, 1, 2}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u, 2u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e1);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = {0u, 1u, 2u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+    }
+
+    SUBCASE("full graph traversal (no_root)") {
+        // E(H) = {{0, 1, 2}, {3, 4}}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {0u, 1u, 2u})
+            hypergraph.bind(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        for (const id_type v : {3u, 4u})
+            hypergraph.bind(v, e1);
+
+        root_vertex_id = gl::algorithm::no_root;
+
+        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertex_id);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret bfs ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+        hypergraph,
+        root_vertex_id,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
+
+    // --- ret bfs ---
+
+    const auto search_tree =
+        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_undirected_hypergraph_traits_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::undirected_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::undirected_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::undirected_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::undirected_t> // vertex-major flat incidence matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "breadth_first_search should properly traverse the directed hypergraph and yield correct "
+    "search trees",
+    HypergraphTraitsType,
+    bfs_bf_directed_hypergraph_traits_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    id_type root_vertex_id;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    SUBCASE("forward star (single hyperedge)") {
+        // E(H) = {0->{1, 2, 3}}
+        hypergraph.add_vertices(4uz);
+        const auto e = hypergraph.add_hyperedge().id();
+
+        hypergraph.bind_tail(0uz, e);
+        for (const id_type v : {1u, 2u, 3u})
+            hypergraph.bind_head(v, e);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 0u};
+        expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+    }
+
+    SUBCASE("chain") {
+        // E(H) = {0->1, 1->{2, 3}, 3->{4, 5}}
+        hypergraph.add_vertices(6uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        hypergraph.bind_head(1uz, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(1uz, e1);
+        for (const id_type v : {2u, 3u})
+            hypergraph.bind_head(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e2);
+        for (const id_type v : {4u, 5u})
+            hypergraph.bind_head(v, e2);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+    }
+
+    SUBCASE("overlapping hyperedges (shortest path preference)") {
+        // E(H) = {0->1, 1->{2, 3}, 0->3 (shortcut!), 3->4}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        hypergraph.bind_head(1uz, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(1uz, e1);
+        for (const id_type v : {2u, 3u})
+            hypergraph.bind_head(v, e1);
+
+        const auto e2 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e2);
+        hypergraph.bind_head(3uz, e2);
+
+        const auto e3 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e3);
+        hypergraph.bind_head(4uz, e3);
+
+        root_vertex_id = hgl::initial_id;
+
+        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
+        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+    }
+
+    SUBCASE("disconnected components (targeted root)") {
+        // E(H) = {0->{1, 2}, 3->4}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        for (const id_type v : {1u, 2u})
+            hypergraph.bind_head(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e1);
+        hypergraph.bind_head(4uz, e1);
+
+        root_vertex_id = hgl::initial_id;
+
+        expected_previsit_order = {0u, 1u, 2u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+    }
+
+    SUBCASE("full graph traversal (no_root)") {
+        // E(H) = {0->{1, 2}, 3->4}
+        hypergraph.add_vertices(5uz);
+
+        const auto e0 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(0uz, e0);
+        for (const id_type v : {1u, 2u})
+            hypergraph.bind_head(v, e0);
+
+        const auto e1 = hypergraph.add_hyperedge().id();
+        hypergraph.bind_tail(3uz, e1);
+        hypergraph.bind_head(4uz, e1);
+
+        root_vertex_id = gl::algorithm::no_root;
+
+        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        expected_postvisit_order = expected_previsit_order;
+        expected_pred_map = {0u, 0u, 0u, 3u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertex_id);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret bfs ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+        hypergraph,
+        root_vertex_id,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
+
+    // --- ret bfs ---
+
+    const auto search_tree =
+        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    bfs_bf_directed_hypergraph_traits_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_SUITE_END(); // test_alg_bfs
+
+} // namespace hgl_testing

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -4,8 +4,6 @@
 
 #include <hgl/algorithm/traversal/breadth_first_search.hpp>
 
-#include <algorithm>
-
 namespace hgl_testing {
 
 TEST_SUITE_BEGIN("test_alg_bfs");

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -1,8 +1,12 @@
 #include "doctest.h"
-#include "hgl/constants.hpp"
+#include "hgl/algorithm/util.hpp"
+#include "testing/common/io.hpp"
 #include "testing/hgl/constants.hpp"
 
 #include <hgl/algorithm/traversal/breadth_first_search.hpp>
+#include <hgl/constants.hpp>
+
+#include <algorithm>
 
 namespace hgl_testing {
 
@@ -20,11 +24,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     id_type root_vertex_id;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
-    // TODO: unreachable vertices
+    std::vector<id_type> unreachable_vertices;
 
     SUBCASE("hub (single hyperedge)") {
         hypergraph.add_vertices(4uz);
@@ -34,10 +37,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+        unreachable_vertices = {};
     }
 
     SUBCASE("chain") {
@@ -58,10 +61,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+        unreachable_vertices = {};
     }
 
     SUBCASE("overlapping hyperedges (shortest path preference)") {
@@ -87,10 +90,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 3u, 2u, 4u};
         expected_pred_map = {0u, 0u, 1u, 0u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+        unreachable_vertices = {};
     }
 
     SUBCASE("disconnected components (targeted root)") {
@@ -107,10 +110,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 1u, 2u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 2u};
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+        unreachable_vertices = {3u, 4u};
     }
 
     SUBCASE("full graph traversal (no_root)") {
@@ -127,18 +130,18 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = gl::algorithm::no_root;
 
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 2u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertex_id);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret bfs ---
 
@@ -158,10 +161,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
-    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
-    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
-    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
     // --- ret bfs ---
 
@@ -176,6 +179,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
     CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -225,10 +234,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     id_type root_vertex_id;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     SUBCASE("forward star (single hyperedge)") {
         // E(H) = {0->{1, 2, 3}}
@@ -241,10 +250,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+        unreachable_vertices = {};
     }
 
     SUBCASE("chain") {
@@ -267,10 +276,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+        unreachable_vertices = {};
     }
 
     SUBCASE("overlapping hyperedges (shortest path preference)") {
@@ -297,10 +306,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 3u, 2u, 4u};
         expected_pred_map = {0u, 0u, 1u, 0u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+        unreachable_vertices = {};
     }
 
     SUBCASE("disconnected components (targeted root)") {
@@ -318,10 +327,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 1u, 2u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 2u};
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+        unreachable_vertices = {3u, 4u};
     }
 
     SUBCASE("full graph traversal (no_root)") {
@@ -339,18 +348,18 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = gl::algorithm::no_root;
 
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 2u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertex_id);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret bfs ---
 
@@ -370,8 +379,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
-    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(previsit_order, expected_visit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_visit_order));
     CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
     CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
 
@@ -388,6 +397,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
     CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/hgl/test_alg_dfs.cpp
+++ b/tests/source/hgl/test_alg_dfs.cpp
@@ -5,8 +5,6 @@
 #include <hgl/algorithm/traversal/depth_first_search.hpp>
 #include <hgl/constants.hpp>
 
-#include <algorithm>
-
 namespace hgl_testing {
 
 TEST_SUITE_BEGIN("test_alg_dfs");

--- a/tests/source/hgl/test_alg_dfs.cpp
+++ b/tests/source/hgl/test_alg_dfs.cpp
@@ -127,7 +127,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const id_type v : {3u, 4u})
             hypergraph.bind(v, e1);
 
-        root_vertex_id = gl::algorithm::no_root;
+        root_vertex_id = hgl::algorithm::no_root;
 
         // 0->1,2; 2; 1; 3->4; 4
         expected_visit_order = {0u, 2u, 1u, 3u, 4u};
@@ -150,7 +150,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::depth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::depth_first_search<hgl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -169,7 +169,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::depth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::depth_first_search<hgl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -348,7 +348,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hypergraph.bind_tail(3uz, e1);
         hypergraph.bind_head(4uz, e1);
 
-        root_vertex_id = gl::algorithm::no_root;
+        root_vertex_id = hgl::algorithm::no_root;
 
         // 0->1,2; 2; 1; 3->4; 4
         expected_visit_order = {0u, 2u, 1u, 3u, 4u};
@@ -371,7 +371,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::depth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::depth_first_search<hgl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -390,7 +390,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::depth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::depth_first_search<hgl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();

--- a/tests/source/hgl/test_alg_dfs.cpp
+++ b/tests/source/hgl/test_alg_dfs.cpp
@@ -21,11 +21,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     id_type root_vertex_id;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
-    // TODO: unreachable vertices
+    std::vector<id_type> unreachable_vertices;
 
     SUBCASE("hub (single hyperedge)") {
         hypergraph.add_vertices(4uz);
@@ -35,10 +34,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 3u, 2u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 3u, 2u, 1u};
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+        unreachable_vertices = {};
     }
 
     SUBCASE("chain") {
@@ -60,10 +59,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1; 1->2,3; 3->4,5; 5; 4; 2
-        expected_previsit_order = {0u, 1u, 3u, 5u, 4u, 2u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 3u, 5u, 4u, 2u};
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+        unreachable_vertices = {};
     }
 
     SUBCASE("overlapping hyperedges (shortest path preference)") {
@@ -89,10 +88,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1,3; 3->1,2,4; 4; 2; 1
-        expected_previsit_order = {0u, 3u, 4u, 2u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 3u, 4u, 2u, 1u};
         expected_pred_map = {0u, 3u, 3u, 0u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e1, e1, e2, e3};
+        unreachable_vertices = {};
     }
 
     SUBCASE("disconnected components (targeted root)") {
@@ -110,10 +109,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1,2; 2; 1
-        expected_previsit_order = {0u, 2u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 2u, 1u};
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+        unreachable_vertices = {3u, 4u};
     }
 
     SUBCASE("full graph traversal (no_root)") {
@@ -131,18 +130,18 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = gl::algorithm::no_root;
 
         // 0->1,2; 2; 1; 3->4; 4
-        expected_previsit_order = {0u, 2u, 1u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 2u, 1u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertex_id);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret bfs ---
 
@@ -162,8 +161,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
@@ -180,6 +179,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK_EQ(ret_pred_map, expected_pred_map);
     CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -229,10 +234,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     id_type root_vertex_id;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     SUBCASE("forward star (single hyperedge)") {
         // E(H) = {0->{1, 2, 3}}
@@ -245,10 +250,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 3u, 2u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 3u, 2u, 1u};
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
+        unreachable_vertices = {};
     }
 
     SUBCASE("chain") {
@@ -272,10 +277,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1; 1->2,3; 3->4,5; 5; 4; 2
-        expected_previsit_order = {0u, 1u, 3u, 5u, 4u, 2u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 1u, 3u, 5u, 4u, 2u};
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
+        unreachable_vertices = {};
     }
 
     SUBCASE("overlapping hyperedges (shortest path preference)") {
@@ -302,10 +307,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1,3; 3->4; 4; 1->2; 2
-        expected_previsit_order = {0u, 3u, 4u, 1u, 2u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 3u, 4u, 1u, 2u};
         expected_pred_map = {0u, 0u, 1u, 0u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+        unreachable_vertices = {};
     }
 
     SUBCASE("disconnected components (targeted root)") {
@@ -324,10 +329,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = hgl::initial_id;
 
         // 0->1,2; 2; 1
-        expected_previsit_order = {0u, 2u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 2u, 1u};
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
+        unreachable_vertices = {3u, 4u};
     }
 
     SUBCASE("full graph traversal (no_root)") {
@@ -346,18 +351,18 @@ TEST_CASE_TEMPLATE_DEFINE(
         root_vertex_id = gl::algorithm::no_root;
 
         // 0->1,2; 2; 1; 3->4; 4
-        expected_previsit_order = {0u, 2u, 1u, 3u, 4u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {0u, 2u, 1u, 3u, 4u};
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertex_id);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret bfs ---
 
@@ -377,8 +382,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
-    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(previsit_order, expected_visit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_visit_order));
     CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
     CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
 
@@ -395,6 +400,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
     CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/hgl/test_alg_dfs.cpp
+++ b/tests/source/hgl/test_alg_dfs.cpp
@@ -2,19 +2,19 @@
 #include "testing/common/io.hpp"
 #include "testing/hgl/constants.hpp"
 
-#include <hgl/algorithm/traversal/breadth_first_search.hpp>
+#include <hgl/algorithm/traversal/depth_first_search.hpp>
 #include <hgl/constants.hpp>
 
 #include <algorithm>
 
 namespace hgl_testing {
 
-TEST_SUITE_BEGIN("test_alg_bfs");
+TEST_SUITE_BEGIN("test_alg_dfs");
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "breadth_first_search should properly traverse the hypergraph and yield correct search trees",
+    "depth_first_search should properly traverse the hypergraph and yield correct search trees",
     HypergraphTraitsType,
-    bfs_undirected_hypergraph_traits_template
+    dfs_undirected_hypergraph_traits_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
@@ -37,7 +37,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_previsit_order = {0u, 3u, 2u, 1u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
@@ -61,7 +61,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        // 0->1; 1->2,3; 3->4,5; 5; 4; 2
+        expected_previsit_order = {0u, 1u, 3u, 5u, 4u, 2u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
@@ -89,11 +90,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        // 0->1,3; 3->1,2,4; 4; 2; 1
+        expected_previsit_order = {0u, 3u, 4u, 2u, 1u};
         expected_postvisit_order = expected_previsit_order;
-        expected_pred_map = {0u, 0u, 1u, 0u, 3u};
-        expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
+        expected_pred_map = {0u, 3u, 3u, 0u, 3u};
+        expected_in_hyperedges = {hgl::invalid_id, e1, e1, e2, e3};
     }
 
     SUBCASE("disconnected components (targeted root)") {
@@ -110,7 +111,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 1u, 2u};
+        // 0->1,2; 2; 1
+        expected_previsit_order = {0u, 2u, 1u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
@@ -130,7 +132,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = gl::algorithm::no_root;
 
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        // 0->1,2; 2; 1; 3->4; 4
+        expected_previsit_order = {0u, 2u, 1u, 3u, 4u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
@@ -150,7 +153,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::depth_first_search<gl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -169,7 +172,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::depth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -182,7 +185,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    bfs_undirected_hypergraph_traits_template,
+    dfs_undirected_hypergraph_traits_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::undirected_t>, // bidirectional incidence list
@@ -216,10 +219,10 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
 );
 
 TEST_CASE_TEMPLATE_DEFINE(
-    "breadth_first_search should properly traverse the directed hypergraph and yield correct "
-    "search trees",
+    "depth_first_search should properly traverse the directed hypergraph and yield correct search "
+    "trees",
     HypergraphTraitsType,
-    bfs_bf_directed_hypergraph_traits_template
+    dfs_bf_directed_hypergraph_traits_template
 ) {
     using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
     using id_type = typename hypergraph_type::id_type;
@@ -244,7 +247,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        expected_previsit_order = {0u, 3u, 2u, 1u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, 0u};
         expected_in_hyperedges = {hgl::invalid_id, e, e, e};
@@ -270,7 +273,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = hypergraph.vertex_ids() | std::ranges::to<std::vector>();
+        // 0->1; 1->2,3; 3->4,5; 5; 4; 2
+        expected_previsit_order = {0u, 1u, 3u, 5u, 4u, 2u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 1u, 1u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e1, e2, e2};
@@ -299,8 +303,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        // BFS guarantees shortest path: 0 -> 3 via e2, skipping 1.
-        expected_previsit_order = {0u, 1u, 3u, 2u, 4u};
+        // 0->1,3; 3->4; 4; 1->2; 2
+        expected_previsit_order = {0u, 3u, 4u, 1u, 2u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 1u, 0u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e1, e2, e3};
@@ -321,7 +325,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = hgl::initial_id;
 
-        expected_previsit_order = {0u, 1u, 2u};
+        // 0->1,2; 2; 1
+        expected_previsit_order = {0u, 2u, 1u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, hgl::invalid_id, hgl::invalid_id};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, hgl::invalid_id};
@@ -342,7 +347,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         root_vertex_id = gl::algorithm::no_root;
 
-        expected_previsit_order = {0u, 1u, 2u, 3u, 4u};
+        // 0->1,2; 2; 1; 3->4; 4
+        expected_previsit_order = {0u, 2u, 1u, 3u, 4u};
         expected_postvisit_order = expected_previsit_order;
         expected_pred_map = {0u, 0u, 0u, 3u, 3u};
         expected_in_hyperedges = {hgl::invalid_id, e0, e0, hgl::invalid_id, e1};
@@ -362,7 +368,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::breadth_first_search<gl::algorithm::noret>(
+    hgl::algorithm::depth_first_search<gl::algorithm::noret>(
         hypergraph,
         root_vertex_id,
         [&](const auto& node) {
@@ -373,15 +379,15 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
-    CHECK_EQ(noret_pred_map, expected_pred_map);
-    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(previsit_order, expected_previsit_order));
+    CHECK(std::ranges::equal(postvisit_order, expected_postvisit_order));
+    CHECK(std::ranges::equal(noret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(noret_in_hyperedges, expected_in_hyperedges));
 
     // --- ret bfs ---
 
     const auto search_tree =
-        hgl::algorithm::breadth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
+        hgl::algorithm::depth_first_search<gl::algorithm::ret>(hypergraph, root_vertex_id);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -389,12 +395,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         search_tree | std::views::transform(&node_type::hyperedge_id)
         | std::ranges::to<std::vector>();
 
-    CHECK_EQ(ret_pred_map, expected_pred_map);
-    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::equal(ret_pred_map, expected_pred_map));
+    CHECK(std::ranges::equal(ret_in_hyperedges, expected_in_hyperedges));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
-    bfs_bf_directed_hypergraph_traits_template,
+    dfs_bf_directed_hypergraph_traits_template,
     hgl::list_hypergraph_traits<
         hgl::impl::bidirectional_t,
         hgl::bf_directed_t>, // bidirectional incidence list
@@ -427,6 +433,6 @@ TEST_CASE_TEMPLATE_INSTANTIATE(
         hgl::bf_directed_t> // vertex-major flat incidence matrix
 );
 
-TEST_SUITE_END(); // test_alg_bfs
+TEST_SUITE_END(); // test_alg_dfs
 
 } // namespace hgl_testing

--- a/tests/source/hgl/test_alg_forward_search.cpp
+++ b/tests/source/hgl/test_alg_forward_search.cpp
@@ -21,10 +21,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     std::vector<id_type> root_vertices;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     /* Topology:
        V = {v0, v1, v2, v3, v4}
@@ -61,8 +61,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         // e2 CAN be traversed because v4 is its only head.
         root_vertices = {4u};
 
-        expected_previsit_order = {4u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {4u, 1u};
 
         expected_pred_map.resize(order, hgl::invalid_id);
         expected_pred_map[4uz] = 4u; // Root
@@ -70,6 +69,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         expected_in_hyperedges.resize(order, hgl::invalid_id);
         expected_in_hyperedges[1uz] = e2;
+
+        unreachable_vertices = {0u, 2u, 3u};
     }
 
     SUBCASE("roots v3 and v4 (complete backward traversal)") {
@@ -85,8 +86,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Queue: [v1, v0]
         // Pop v1 -> no incoming edges
         // Pop v0 -> no incoming edges
-        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {3u, 4u, 2u, 1u, 0u};
 
         expected_pred_map = {
             2u, // v0 reached backward from v2 via e0
@@ -103,14 +103,16 @@ TEST_CASE_TEMPLATE_DEFINE(
             hgl::invalid_id, // v3 root
             hgl::invalid_id // v4 root
         };
+
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertices);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret search ---
 
@@ -130,8 +132,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
@@ -148,6 +150,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK_EQ(ret_pred_map, expected_pred_map);
     CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -196,10 +204,10 @@ TEST_CASE_TEMPLATE_DEFINE(
     hypergraph_type hypergraph;
     std::vector<id_type> root_vertices;
 
-    std::vector<id_type> expected_previsit_order;
-    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_visit_order;
     std::vector<id_type> expected_pred_map;
     std::vector<id_type> expected_in_hyperedges;
+    std::vector<id_type> unreachable_vertices;
 
     /* Topology:
        V = {v0, v1, v2, v3, v4}
@@ -234,8 +242,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("single root v4 (partial backward traversal)") {
         root_vertices = {4u};
 
-        expected_previsit_order = {4u, 1u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {4u, 1u};
 
         expected_pred_map.resize(order, hgl::invalid_id);
         expected_pred_map[4uz] = 4u; // Root
@@ -243,6 +250,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         expected_in_hyperedges.resize(order, hgl::invalid_id);
         expected_in_hyperedges[1uz] = e2;
+
+        unreachable_vertices = {0u, 2u, 3u};
     }
 
     SUBCASE("roots v3 and v4 (complete backward traversal)") {
@@ -255,8 +264,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Pop v3 -> e1 unlocked -> pushes v2.
         // Pop v2 -> e0 unlocked -> pushes v0, v1(visited).
         // Pop v0 -> no incoming edges.
-        expected_previsit_order = {4u, 1u, 3u, 2u, 0u};
-        expected_postvisit_order = expected_previsit_order;
+        expected_visit_order = {4u, 1u, 3u, 2u, 0u};
 
         // Notice v2's pred is v3 now! (v3 was popped after v4, unlocking e1)
         expected_pred_map = {
@@ -274,14 +282,16 @@ TEST_CASE_TEMPLATE_DEFINE(
             hgl::invalid_id, // v3 root
             hgl::invalid_id // v4 root
         };
+
+        unreachable_vertices = {};
     }
 
     CAPTURE(hypergraph);
     CAPTURE(root_vertices);
-    CAPTURE(expected_previsit_order);
-    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_visit_order);
     CAPTURE(expected_pred_map);
     CAPTURE(expected_in_hyperedges);
+    CAPTURE(unreachable_vertices);
 
     // --- noret search ---
 
@@ -301,8 +311,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
     );
 
-    CHECK_EQ(previsit_order, expected_previsit_order);
-    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(previsit_order, expected_visit_order);
+    CHECK_EQ(postvisit_order, expected_visit_order);
     CHECK_EQ(noret_pred_map, expected_pred_map);
     CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
 
@@ -319,6 +329,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     CHECK_EQ(ret_pred_map, expected_pred_map);
     CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+    CHECK(std::ranges::all_of(expected_visit_order, [&search_tree](const auto v_id) {
+        return hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
+    CHECK(std::ranges::all_of(unreachable_vertices, [&search_tree](const auto v_id) {
+        return not hgl::algorithm::is_reachable(search_tree, v_id);
+    }));
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/hgl/test_alg_forward_search.cpp
+++ b/tests/source/hgl/test_alg_forward_search.cpp
@@ -121,7 +121,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::forward_bfs<gl::algorithm::noret>(
+    hgl::algorithm::forward_bfs<hgl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -140,7 +140,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::forward_bfs<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::forward_bfs<hgl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
@@ -300,7 +300,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
     std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
 
-    hgl::algorithm::forward_dfs<gl::algorithm::noret>(
+    hgl::algorithm::forward_dfs<hgl::algorithm::noret>(
         hypergraph,
         root_vertices,
         [&](const auto& node) {
@@ -319,7 +319,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     // --- ret search ---
 
     const auto search_tree =
-        hgl::algorithm::forward_dfs<gl::algorithm::ret>(hypergraph, root_vertices);
+        hgl::algorithm::forward_dfs<hgl::algorithm::ret>(hypergraph, root_vertices);
 
     const auto ret_pred_map =
         search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();

--- a/tests/source/hgl/test_alg_forward_search.cpp
+++ b/tests/source/hgl/test_alg_forward_search.cpp
@@ -1,0 +1,360 @@
+#include "doctest.h"
+#include "testing/common/io.hpp"
+#include "testing/hgl/constants.hpp"
+
+#include <hgl/algorithm/traversal/forward_search.hpp>
+#include <hgl/constants.hpp>
+
+namespace hgl_testing {
+
+TEST_SUITE_BEGIN("test_alg_forward_search");
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "forward_bfs should properly enforce head dependencies during traversal",
+    HypergraphTraitsType,
+    forward_bfs_directed_hypergraph_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    std::vector<id_type> root_vertices;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
+
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
+
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v4 (partial backward traversal)") {
+        // Rooting at v4. e1 cannot be traversed backwards because it also requires v3.
+        // e2 CAN be traversed because v4 is its only head.
+        root_vertices = {4u};
+
+        expected_previsit_order = {4u, 1u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[4uz] = 4u; // Root
+        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
+
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges[1uz] = e2;
+    }
+
+    SUBCASE("roots v3 and v4 (complete backward traversal)") {
+        // Rooting at v3 and v4 unlocks e1, which unlocks v2, which unlocks e0, which unlocks v0 and v1.
+        root_vertices = {3u, 4u};
+
+        // Queue trace:
+        // Init: [v3, v4]
+        // Pop v3 -> sees e1 (needs v4, so wait)
+        // Pop v4 -> sees e1 (unlocked -> enqueues v2), sees e2 (unlocked -> enqueues v1)
+        // Queue: [v2, v1]
+        // Pop v2 -> sees e0 (unlocked -> enqueues v0, v1) - v1 is already visited
+        // Queue: [v1, v0]
+        // Pop v1 -> no incoming edges
+        // Pop v0 -> no incoming edges
+        expected_previsit_order = {3u, 4u, 2u, 1u, 0u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map = {
+            2u, // v0 reached backward from v2 via e0
+            4u, // v1 reached backward from v4 via e2
+            4u, // v2 reached backward from v4 via e1
+            3u, // v3 is a root
+            4u // v4 is a root
+        };
+
+        expected_in_hyperedges = {
+            e0, // v0 reached via e0
+            e2, // v1 reached via e2
+            e1, // v2 reached via e1
+            hgl::invalid_id, // v3 root
+            hgl::invalid_id // v4 root
+        };
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertices);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret search ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::forward_bfs<gl::algorithm::noret>(
+        hypergraph,
+        root_vertices,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK_EQ(previsit_order, expected_previsit_order);
+    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+
+    // --- ret search ---
+
+    const auto search_tree =
+        hgl::algorithm::forward_bfs<gl::algorithm::ret>(hypergraph, root_vertices);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK_EQ(ret_pred_map, expected_pred_map);
+    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    forward_bfs_directed_hypergraph_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_CASE_TEMPLATE_DEFINE(
+    "forward_dfs should properly enforce head dependencies during traversal",
+    HypergraphTraitsType,
+    forward_dfs_directed_hypergraph_template
+) {
+    using hypergraph_type = hgl::hypergraph<HypergraphTraitsType>;
+    using id_type = typename hypergraph_type::id_type;
+    using node_type = hgl::algorithm::search_node<hypergraph_type>;
+
+    hypergraph_type hypergraph;
+    std::vector<id_type> root_vertices;
+
+    std::vector<id_type> expected_previsit_order;
+    std::vector<id_type> expected_postvisit_order;
+    std::vector<id_type> expected_pred_map;
+    std::vector<id_type> expected_in_hyperedges;
+
+    /* Topology:
+       V = {v0, v1, v2, v3, v4}
+       e0 = {v0, v1} -> {v2}
+       e1 = {v2} -> {v3, v4}
+       e2 = {v1} -> {v4}
+
+       v0                v3
+         \              /
+          -->-- v2 -->--
+         /              \
+       v1 ------->------ v4
+    */
+
+    const auto order = 5uz;
+    hypergraph.add_vertices(order);
+
+    const auto e0 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(0uz, e0);
+    hypergraph.bind_tail(1uz, e0);
+    hypergraph.bind_head(2uz, e0);
+
+    const auto e1 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(2uz, e1);
+    hypergraph.bind_head(3uz, e1);
+    hypergraph.bind_head(4uz, e1);
+
+    const auto e2 = hypergraph.add_hyperedge().id();
+    hypergraph.bind_tail(1uz, e2);
+    hypergraph.bind_head(4uz, e2);
+
+    SUBCASE("single root v4 (partial backward traversal)") {
+        root_vertices = {4u};
+
+        expected_previsit_order = {4u, 1u};
+        expected_postvisit_order = expected_previsit_order;
+
+        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map[4uz] = 4u; // Root
+        expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
+
+        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges[1uz] = e2;
+    }
+
+    SUBCASE("roots v3 and v4 (complete backward traversal)") {
+        root_vertices = {3u, 4u};
+
+        // DFS Stack Trace (LIFO):
+        // Init: [v3, v4]
+        // Pop v4 -> e1 wait (needs v3). e2 unlocked -> pushes v1.
+        // Pop v1 -> no incoming edges.
+        // Pop v3 -> e1 unlocked -> pushes v2.
+        // Pop v2 -> e0 unlocked -> pushes v0, v1(visited).
+        // Pop v0 -> no incoming edges.
+        expected_previsit_order = {4u, 1u, 3u, 2u, 0u};
+        expected_postvisit_order = expected_previsit_order;
+
+        // Notice v2's pred is v3 now! (v3 was popped after v4, unlocking e1)
+        expected_pred_map = {
+            2u, // v0 reached backward from v2 via e0
+            4u, // v1 reached backward from v4 via e2
+            3u, // v2 reached backward from v3 via e1
+            3u, // v3 is a root
+            4u // v4 is a root
+        };
+
+        expected_in_hyperedges = {
+            e0, // v0 reached via e0
+            e2, // v1 reached via e2
+            e1, // v2 reached via e1
+            hgl::invalid_id, // v3 root
+            hgl::invalid_id // v4 root
+        };
+    }
+
+    CAPTURE(hypergraph);
+    CAPTURE(root_vertices);
+    CAPTURE(expected_previsit_order);
+    CAPTURE(expected_postvisit_order);
+    CAPTURE(expected_pred_map);
+    CAPTURE(expected_in_hyperedges);
+
+    // --- noret search ---
+
+    std::vector<id_type> previsit_order;
+    std::vector<id_type> postvisit_order;
+    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+
+    hgl::algorithm::forward_dfs<gl::algorithm::noret>(
+        hypergraph,
+        root_vertices,
+        [&](const auto& node) {
+            previsit_order.push_back(node.vertex_id);
+            noret_pred_map[node.vertex_id] = node.pred_id;
+            noret_in_hyperedges[node.vertex_id] = node.hyperedge_id;
+        },
+        [&](const auto& node) { postvisit_order.push_back(node.vertex_id); }
+    );
+
+    CHECK_EQ(previsit_order, expected_previsit_order);
+    CHECK_EQ(postvisit_order, expected_postvisit_order);
+    CHECK_EQ(noret_pred_map, expected_pred_map);
+    CHECK_EQ(noret_in_hyperedges, expected_in_hyperedges);
+
+    // --- ret search ---
+
+    const auto search_tree =
+        hgl::algorithm::forward_dfs<gl::algorithm::ret>(hypergraph, root_vertices);
+
+    const auto ret_pred_map =
+        search_tree | std::views::transform(&node_type::pred_id) | std::ranges::to<std::vector>();
+    const auto ret_in_hyperedges =
+        search_tree | std::views::transform(&node_type::hyperedge_id)
+        | std::ranges::to<std::vector>();
+
+    CHECK_EQ(ret_pred_map, expected_pred_map);
+    CHECK_EQ(ret_in_hyperedges, expected_in_hyperedges);
+}
+
+TEST_CASE_TEMPLATE_INSTANTIATE(
+    forward_dfs_directed_hypergraph_template,
+    hgl::list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence list
+    hgl::list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::bidirectional_t,
+        hgl::bf_directed_t>, // bidirectional flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence list
+    hgl::flat_list_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major flat incidence list
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major incidence matrix
+    hgl::matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t>, // vertex-major incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::hyperedge_major_t,
+        hgl::bf_directed_t>, // hyperedge-major flat incidence matrix
+    hgl::flat_matrix_hypergraph_traits<
+        hgl::impl::vertex_major_t,
+        hgl::bf_directed_t> // vertex-major flat incidence matrix
+);
+
+TEST_SUITE_END(); // test_alg_forward_search
+
+} // namespace hgl_testing


### PR DESCRIPTION
- Defined core hypergraph algorithm utility
- Implemented generic hypergraph traversal templates: BFS and DFS 
- Implemented concrete hypergraph searching algorithms:
  - Common: breadth_first_search and depth_first_search
  - Specific for BF-Hypergraph: backward_bfs, backward_dfs, forward_bfs, forward_dfs
- Performed a cleanup and naming alignment of the gl::algorithm module