### PR TITLE
YT-CPPGL-71: Align the naming of edge getter methods

### DIFF
--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -65,7 +65,7 @@ template <
         empty_callback{}, // visit callback
         [&paths, &negative_edge](id_type vertex_id, const edge_type& in_edge)
             -> decision { // enqueue predicate
-            const auto pred_id = in_edge.incident_vertex(vertex_id);
+            const auto pred_id = in_edge.other(vertex_id);
 
             const auto edge_weight = get_weight<G>(in_edge);
             if (edge_weight < 0) {

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -117,10 +117,8 @@ template <traits::c_id_type IdType, traits::c_random_access_range_of<IdType> IdR
     while (true) {
         path.push_front(current_vertex);
         IdType predecessor = predecessor_map[to_idx(current_vertex)];
-
         if (predecessor == current_vertex)
             break;
-
         current_vertex = predecessor;
     }
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -51,7 +51,7 @@ template <traits::c_undirected_graph G>
     if (root_id == invalid_id)
         root_id = initial_id;
 
-    for (const auto& edge : graph.incidenct_edges(root_id))
+    for (const auto& edge : graph.incident_edges(root_id))
         edge_queue.emplace(edge);
 
     // mark the root vertex as visited
@@ -75,7 +75,7 @@ template <traits::c_undirected_graph G>
         ++n_vertices_in_mst;
 
         // enqueue all edges incident with the `target` vertex if they lead to unvisited verties
-        for (const auto& edge : graph.incidenct_edges(min_edge.target()))
+        for (const auto& edge : graph.incident_edges(min_edge.target()))
             if (not visited[to_idx(edge.other(min_edge.target()))])
                 edge_queue.emplace(edge);
     }
@@ -132,7 +132,7 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
         }
 
         // Update adjacent vertices
-        for (const auto& edge : graph.incidenct_edges(vertex_id)) {
+        for (const auto& edge : graph.incident_edges(vertex_id)) {
             const auto edge_weight = get_weight<G>(edge);
             const auto target_vertex_idx = to_idx(edge.other(vertex_id));
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -76,7 +76,7 @@ template <traits::c_undirected_graph G>
 
         // enqueue all edges incident with the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.incidenct_edges(min_edge.target()))
-            if (not visited[to_idx(edge.incident_vertex(min_edge.target()))])
+            if (not visited[to_idx(edge.other(min_edge.target()))])
                 edge_queue.emplace(edge);
     }
 
@@ -134,7 +134,7 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
         // Update adjacent vertices
         for (const auto& edge : graph.incidenct_edges(vertex_id)) {
             const auto edge_weight = get_weight<G>(edge);
-            const auto target_vertex_idx = to_idx(edge.incident_vertex(vertex_id));
+            const auto target_vertex_idx = to_idx(edge.other(vertex_id));
 
             if (not in_mst[target_vertex_idx] and edge_weight < min_cost[target_vertex_idx]) {
                 min_cost[target_vertex_idx] = edge_weight;

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -47,7 +47,7 @@ template <traits::c_undirected_graph G>
     std::vector<bool> visited(n_vertices, false);
     queue_type edge_queue;
 
-    // insert the edges adjacent to the root vertex to the queue
+    // insert the edges incident with the root vertex to the queue
     if (root_id == invalid_id)
         root_id = initial_id;
 
@@ -74,7 +74,7 @@ template <traits::c_undirected_graph G>
         visited[min_edge_tgt] = true;
         ++n_vertices_in_mst;
 
-        // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
+        // enqueue all edges incident with the `target` vertex if they lead to unvisited verties
         for (const auto& edge : graph.incidenct_edges(min_edge.target()))
             if (not visited[to_idx(edge.incident_vertex(min_edge.target()))])
                 edge_queue.emplace(edge);
@@ -134,11 +134,11 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
         // Update adjacent vertices
         for (const auto& edge : graph.incidenct_edges(vertex_id)) {
             const auto edge_weight = get_weight<G>(edge);
-            const auto incident_vertex_idx = to_idx(edge.incident_vertex(vertex_id));
+            const auto target_vertex_idx = to_idx(edge.incident_vertex(vertex_id));
 
-            if (not in_mst[incident_vertex_idx] and edge_weight < min_cost[incident_vertex_idx]) {
-                min_cost[incident_vertex_idx] = edge_weight;
-                min_cost_edges[incident_vertex_idx].emplace(edge);
+            if (not in_mst[target_vertex_idx] and edge_weight < min_cost[target_vertex_idx]) {
+                min_cost[target_vertex_idx] = edge_weight;
+                min_cost_edges[target_vertex_idx].emplace(edge);
             }
         }
 

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -51,7 +51,7 @@ template <traits::c_undirected_graph G>
     if (root_id == invalid_id)
         root_id = initial_id;
 
-    for (const auto& edge : graph.adjacent_edges(root_id))
+    for (const auto& edge : graph.incidenct_edges(root_id))
         edge_queue.emplace(edge);
 
     // mark the root vertex as visited
@@ -75,7 +75,7 @@ template <traits::c_undirected_graph G>
         ++n_vertices_in_mst;
 
         // enqueue all edges adjacent to the `target` vertex if they lead to unvisited verties
-        for (const auto& edge : graph.adjacent_edges(min_edge.target()))
+        for (const auto& edge : graph.incidenct_edges(min_edge.target()))
             if (not visited[to_idx(edge.incident_vertex(min_edge.target()))])
                 edge_queue.emplace(edge);
     }
@@ -132,7 +132,7 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
         }
 
         // Update adjacent vertices
-        for (const auto& edge : graph.adjacent_edges(vertex_id)) {
+        for (const auto& edge : graph.incidenct_edges(vertex_id)) {
             const auto edge_weight = get_weight<G>(edge);
             const auto incident_vertex_idx = to_idx(edge.incident_vertex(vertex_id));
 

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -55,7 +55,7 @@ bool bfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
             const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -55,7 +55,7 @@ bool bfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incident_edges(node.vertex_id)) {
             const auto target_vertex_id = edge.other(node.vertex_id);
             const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -56,14 +56,12 @@ bool bfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
-
-            const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
+            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;
-
             if (enqueue)
-                q.emplace(incident_vertex_id, node.vertex_id);
+                q.emplace(target_vertex_id, node.vertex_id);
         }
 
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)

--- a/include/gl/algorithm/templates/bfs.hpp
+++ b/include/gl/algorithm/templates/bfs.hpp
@@ -56,7 +56,7 @@ bool bfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            const auto target_vertex_id = edge.other(node.vertex_id);
             const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -55,7 +55,7 @@ bool dfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incident_edges(node.vertex_id)) {
             const auto target_vertex_id = edge.other(node.vertex_id);
             if (enqueue_vertex_pred(target_vertex_id, edge))
                 s.emplace(target_vertex_id, node.vertex_id);
@@ -96,7 +96,7 @@ void r_dfs(
     visit(vertex_id, pred_id);
 
     // recursively search vertices adjacent to the current vertex
-    for (const auto& edge : graph.incidenct_edges(vertex_id)) {
+    for (const auto& edge : graph.incident_edges(vertex_id)) {
         const auto target_vertex_id = edge.other(vertex_id);
         if (enqueue_vertex_pred(target_vertex_id, edge))
             r_dfs(

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -56,9 +56,9 @@ bool dfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
-            if (enqueue_vertex_pred(incident_vertex_id, edge))
-                s.emplace(incident_vertex_id, node.vertex_id);
+            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            if (enqueue_vertex_pred(target_vertex_id, edge))
+                s.emplace(target_vertex_id, node.vertex_id);
         }
 
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)
@@ -97,11 +97,11 @@ void r_dfs(
 
     // recursively search vertices adjacent to the current vertex
     for (const auto& edge : graph.incidenct_edges(vertex_id)) {
-        const auto& incident_vertex_id = edge.incident_vertex(vertex_id);
-        if (enqueue_vertex_pred(incident_vertex_id, edge))
+        const auto target_vertex_id = edge.incident_vertex(vertex_id);
+        if (enqueue_vertex_pred(target_vertex_id, edge))
             r_dfs(
                 graph,
-                incident_vertex_id,
+                target_vertex_id,
                 vertex_id,
                 visit_vertex_pred,
                 visit,

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -55,7 +55,7 @@ bool dfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
             const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
             if (enqueue_vertex_pred(incident_vertex_id, edge))
                 s.emplace(incident_vertex_id, node.vertex_id);
@@ -96,7 +96,7 @@ void r_dfs(
     visit(vertex_id, pred_id);
 
     // recursively search vertices adjacent to the current vertex
-    for (const auto& edge : graph.adjacent_edges(vertex_id)) {
+    for (const auto& edge : graph.incidenct_edges(vertex_id)) {
         const auto& incident_vertex_id = edge.incident_vertex(vertex_id);
         if (enqueue_vertex_pred(incident_vertex_id, edge))
             r_dfs(

--- a/include/gl/algorithm/templates/dfs.hpp
+++ b/include/gl/algorithm/templates/dfs.hpp
@@ -56,7 +56,7 @@ bool dfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            const auto target_vertex_id = edge.other(node.vertex_id);
             if (enqueue_vertex_pred(target_vertex_id, edge))
                 s.emplace(target_vertex_id, node.vertex_id);
         }
@@ -97,7 +97,7 @@ void r_dfs(
 
     // recursively search vertices adjacent to the current vertex
     for (const auto& edge : graph.incidenct_edges(vertex_id)) {
-        const auto target_vertex_id = edge.incident_vertex(vertex_id);
+        const auto target_vertex_id = edge.other(vertex_id);
         if (enqueue_vertex_pred(target_vertex_id, edge))
             r_dfs(
                 graph,

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -59,7 +59,7 @@ bool pfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incident_edges(node.vertex_id)) {
             const auto target_vertex_id = edge.other(node.vertex_id);
             const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -60,14 +60,12 @@ bool pfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
-
-            const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);
+            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;
-
             if (enqueue)
-                q.emplace(incident_vertex_id, node.vertex_id);
+                q.emplace(target_vertex_id, node.vertex_id);
         }
         if constexpr (not traits::c_empty_callback<PostVisitCallback>)
             post_visit(node.vertex_id);

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -60,7 +60,7 @@ bool pfs(
                 return false;
 
         for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
-            const auto target_vertex_id = edge.incident_vertex(node.vertex_id);
+            const auto target_vertex_id = edge.other(node.vertex_id);
             const auto enqueue = enqueue_vertex_pred(target_vertex_id, edge);
             if (enqueue == decision::abort)
                 return false;

--- a/include/gl/algorithm/templates/pfs.hpp
+++ b/include/gl/algorithm/templates/pfs.hpp
@@ -59,7 +59,7 @@ bool pfs(
             if (not visit(node.vertex_id, node.pred_id))
                 return false;
 
-        for (const auto& edge : graph.adjacent_edges(node.vertex_id)) {
+        for (const auto& edge : graph.incidenct_edges(node.vertex_id)) {
             const auto incident_vertex_id = edge.incident_vertex(node.vertex_id);
 
             const auto enqueue = enqueue_vertex_pred(incident_vertex_id, edge);

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -38,7 +38,7 @@ template <
                 if (in_edge.is_loop())
                     return decision::abort; // graph is not bipartite
 
-                const auto pred_id = in_edge.incident_vertex(vertex_id);
+                const auto pred_id = in_edge.other(vertex_id);
 
                 auto& v_color = coloring[to_idx(vertex_id)];
                 auto p_color = coloring[to_idx(pred_id)];

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -86,14 +86,14 @@ struct to_impl<impl::flat_list_t, impl::list_t> {
         auto& source_list = source._impl._list;
 
         std::size_t total_items = 0uz;
-        for (const auto& adj : source_list)
-            total_items += adj.size();
+        for (const auto& inc : source_list)
+            total_items += inc.size();
 
         target_list.reserve_segments(source_list.size());
         target_list.reserve_data(total_items);
 
-        for (auto& adj : source_list)
-            target_list.push_back(std::move(adj));
+        for (auto& inc : source_list)
+            target_list.push_back(std::move(inc));
     }
 };
 
@@ -106,8 +106,8 @@ struct to_impl<impl::list_t, impl::flat_list_t> {
         auto& source_list = source._impl._list;
 
         target_list.reserve(source_list.size());
-        for (auto adj : source_list)
-            target_list.emplace_back(adj.begin(), adj.end());
+        for (auto inc : source_list)
+            target_list.emplace_back(inc.begin(), inc.end());
     }
 };
 

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -122,8 +122,7 @@ public:
 
     // clang-format on
 
-    // returns the `other` vertex or throws error if the given vertex is not incident with the edge
-    [[nodiscard]] const id_type incident_vertex(const id_type vertex_id) const {
+    [[nodiscard]] const id_type other(const id_type vertex_id) const {
         if (vertex_id == this->_vertices.first)
             return this->_vertices.second;
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -693,7 +693,7 @@ private:
         );
 
         for (const auto& vertex : this->vertices()) {
-            os << "- " << vertex << "\n  adjacent edges:\n";
+            os << "- " << vertex << "\n  incident edges:\n";
             for (const auto& edge : this->incidenct_edges(vertex.id()))
                 os << "\t- " << edge << '\n';
         }

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -293,16 +293,16 @@ public:
         return this->at(vertex.id());
     }
 
-    [[nodiscard]] inline auto incidenct_edges(const id_type vertex_id) const {
+    [[nodiscard]] inline auto incident_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.incidenct_edges(vertex_id, this->_edge_properties);
+            return this->_impl.incident_edges(vertex_id, this->_edge_properties);
         else
-            return this->_impl.incidenct_edges(vertex_id);
+            return this->_impl.incident_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(const vertex_type& vertex) const {
-        return this->incidenct_edges(vertex.id());
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(const vertex_type& vertex) const {
+        return this->incident_edges(vertex.id());
     }
 
     [[nodiscard]] inline auto in_edges(const id_type vertex_id) const {
@@ -694,7 +694,7 @@ private:
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << "\n  incident edges:\n";
-            for (const auto& edge : this->incidenct_edges(vertex.id()))
+            for (const auto& edge : this->incident_edges(vertex.id()))
                 os << "\t- " << edge << '\n';
         }
     }
@@ -704,7 +704,7 @@ private:
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << " :";
-            for (const auto& edge : this->incidenct_edges(vertex.id()))
+            for (const auto& edge : this->incident_edges(vertex.id()))
                 os << ' ' << edge;
             os << '\n';
         }
@@ -734,7 +734,7 @@ private:
         if constexpr (traits::c_writable<typename edge_type::properties_type>) {
             if (with_edge_properties) {
                 const auto print_incident_edges = [this, &os](const id_type vertex_id) {
-                    for (const auto& edge : this->incidenct_edges(vertex_id)) {
+                    for (const auto& edge : this->incident_edges(vertex_id)) {
                         if (edge.source() != vertex_id)
                             continue; // vertex is not the source
                         os << edge.source() << ' ' << edge.target() << ' ' << edge.properties()
@@ -750,7 +750,7 @@ private:
         }
 
         const auto print_incident_edges = [this, &os](const id_type vertex_id) {
-            for (const auto& edge : this->incidenct_edges(vertex_id)) {
+            for (const auto& edge : this->incident_edges(vertex_id)) {
                 if (edge.source() != vertex_id)
                     continue; // vertex is not the source
                 os << edge.source() << ' ' << edge.target() << '\n';

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -293,18 +293,16 @@ public:
         return this->at(vertex.id());
     }
 
-    // TODO: rename to incident_edges
-    [[nodiscard]] inline auto adjacent_edges(const id_type vertex_id) const {
+    [[nodiscard]] inline auto incidenct_edges(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.adjacent_edges(vertex_id, this->_edge_properties);
+            return this->_impl.incidenct_edges(vertex_id, this->_edge_properties);
         else
-            return this->_impl.adjacent_edges(vertex_id);
+            return this->_impl.incidenct_edges(vertex_id);
     }
 
-    // TODO: rename to incident_edges
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(const vertex_type& vertex) const {
-        return this->adjacent_edges(vertex.id());
+    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(const vertex_type& vertex) const {
+        return this->incidenct_edges(vertex.id());
     }
 
     [[nodiscard]] inline auto in_edges(const id_type vertex_id) const {
@@ -696,7 +694,7 @@ private:
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << "\n  adjacent edges:\n";
-            for (const auto& edge : this->adjacent_edges(vertex.id()))
+            for (const auto& edge : this->incidenct_edges(vertex.id()))
                 os << "\t- " << edge << '\n';
         }
     }
@@ -706,7 +704,7 @@ private:
 
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << " :";
-            for (const auto& edge : this->adjacent_edges(vertex.id()))
+            for (const auto& edge : this->incidenct_edges(vertex.id()))
                 os << ' ' << edge;
             os << '\n';
         }
@@ -736,7 +734,7 @@ private:
         if constexpr (traits::c_writable<typename edge_type::properties_type>) {
             if (with_edge_properties) {
                 const auto print_incident_edges = [this, &os](const id_type vertex_id) {
-                    for (const auto& edge : this->adjacent_edges(vertex_id)) {
+                    for (const auto& edge : this->incidenct_edges(vertex_id)) {
                         if (edge.source() != vertex_id)
                             continue; // vertex is not the source
                         os << edge.source() << ' ' << edge.target() << ' ' << edge.properties()
@@ -752,7 +750,7 @@ private:
         }
 
         const auto print_incident_edges = [this, &os](const id_type vertex_id) {
-            for (const auto& edge : this->adjacent_edges(vertex_id)) {
+            for (const auto& edge : this->incidenct_edges(vertex_id)) {
                 if (edge.source() != vertex_id)
                     continue; // vertex is not the source
                 os << edge.source() << ' ' << edge.target() << '\n';

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -120,9 +120,9 @@ public:
     [[nodiscard]] std::optional<edge_type> get_edge(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
-        const auto& adjacent_edges = this->_list[to_idx(source_id)];
-        const auto item_it = std::ranges::find(adjacent_edges, target_id, &item_type::vertex_id);
-        if (item_it == adjacent_edges.cend())
+        const auto& incidenct_edges = this->_list[to_idx(source_id)];
+        const auto item_it = std::ranges::find(incidenct_edges, target_id, &item_type::vertex_id);
+        if (item_it == incidenct_edges.cend())
             return std::nullopt;
         return std::make_optional<edge_type>(item_it->edge_id, source_id, target_id);
     }
@@ -132,11 +132,11 @@ public:
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
-        const auto& adjacent_edges = this->_list[to_idx(source_id)];
-        const auto item_it = std::ranges::find(adjacent_edges, target_id, [](const auto& item) {
+        const auto& incidenct_edges = this->_list[to_idx(source_id)];
+        const auto item_it = std::ranges::find(incidenct_edges, target_id, [](const auto& item) {
             return item.vertex_id;
         });
-        if (item_it == adjacent_edges.cend())
+        if (item_it == incidenct_edges.cend())
             return std::nullopt;
         return std::make_optional<edge_type>(
             item_it->edge_id, source_id, target_id, *edge_properties_map[to_idx(item_it->edge_id)]
@@ -188,13 +188,13 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(
         id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
@@ -257,14 +257,14 @@ public:
     [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
-        return this->adjacent_edges(vertex_id);
+        return this->incidenct_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id, const auto& edge_properties_map)
         const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
-        return this->adjacent_edges(vertex_id, edge_properties_map);
+        return this->incidenct_edges(vertex_id, edge_properties_map);
     }
 
     // --- comparison ---

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -120,9 +120,9 @@ public:
     [[nodiscard]] std::optional<edge_type> get_edge(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
-        const auto& incidenct_edges = this->_list[to_idx(source_id)];
-        const auto item_it = std::ranges::find(incidenct_edges, target_id, &item_type::vertex_id);
-        if (item_it == incidenct_edges.cend())
+        const auto& incident_edges = this->_list[to_idx(source_id)];
+        const auto item_it = std::ranges::find(incident_edges, target_id, &item_type::vertex_id);
+        if (item_it == incident_edges.cend())
             return std::nullopt;
         return std::make_optional<edge_type>(item_it->edge_id, source_id, target_id);
     }
@@ -132,11 +132,11 @@ public:
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
-        const auto& incidenct_edges = this->_list[to_idx(source_id)];
-        const auto item_it = std::ranges::find(incidenct_edges, target_id, [](const auto& item) {
+        const auto& incident_edges = this->_list[to_idx(source_id)];
+        const auto item_it = std::ranges::find(incident_edges, target_id, [](const auto& item) {
             return item.vertex_id;
         });
-        if (item_it == incidenct_edges.cend())
+        if (item_it == incident_edges.cend())
             return std::nullopt;
         return std::make_optional<edge_type>(
             item_it->edge_id, source_id, target_id, *edge_properties_map[to_idx(item_it->edge_id)]
@@ -188,13 +188,13 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(
         id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
@@ -257,14 +257,14 @@ public:
     [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
-        return this->incidenct_edges(vertex_id);
+        return this->incident_edges(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id, const auto& edge_properties_map)
         const
     requires(traits::c_has_non_empty_properties<edge_type>)
     {
-        return this->incidenct_edges(vertex_id, edge_properties_map);
+        return this->incident_edges(vertex_id, edge_properties_map);
     }
 
     // --- comparison ---

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -35,7 +35,7 @@ public:
 
     using vertex_type = typename GraphTraits::vertex_type;
     using edge_type = typename GraphTraits::edge_type;
-    using item_type = specialized::adjacency_list_item<id_type>;
+    using item_type = specialized::incidence_item<id_type>;
     using adjacency_storage_type = typename specialized::adjacency_list_impl_traits<
         adjacency_list>::template storage_type<item_type>;
 
@@ -173,8 +173,8 @@ public:
 
     gl_attr_force_inline void remove_edge(const edge_type& edge) {
         specialized_impl::remove_edge(*this, edge);
-        for (auto&& adj : this->_list)
-            for (auto& item : adj)
+        for (auto&& inc : this->_list)
+            for (auto& item : inc)
                 item.edge_id -= static_cast<id_type>(item.edge_id > edge.id());
     }
 
@@ -290,8 +290,8 @@ private:
             std::ranges::unique(removed_edge_ids).begin(), removed_edge_ids.end()
         );
 
-        for (auto&& adj : this->_list) {
-            for (auto& edge_item : adj) {
+        for (auto&& inc : this->_list) {
+            for (auto& edge_item : inc) {
                 auto it = std::ranges::lower_bound(removed_edge_ids, edge_item.edge_id);
                 if (it != removed_edge_ids.end() and *it == edge_item.edge_id)
                     edge_item.edge_id = invalid_id; // edge was removed

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -178,13 +178,13 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(
         id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -178,13 +178,13 @@ public:
         return removed_edge_ids;
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(id_type vertex_id) const
+    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(id_type vertex_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->out_edges(vertex_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto adjacent_edges(
+    [[nodiscard]] gl_attr_force_inline auto incidenct_edges(
         id_type vertex_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -25,18 +25,18 @@ class adjacency_list;
 namespace specialized {
 
 template <traits::c_id_type IdType>
-struct adjacency_list_item {
+struct incidence_item {
     using id_type = IdType;
 
     id_type vertex_id;
     id_type edge_id;
 
-    [[nodiscard]] bool operator==(const adjacency_list_item&) const = default;
+    [[nodiscard]] bool operator==(const incidence_item&) const = default;
 };
 
 namespace detail {
 
-template <traits::c_instantiation_of<adjacency_list_item> AdjListItem>
+template <traits::c_instantiation_of<incidence_item> AdjListItem>
 [[nodiscard]] auto strict_find(traits::c_range_of<AdjListItem> auto& edge_list, const auto& edge) {
     const auto it = std::ranges::find(edge_list, edge.id(), &AdjListItem::edge_id);
     if (it == edge_list.end())
@@ -58,7 +58,7 @@ struct directed_adjacency_list {
     using impl_type = AdjacencyList;
     using id_type = typename impl_type::id_type;
     using edge_type = typename impl_type::edge_type;
-    using item_type = adjacency_list_item<id_type>;
+    using item_type = incidence_item<id_type>;
 
     [[nodiscard]] static auto in_edges(const impl_type& self, id_type vertex_id) {
         std::vector<item_type> in_edges;
@@ -69,7 +69,7 @@ struct directed_adjacency_list {
                       return item.vertex_id == tgt_id;
                   })
                 | std::views::transform([src_id](const auto& item) {
-                      return adjacency_list_item{src_id, item.edge_id};
+                      return incidence_item{src_id, item.edge_id};
                   });
             in_edges.insert(in_edges.end(), in_edges_view.begin(), in_edges_view.end());
         }
@@ -101,8 +101,8 @@ struct directed_adjacency_list {
     [[nodiscard]] static std::vector<size_type> in_degree_map(const impl_type& self) {
         std::vector<size_type> in_degree_map(self._list.size(), 0uz);
 
-        for (const auto& adj_edges : self._list)
-            for (const auto& item : adj_edges)
+        for (const auto& inc_edges : self._list)
+            for (const auto& item : inc_edges)
                 ++in_degree_map[to_idx(item.vertex_id)];
 
         return in_degree_map;
@@ -112,7 +112,7 @@ struct directed_adjacency_list {
         const impl_type& self
     ) {
         return self._list
-             | std::views::transform([](const auto& adj_edges) { return adj_edges.size(); })
+             | std::views::transform([](const auto& inc_edges) { return inc_edges.size(); })
              | std::ranges::to<std::vector<size_type>>();
     }
 
@@ -138,19 +138,19 @@ struct directed_adjacency_list {
 
         // remove all edges incident to the vertex
         for (auto idx = 0uz; idx < self._list.size(); ++idx) {
-            auto& adj_edges = self._list[idx];
-            if (idx == vertex_idx or adj_edges.empty())
+            auto& inc_edges = self._list[idx];
+            if (idx == vertex_idx or inc_edges.empty())
                 continue;
 
             const auto removed_subrng =
-                std::ranges::remove_if(adj_edges, [vertex_id, &removed_edges](const auto& item) {
+                std::ranges::remove_if(inc_edges, [vertex_id, &removed_edges](const auto& item) {
                     if (item.vertex_id == vertex_id) {
                         removed_edges.push_back(item.edge_id);
                         return true;
                     }
                     return false;
                 });
-            adj_edges.erase(removed_subrng.begin(), removed_subrng.end());
+            inc_edges.erase(removed_subrng.begin(), removed_subrng.end());
         }
 
         // remove the list of edges incident from the vertex entirely
@@ -170,16 +170,16 @@ struct directed_adjacency_list {
         id_type source_id,
         const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
-        auto& adjacent_edges_source = self._list[to_idx(source_id)];
-        adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());
+        auto& inc_edges_source = self._list[to_idx(source_id)];
+        inc_edges_source.reserve(inc_edges_source.size() + target_ids.size());
 
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids))
-            adjacent_edges_source.emplace_back(target_id, edge_id);
+            inc_edges_source.emplace_back(target_id, edge_id);
     }
 
     gl_attr_force_inline static void remove_edge(impl_type& self, const edge_type& edge) {
-        auto& adj_edges = self._list[to_idx(edge.source())];
-        adj_edges.erase(detail::strict_find<item_type>(adj_edges, edge));
+        auto& inc_edges = self._list[to_idx(edge.source())];
+        inc_edges.erase(detail::strict_find<item_type>(inc_edges, edge));
     }
 };
 
@@ -189,7 +189,7 @@ struct undirected_adjacency_list {
     using impl_type = AdjacencyList;
     using id_type = typename impl_type::id_type;
     using edge_type = typename impl_type::edge_type;
-    using item_type = adjacency_list_item<id_type>;
+    using item_type = incidence_item<id_type>;
 
     [[nodiscard]] gl_attr_force_inline static auto in_edges(
         const impl_type& self, id_type vertex_id
@@ -244,11 +244,11 @@ struct undirected_adjacency_list {
             if (item.vertex_id == vertex_id)
                 continue; // will be removed with the vertex's list
 
-            auto& adj_edges = self._list[to_idx(item.vertex_id)];
+            auto& inc_edges = self._list[to_idx(item.vertex_id)];
             const auto removed_subrng = std::ranges::remove_if(
-                adj_edges, [vertex_id](const auto& item) { return item.vertex_id == vertex_id; }
+                inc_edges, [vertex_id](const auto& item) { return item.vertex_id == vertex_id; }
             );
-            adj_edges.erase(removed_subrng.begin(), removed_subrng.end());
+            inc_edges.erase(removed_subrng.begin(), removed_subrng.end());
         }
 
         // remove the list of edges incident from the vertex entirely
@@ -271,23 +271,23 @@ struct undirected_adjacency_list {
         id_type source_id,
         const traits::c_forward_range_of<id_type> auto& target_ids
     ) {
-        auto& adjacent_edges_source = self._list[to_idx(source_id)];
-        adjacent_edges_source.reserve(adjacent_edges_source.size() + target_ids.size());
+        auto& inc_edges_source = self._list[to_idx(source_id)];
+        inc_edges_source.reserve(inc_edges_source.size() + target_ids.size());
 
         for (auto [edge_id, target_id] : std::views::zip(edge_ids, target_ids)) {
-            adjacent_edges_source.emplace_back(target_id, edge_id);
+            inc_edges_source.emplace_back(target_id, edge_id);
             if (source_id != target_id)
                 self._list[to_idx(target_id)].emplace_back(source_id, edge_id);
         }
     }
 
     static void remove_edge(impl_type& self, const edge_type& edge) {
-        auto& adj_edges_first = self._list[to_idx(edge.source())];
-        auto& adj_edges_second = self._list[to_idx(edge.target())];
+        auto& inc_edges_first = self._list[to_idx(edge.source())];
+        auto& inc_edges_second = self._list[to_idx(edge.target())];
 
-        adj_edges_first.erase(detail::strict_find<item_type>(adj_edges_first, edge));
+        inc_edges_first.erase(detail::strict_find<item_type>(inc_edges_first, edge));
         if (not edge.is_loop())
-            adj_edges_second.erase(detail::strict_find<item_type>(adj_edges_second, edge));
+            inc_edges_second.erase(detail::strict_find<item_type>(inc_edges_second, edge));
     }
 };
 

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -78,9 +78,9 @@ struct directed_adjacency_list {
 
     [[nodiscard]] static size_type in_degree(const impl_type& self, id_type vertex_id) {
         size_type in_deg = 0uz;
-        for (const auto& incidenct_edges : self._list)
+        for (const auto& incident_edges : self._list)
             in_deg += static_cast<size_type>(
-                std::ranges::count(incidenct_edges, vertex_id, &item_type::vertex_id)
+                std::ranges::count(incident_edges, vertex_id, &item_type::vertex_id)
             );
 
         return in_deg;

--- a/include/gl/impl/specialized/adjacency_list.hpp
+++ b/include/gl/impl/specialized/adjacency_list.hpp
@@ -78,9 +78,9 @@ struct directed_adjacency_list {
 
     [[nodiscard]] static size_type in_degree(const impl_type& self, id_type vertex_id) {
         size_type in_deg = 0uz;
-        for (const auto& adjacent_edges : self._list)
+        for (const auto& incidenct_edges : self._list)
             in_deg += static_cast<size_type>(
-                std::ranges::count(adjacent_edges, vertex_id, &item_type::vertex_id)
+                std::ranges::count(incidenct_edges, vertex_id, &item_type::vertex_id)
             );
 
         return in_deg;

--- a/include/gl/impl/specialized/flat_adjacency_list.hpp
+++ b/include/gl/impl/specialized/flat_adjacency_list.hpp
@@ -23,7 +23,7 @@ struct directed_flat_adjacency_list {
     using impl_type = AdjacencyList;
     using id_type = typename impl_type::id_type;
     using edge_type = typename impl_type::edge_type;
-    using item_type = adjacency_list_item<id_type>;
+    using item_type = incidence_item<id_type>;
 
     [[nodiscard]] static auto in_edges(const impl_type& self, id_type vertex_id) {
         std::vector<item_type> in_edges;
@@ -34,7 +34,7 @@ struct directed_flat_adjacency_list {
                       return item.vertex_id == tgt_id;
                   })
                 | std::views::transform([src_id](const auto& item) {
-                      return adjacency_list_item{src_id, item.edge_id};
+                      return incidence_item{src_id, item.edge_id};
                   });
             in_edges.insert(in_edges.end(), in_edges_view.begin(), in_edges_view.end());
         }
@@ -151,7 +151,7 @@ struct undirected_flat_adjacency_list {
     using impl_type = AdjacencyList;
     using id_type = typename impl_type::id_type;
     using edge_type = typename impl_type::edge_type;
-    using item_type = adjacency_list_item<id_type>;
+    using item_type = incidence_item<id_type>;
 
     [[nodiscard]] gl_attr_force_inline static auto in_edges(
         const impl_type& self, id_type vertex_id
@@ -255,17 +255,17 @@ struct undirected_flat_adjacency_list {
 
         // remove from the source segment
         {
-            auto adj_edges = self._list[src_idx];
-            const auto it = detail::strict_find<item_type>(adj_edges, edge);
-            const auto pos = static_cast<size_type>(std::distance(adj_edges.begin(), it));
+            auto inc_edges = self._list[src_idx];
+            const auto it = detail::strict_find<item_type>(inc_edges, edge);
+            const auto pos = static_cast<size_type>(std::distance(inc_edges.begin(), it));
             self._list.erase(src_idx, pos);
         }
 
         // remove from the target segment (if edge not a self-loop)
         if (src_idx != tgt_idx) {
-            auto adj_edges = self._list[tgt_idx];
-            const auto it = detail::strict_find<item_type>(adj_edges, edge);
-            const auto pos = static_cast<size_type>(std::distance(adj_edges.begin(), it));
+            auto inc_edges = self._list[tgt_idx];
+            const auto it = detail::strict_find<item_type>(inc_edges, edge);
+            const auto pos = static_cast<size_type>(std::distance(inc_edges.begin(), it));
             self._list.erase(tgt_idx, pos);
         }
     }

--- a/include/gl/io/stream_options_manipulator.hpp
+++ b/include/gl/io/stream_options_manipulator.hpp
@@ -7,6 +7,7 @@
 #include "gl/attributes/force_inline.hpp"
 
 #include <iostream>
+#include <utility>
 
 namespace gl::io {
 

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -13,7 +13,7 @@ void verify_graph_structure(const GraphType& actual, const GraphType& expected) 
 
     // verify that the edges of the in graph are equivalent to the edges of the out graph
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
-        return std::ranges::all_of(actual.adjacent_edges(v_actual), [&](const auto& edge) {
+        return std::ranges::all_of(actual.incidenct_edges(v_actual), [&](const auto& edge) {
             return expected.has_edge(edge.source(), edge.target());
         });
     }));
@@ -35,7 +35,7 @@ void verify_vertex_properties(const GraphType& actual, const GraphType& expected
 template <gl::traits::c_graph GraphType>
 void verify_edge_properties(const GraphType& actual, const GraphType& expected) {
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
-        return std::ranges::all_of(actual.adjacent_edges(v_actual), [&](const auto& edge) {
+        return std::ranges::all_of(actual.incidenct_edges(v_actual), [&](const auto& edge) {
             return edge.properties()
                 == expected.get_edge(edge.source(), edge.target())->properties();
         });

--- a/tests/include/testing/gl/io_common.hpp
+++ b/tests/include/testing/gl/io_common.hpp
@@ -13,7 +13,7 @@ void verify_graph_structure(const GraphType& actual, const GraphType& expected) 
 
     // verify that the edges of the in graph are equivalent to the edges of the out graph
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
-        return std::ranges::all_of(actual.incidenct_edges(v_actual), [&](const auto& edge) {
+        return std::ranges::all_of(actual.incident_edges(v_actual), [&](const auto& edge) {
             return expected.has_edge(edge.source(), edge.target());
         });
     }));
@@ -35,7 +35,7 @@ void verify_vertex_properties(const GraphType& actual, const GraphType& expected
 template <gl::traits::c_graph GraphType>
 void verify_edge_properties(const GraphType& actual, const GraphType& expected) {
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
-        return std::ranges::all_of(actual.incidenct_edges(v_actual), [&](const auto& edge) {
+        return std::ranges::all_of(actual.incident_edges(v_actual), [&](const auto& edge) {
             return edge.properties()
                 == expected.get_edge(edge.source(), edge.target())->properties();
         });

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -170,9 +170,9 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        const auto incident_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(incident_edges_1.size(), 1uz);
-        CHECK_EQ(sut.incidenct_edges(constants::v2_id).size(), 0uz);
+        CHECK_EQ(sut.incident_edges(constants::v2_id).size(), 0uz);
 
         const auto& new_edge_extracted = incident_edges_1[0uz];
         CHECK_EQ(new_edge_extracted, new_edge);
@@ -181,7 +181,7 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     SUBCASE("at should return the incident edges of a vertex") {
         init_complete_graph();
         for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incidenct_edges(vertex_id)));
+            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incident_edges(vertex_id)));
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -253,16 +253,16 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     SUBCASE("remove_edge should remove the edge from the source vertex's list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
-        REQUIRE_EQ(incidenct_edges.size(), n_incident_edges_for_fully_connected_vertex);
+        auto incident_edges = sut.incident_edges(constants::v1_id);
+        REQUIRE_EQ(incident_edges.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = incidenct_edges[0uz];
+        const auto& edge_to_remove = incident_edges[0uz];
         sut.remove_edge(edge_to_remove);
 
-        incidenct_edges = sut.incidenct_edges(constants::v1_id);
-        REQUIRE_EQ(incidenct_edges.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
+        incident_edges = sut.incident_edges(constants::v1_id);
+        REQUIRE_EQ(incident_edges.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         // validate that the incident edges list has been properly aligned
-        CHECK_EQ(std::ranges::find(incidenct_edges, edge_to_remove), incidenct_edges.end());
+        CHECK_EQ(std::ranges::find(incident_edges, edge_to_remove), incident_edges.end());
     }
 
     SUBCASE("in_edges should return edges where the vertex is the target") {
@@ -386,12 +386,12 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
+        const auto adj_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
+        const auto adj_edges_2 = sut.incident_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge6.id() - n_removed_edges);
         CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);
@@ -470,8 +470,8 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-        const auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+        const auto incident_edges_1 = sut.incident_edges(constants::v1_id);
+        const auto incident_edges_2 = sut.incident_edges(constants::v2_id);
 
         REQUIRE_EQ(incident_edges_1.size(), 1uz);
         REQUIRE_EQ(incident_edges_2.size(), 1uz);
@@ -488,17 +488,17 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE(new_edge.is_loop());
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-        const auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
-        REQUIRE_EQ(incidenct_edges.size(), 1uz);
+        const auto incident_edges = sut.incident_edges(constants::v1_id);
+        REQUIRE_EQ(incident_edges.size(), 1uz);
 
-        const auto& new_edge_extracted_1 = incidenct_edges[0uz];
+        const auto& new_edge_extracted_1 = incident_edges[0uz];
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
     SUBCASE("at should return the incident edges of a vertex") {
         init_complete_graph();
         for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incidenct_edges(vertex_id)));
+            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incident_edges(vertex_id)));
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -577,25 +577,25 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto incident_edges_first = sut.incidenct_edges(constants::v1_id);
+        auto incident_edges_first = sut.incident_edges(constants::v1_id);
         REQUIRE_EQ(incident_edges_first.size(), n_incident_edges_for_fully_connected_vertex);
 
         const auto& edge_to_remove = incident_edges_first[0uz];
 
         const auto target_id = edge_to_remove.target();
-        REQUIRE_EQ(sut.incidenct_edges(target_id).size(), 1uz);
+        REQUIRE_EQ(sut.incident_edges(target_id).size(), 1uz);
 
         sut.remove_edge(edge_to_remove);
 
         // validate that the first incident edges list has been properly aligned
-        incident_edges_first = sut.incidenct_edges(0uz);
+        incident_edges_first = sut.incident_edges(0uz);
         REQUIRE_EQ(incident_edges_first.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         CHECK_EQ(
             std::ranges::find(incident_edges_first, edge_to_remove), incident_edges_first.end()
         );
 
         // validate that the second adjacent edges list has been properly aligned
-        const auto incident_edges_second = sut.incidenct_edges(target_id);
+        const auto incident_edges_second = sut.incident_edges(target_id);
         REQUIRE_EQ(incident_edges_second.size(), 0uz);
         CHECK_EQ(
             std::ranges::find(incident_edges_second, edge_to_remove), incident_edges_second.end()
@@ -609,8 +609,8 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
         const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-        CHECK(std::ranges::equal(in_edges, sut.incidenct_edges(constants::v1_id)));
-        CHECK(std::ranges::equal(out_edges, sut.incidenct_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(in_edges, sut.incident_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.incident_edges(constants::v1_id)));
     }
 
     SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from} the given "
@@ -693,12 +693,12 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
+        const auto adj_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
+        const auto adj_edges_2 = sut.incident_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -38,8 +38,8 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
             "list") {
         SutType sut{constants::n_elements};
         REQUIRE_EQ(fixture.size(sut), constants::n_elements);
-        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adjacent_items) {
-            return adjacent_items.empty();
+        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adj_items) {
+            return adj_items.empty();
         }));
     }
 
@@ -53,8 +53,8 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
         }
 
         CHECK_EQ(fixture.size(sut), target_n_vertices);
-        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adjacent_items) {
-            return adjacent_items.empty();
+        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adj_items) {
+            return adj_items.empty();
         }));
     }
 
@@ -63,8 +63,8 @@ TEST_CASE_TEMPLATE_DEFINE("common adjacency list tests", SutType, common_adj_lis
         sut.add_vertices(constants::n_elements);
 
         CHECK_EQ(fixture.size(sut), constants::n_elements);
-        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adjacent_items) {
-            return adjacent_items.empty();
+        CHECK(std::ranges::all_of(fixture.get(sut), [](const auto& adj_items) {
+            return adj_items.empty();
         }));
     }
 
@@ -135,12 +135,12 @@ struct test_directed_adjacency_list : public test_adjacency_list {
             fully_connect_vertex(source_id, no_loops);
 
         if (no_loops)
-            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex;
+            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adj_items) {
+                return adj_items.size() == n_incident_edges_for_fully_connected_vertex;
             }));
         else
-            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
+            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adj_items) {
+                return adj_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 
@@ -170,18 +170,18 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-        CHECK_EQ(adjacent_edges_1.size(), 1uz);
-        CHECK_EQ(sut.adjacent_edges(constants::v2_id).size(), 0uz);
+        const auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        CHECK_EQ(incident_edges_1.size(), 1uz);
+        CHECK_EQ(sut.incidenct_edges(constants::v2_id).size(), 0uz);
 
-        const auto& new_edge_extracted = adjacent_edges_1[0uz];
+        const auto& new_edge_extracted = incident_edges_1[0uz];
         CHECK_EQ(new_edge_extracted, new_edge);
     }
 
-    SUBCASE("at should return the adjacent edges of a vertex") {
+    SUBCASE("at should return the incident edges of a vertex") {
         init_complete_graph();
         for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.adjacent_edges(vertex_id)));
+            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incidenct_edges(vertex_id)));
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -253,16 +253,16 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
     SUBCASE("remove_edge should remove the edge from the source vertex's list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(adjacent_edges.size(), n_incident_edges_for_fully_connected_vertex);
+        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        REQUIRE_EQ(incidenct_edges.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges[0uz];
+        const auto& edge_to_remove = incidenct_edges[0uz];
         sut.remove_edge(edge_to_remove);
 
-        adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(adjacent_edges.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
-        // validate that the adjacent edges list has been properly aligned
-        CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
+        incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        REQUIRE_EQ(incidenct_edges.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
+        // validate that the incident edges list has been properly aligned
+        CHECK_EQ(std::ranges::find(incidenct_edges, edge_to_remove), incidenct_edges.end());
     }
 
     SUBCASE("in_edges should return edges where the vertex is the target") {
@@ -386,12 +386,12 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        const auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        const auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge6.id() - n_removed_edges);
         CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);
@@ -432,12 +432,12 @@ struct test_undirected_adjacency_list : public test_adjacency_list {
         }
 
         if (no_loops)
-            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex;
+            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adj_items) {
+                return adj_items.size() == n_incident_edges_for_fully_connected_vertex;
             }));
         else
-            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adjacent_items) {
-                return adjacent_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
+            REQUIRE(std::ranges::all_of(get(sut), [&](const auto& adj_items) {
+                return adj_items.size() == n_incident_edges_for_fully_connected_vertex + 1uz;
             }));
     }
 
@@ -470,16 +470,16 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        const auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-        const auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+        const auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        const auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-        REQUIRE_EQ(adjacent_edges_1.size(), 1uz);
-        REQUIRE_EQ(adjacent_edges_2.size(), 1uz);
+        REQUIRE_EQ(incident_edges_1.size(), 1uz);
+        REQUIRE_EQ(incident_edges_2.size(), 1uz);
 
-        const auto& new_edge_extracted_1 = adjacent_edges_1[0uz];
+        const auto& new_edge_extracted_1 = incident_edges_1[0uz];
         CHECK_EQ(new_edge_extracted_1, new_edge);
 
-        const auto& new_edge_extracted_2 = adjacent_edges_2[0uz];
+        const auto& new_edge_extracted_2 = incident_edges_2[0uz];
         CHECK_EQ(new_edge_extracted_2, new_edge);
     }
 
@@ -488,17 +488,17 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         REQUIRE(new_edge.is_loop());
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-        const auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(adjacent_edges.size(), 1uz);
+        const auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        REQUIRE_EQ(incidenct_edges.size(), 1uz);
 
-        const auto& new_edge_extracted_1 = adjacent_edges[0uz];
+        const auto& new_edge_extracted_1 = incidenct_edges[0uz];
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
-    SUBCASE("at should return the adjacent edges of a vertex") {
+    SUBCASE("at should return the incident edges of a vertex") {
         init_complete_graph();
         for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.adjacent_edges(vertex_id)));
+            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incidenct_edges(vertex_id)));
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -577,28 +577,28 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
     SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex);
+        auto incident_edges_first = sut.incidenct_edges(constants::v1_id);
+        REQUIRE_EQ(incident_edges_first.size(), n_incident_edges_for_fully_connected_vertex);
 
-        const auto& edge_to_remove = adjacent_edges_first[0uz];
+        const auto& edge_to_remove = incident_edges_first[0uz];
 
         const auto target_id = edge_to_remove.target();
-        REQUIRE_EQ(sut.adjacent_edges(target_id).size(), 1uz);
+        REQUIRE_EQ(sut.incidenct_edges(target_id).size(), 1uz);
 
         sut.remove_edge(edge_to_remove);
 
-        // validate that the first adjacent edges list has been properly aligned
-        adjacent_edges_first = sut.adjacent_edges(0uz);
-        REQUIRE_EQ(adjacent_edges_first.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
+        // validate that the first incident edges list has been properly aligned
+        incident_edges_first = sut.incidenct_edges(0uz);
+        REQUIRE_EQ(incident_edges_first.size(), n_incident_edges_for_fully_connected_vertex - 1uz);
         CHECK_EQ(
-            std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end()
+            std::ranges::find(incident_edges_first, edge_to_remove), incident_edges_first.end()
         );
 
         // validate that the second adjacent edges list has been properly aligned
-        const auto adjacent_edges_second = sut.adjacent_edges(target_id);
-        REQUIRE_EQ(adjacent_edges_second.size(), 0uz);
+        const auto incident_edges_second = sut.incidenct_edges(target_id);
+        REQUIRE_EQ(incident_edges_second.size(), 0uz);
         CHECK_EQ(
-            std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end()
+            std::ranges::find(incident_edges_second, edge_to_remove), incident_edges_second.end()
         );
     }
 
@@ -609,8 +609,8 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
         const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-        CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
-        CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(in_edges, sut.incidenct_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.incidenct_edges(constants::v1_id)));
     }
 
     SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from} the given "
@@ -693,12 +693,12 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        const auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        const auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
         CHECK_EQ(adj_edges_1.size(), 1uz);
         CHECK_EQ(adj_edges_1.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_1.front().target(), constants::v2_id);
 
-        const auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        const auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
         CHECK_EQ(adj_edges_2.size(), 1uz);
         CHECK_EQ(adj_edges_2.front().id(), edge5.id() - n_removed_edges);
         CHECK_EQ(adj_edges_2.front().target(), constants::v1_id);

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -215,11 +215,11 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-        CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-        CHECK_EQ(gl::util::range_size(sut.adjacent_edges(constants::v2_id)), 0uz);
+        auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
+        CHECK_EQ(gl::util::range_size(sut.incidenct_edges(constants::v2_id)), 0uz);
 
-        const auto& new_edge_extracted = *std::ranges::begin(adjacent_edges_1);
+        const auto& new_edge_extracted = *std::ranges::begin(incident_edges_1);
         CHECK_EQ(new_edge_extracted, new_edge);
     }
 
@@ -238,14 +238,14 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         }
     }
 
-    SUBCASE("adjacent_edges should return a filtered view of edges adjacent with the given vertex"
+    SUBCASE("incidenct_edges should return a filtered view of edges incident with the given vertex"
     ) {
         const auto vertex_id = constants::v1_id;
         const auto edge = add_edge(vertex_id, constants::v2_id);
-        auto adjacent_edges = sut.adjacent_edges(vertex_id);
+        auto incidenct_edges = sut.incidenct_edges(vertex_id);
 
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
-        CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
+        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(incidenct_edges), edge);
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -296,20 +296,20 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
     SUBCASE("remove_edge should remove the edge from the source vertex's list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
+        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex
+            gl::util::range_size(incidenct_edges), n_incident_edges_for_fully_connected_vertex
         );
 
-        const auto edge_to_remove = *std::ranges::begin(adjacent_edges);
+        const auto edge_to_remove = *std::ranges::begin(incidenct_edges);
         sut.remove_edge(edge_to_remove);
 
-        // validate that the adjacent edges list has been properly aligned
-        adjacent_edges = sut.adjacent_edges(constants::v1_id);
+        // validate that the incident edges list has been properly aligned
+        incidenct_edges = sut.incidenct_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(adjacent_edges), n_incident_edges_for_fully_connected_vertex - 1uz
+            gl::util::range_size(incidenct_edges), n_incident_edges_for_fully_connected_vertex - 1uz
         );
-        CHECK_EQ(std::ranges::find(adjacent_edges, edge_to_remove), adjacent_edges.end());
+        CHECK_EQ(std::ranges::find(incidenct_edges, edge_to_remove), incidenct_edges.end());
     }
 
     SUBCASE("in_edges should return edges where the vertex is the target") {
@@ -432,12 +432,12 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
         CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge5.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-        auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
         CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge6.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
@@ -520,16 +520,16 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-        auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+        auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
+        REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
+        REQUIRE_EQ(gl::util::range_size(incident_edges_2), 1uz);
 
-        const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+        const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
         CHECK_EQ(new_edge_extracted_1, new_edge);
 
-        const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+        const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
         CHECK_EQ(new_edge_extracted_2, new_edge);
     }
 
@@ -538,10 +538,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(new_edge.is_loop());
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-        auto adjacent_edges = sut.adjacent_edges(constants::v1_id);
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
+        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
 
-        const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges);
+        const auto new_edge_extracted_1 = *std::ranges::begin(incidenct_edges);
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
@@ -566,14 +566,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(v3_row_view[constants::v2_id], edge2);
     }
 
-    SUBCASE("adjacent_edges should return a filtered view of edges adjacent with the given vertex"
+    SUBCASE("incidenct_edges should return a filtered view of edges incident with the given vertex"
     ) {
         const auto vertex_id = constants::v1_id;
         const auto edge = add_edge(vertex_id, constants::v2_id);
-        auto adjacent_edges = sut.adjacent_edges(vertex_id);
+        auto incidenct_edges = sut.incidenct_edges(vertex_id);
 
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges), 1uz);
-        CHECK_EQ(*std::ranges::begin(adjacent_edges), edge);
+        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(incidenct_edges), edge);
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -626,33 +626,33 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
+        auto incident_edges_first = sut.incidenct_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(adjacent_edges_first), n_incident_edges_for_fully_connected_vertex
+            gl::util::range_size(incident_edges_first), n_incident_edges_for_fully_connected_vertex
         );
 
-        const auto edge_to_remove = *std::ranges::begin(adjacent_edges_first);
+        const auto edge_to_remove = *std::ranges::begin(incident_edges_first);
 
         const auto target_id = edge_to_remove.target();
-        REQUIRE_EQ(gl::util::range_size(sut.adjacent_edges(target_id)), 1uz);
+        REQUIRE_EQ(gl::util::range_size(sut.incidenct_edges(target_id)), 1uz);
 
         sut.remove_edge(edge_to_remove);
 
-        // validate that the first adjacent edges list has been properly aligned
-        adjacent_edges_first = sut.adjacent_edges(constants::v1_id);
+        // validate that the first incident edges list has been properly aligned
+        incident_edges_first = sut.incidenct_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(adjacent_edges_first),
+            gl::util::range_size(incident_edges_first),
             n_incident_edges_for_fully_connected_vertex - 1uz
         );
         CHECK_EQ(
-            std::ranges::find(adjacent_edges_first, edge_to_remove), adjacent_edges_first.end()
+            std::ranges::find(incident_edges_first, edge_to_remove), incident_edges_first.end()
         );
 
-        // validate that the second adjacent edges list has been properly aligned
-        auto adjacent_edges_second = sut.adjacent_edges(target_id);
-        REQUIRE_EQ(gl::util::range_size(adjacent_edges_second), 0uz);
+        // validate that the second incident edges list has been properly aligned
+        auto incident_edges_second = sut.incidenct_edges(target_id);
+        REQUIRE_EQ(gl::util::range_size(incident_edges_second), 0uz);
         CHECK_EQ(
-            std::ranges::find(adjacent_edges_second, edge_to_remove), adjacent_edges_second.end()
+            std::ranges::find(incident_edges_second, edge_to_remove), incident_edges_second.end()
         );
     }
 
@@ -663,8 +663,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
         const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-        CHECK(std::ranges::equal(in_edges, sut.adjacent_edges(constants::v1_id)));
-        CHECK(std::ranges::equal(out_edges, sut.adjacent_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(in_edges, sut.incidenct_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.incidenct_edges(constants::v1_id)));
     }
 
     SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from/with} the given "
@@ -744,12 +744,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        auto adj_edges_1 = sut.adjacent_edges(constants::v1_id);
+        auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
         CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge3.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-        auto adj_edges_2 = sut.adjacent_edges(constants::v2_id);
+        auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
         CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge3.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -215,9 +215,9 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+        auto incident_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
-        CHECK_EQ(gl::util::range_size(sut.incidenct_edges(constants::v2_id)), 0uz);
+        CHECK_EQ(gl::util::range_size(sut.incident_edges(constants::v2_id)), 0uz);
 
         const auto& new_edge_extracted = *std::ranges::begin(incident_edges_1);
         CHECK_EQ(new_edge_extracted, new_edge);
@@ -238,14 +238,14 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         }
     }
 
-    SUBCASE("incidenct_edges should return a filtered view of edges incident with the given vertex"
+    SUBCASE("incident_edges should return a filtered view of edges incident with the given vertex"
     ) {
         const auto vertex_id = constants::v1_id;
         const auto edge = add_edge(vertex_id, constants::v2_id);
-        auto incidenct_edges = sut.incidenct_edges(vertex_id);
+        auto incident_edges = sut.incident_edges(vertex_id);
 
-        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
-        CHECK_EQ(*std::ranges::begin(incidenct_edges), edge);
+        REQUIRE_EQ(gl::util::range_size(incident_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(incident_edges), edge);
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -296,20 +296,20 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
     SUBCASE("remove_edge should remove the edge from the source vertex's list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        auto incident_edges = sut.incident_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(incidenct_edges), n_incident_edges_for_fully_connected_vertex
+            gl::util::range_size(incident_edges), n_incident_edges_for_fully_connected_vertex
         );
 
-        const auto edge_to_remove = *std::ranges::begin(incidenct_edges);
+        const auto edge_to_remove = *std::ranges::begin(incident_edges);
         sut.remove_edge(edge_to_remove);
 
         // validate that the incident edges list has been properly aligned
-        incidenct_edges = sut.incidenct_edges(constants::v1_id);
+        incident_edges = sut.incident_edges(constants::v1_id);
         REQUIRE_EQ(
-            gl::util::range_size(incidenct_edges), n_incident_edges_for_fully_connected_vertex - 1uz
+            gl::util::range_size(incident_edges), n_incident_edges_for_fully_connected_vertex - 1uz
         );
-        CHECK_EQ(std::ranges::find(incidenct_edges, edge_to_remove), incidenct_edges.end());
+        CHECK_EQ(std::ranges::find(incident_edges, edge_to_remove), incident_edges.end());
     }
 
     SUBCASE("in_edges should return edges where the vertex is the target") {
@@ -432,12 +432,12 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
+        auto adj_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge5.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-        auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
+        auto adj_edges_2 = sut.incident_edges(constants::v2_id);
         CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge6.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);
@@ -520,8 +520,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
         REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-        auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-        auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+        auto incident_edges_1 = sut.incident_edges(constants::v1_id);
+        auto incident_edges_2 = sut.incident_edges(constants::v2_id);
 
         REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
         REQUIRE_EQ(gl::util::range_size(incident_edges_2), 1uz);
@@ -538,10 +538,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(new_edge.is_loop());
         REQUIRE(new_edge.is_incident_from(constants::v1_id));
 
-        auto incidenct_edges = sut.incidenct_edges(constants::v1_id);
-        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
+        auto incident_edges = sut.incident_edges(constants::v1_id);
+        REQUIRE_EQ(gl::util::range_size(incident_edges), 1uz);
 
-        const auto new_edge_extracted_1 = *std::ranges::begin(incidenct_edges);
+        const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges);
         CHECK_EQ(new_edge_extracted_1, new_edge);
     }
 
@@ -566,14 +566,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_EQ(v3_row_view[constants::v2_id], edge2);
     }
 
-    SUBCASE("incidenct_edges should return a filtered view of edges incident with the given vertex"
+    SUBCASE("incident_edges should return a filtered view of edges incident with the given vertex"
     ) {
         const auto vertex_id = constants::v1_id;
         const auto edge = add_edge(vertex_id, constants::v2_id);
-        auto incidenct_edges = sut.incidenct_edges(vertex_id);
+        auto incident_edges = sut.incident_edges(vertex_id);
 
-        REQUIRE_EQ(gl::util::range_size(incidenct_edges), 1uz);
-        CHECK_EQ(*std::ranges::begin(incidenct_edges), edge);
+        REQUIRE_EQ(gl::util::range_size(incident_edges), 1uz);
+        CHECK_EQ(*std::ranges::begin(incident_edges), edge);
     }
 
     SUBCASE("has_edge(id, id) should return true if there is an edge in the graph which connects "
@@ -626,7 +626,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("remove_edge should remove the edge from both the first and second vertices' list") {
         fully_connect_vertex(constants::v1_id);
 
-        auto incident_edges_first = sut.incidenct_edges(constants::v1_id);
+        auto incident_edges_first = sut.incident_edges(constants::v1_id);
         REQUIRE_EQ(
             gl::util::range_size(incident_edges_first), n_incident_edges_for_fully_connected_vertex
         );
@@ -634,12 +634,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto edge_to_remove = *std::ranges::begin(incident_edges_first);
 
         const auto target_id = edge_to_remove.target();
-        REQUIRE_EQ(gl::util::range_size(sut.incidenct_edges(target_id)), 1uz);
+        REQUIRE_EQ(gl::util::range_size(sut.incident_edges(target_id)), 1uz);
 
         sut.remove_edge(edge_to_remove);
 
         // validate that the first incident edges list has been properly aligned
-        incident_edges_first = sut.incidenct_edges(constants::v1_id);
+        incident_edges_first = sut.incident_edges(constants::v1_id);
         REQUIRE_EQ(
             gl::util::range_size(incident_edges_first),
             n_incident_edges_for_fully_connected_vertex - 1uz
@@ -649,7 +649,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
 
         // validate that the second incident edges list has been properly aligned
-        auto incident_edges_second = sut.incidenct_edges(target_id);
+        auto incident_edges_second = sut.incident_edges(target_id);
         REQUIRE_EQ(gl::util::range_size(incident_edges_second), 0uz);
         CHECK_EQ(
             std::ranges::find(incident_edges_second, edge_to_remove), incident_edges_second.end()
@@ -663,8 +663,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         const auto in_edges = sut.in_edges(constants::v1_id) | std::ranges::to<std::vector>();
         const auto out_edges = sut.out_edges(constants::v1_id) | std::ranges::to<std::vector>();
 
-        CHECK(std::ranges::equal(in_edges, sut.incidenct_edges(constants::v1_id)));
-        CHECK(std::ranges::equal(out_edges, sut.incidenct_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(in_edges, sut.incident_edges(constants::v1_id)));
+        CHECK(std::ranges::equal(out_edges, sut.incident_edges(constants::v1_id)));
     }
 
     SUBCASE("{in_/out_/}degree should return the number of edges incident {to/from/with} the given "
@@ -744,12 +744,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Check the structure of the graph considering the aligned IDs
         CHECK_EQ(size(sut), constants::n_elements - 1uz);
 
-        auto adj_edges_1 = sut.incidenct_edges(constants::v1_id);
+        auto adj_edges_1 = sut.incident_edges(constants::v1_id);
         CHECK_EQ(gl::util::range_size(adj_edges_1), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).id(), edge3.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_1)).target(), constants::v2_id);
 
-        auto adj_edges_2 = sut.incidenct_edges(constants::v2_id);
+        auto adj_edges_2 = sut.incident_edges(constants::v2_id);
         CHECK_EQ(gl::util::range_size(adj_edges_2), 1uz);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).id(), edge3.id() - n_removed_edges);
         CHECK_EQ((*std::ranges::begin(adj_edges_2)).target(), constants::v1_id);

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -40,7 +40,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.incidenct_edges(vertex_id)) {
+                for (const auto& edge : sut.incident_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
                     expected_edges.emplace_back(edge.source(), edge.target());
                 }
@@ -128,7 +128,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.incidenct_edges(vertex_id))
+        for (const auto& edge : sut.incident_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
     const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);
@@ -185,7 +185,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.incidenct_edges(vertex_id)) {
+                for (const auto& edge : sut.incident_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
                     expected_edges.emplace_back(edge.source(), edge.target());
                 }
@@ -273,7 +273,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.incidenct_edges(vertex_id))
+        for (const auto& edge : sut.incident_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
     const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -40,7 +40,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
+                for (const auto& edge : sut.incidenct_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
                     expected_edges.emplace_back(edge.source(), edge.target());
                 }
@@ -128,7 +128,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.adjacent_edges(vertex_id))
+        for (const auto& edge : sut.incidenct_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
     const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);
@@ -185,7 +185,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             const weight_type edge_weight = 3;
             for (const auto vertex_id : sut.vertex_ids()) {
-                for (const auto& edge : sut.adjacent_edges(vertex_id)) {
+                for (const auto& edge : sut.incidenct_edges(vertex_id)) {
                     edge.properties().weight = edge_weight;
                     expected_edges.emplace_back(edge.source(), edge.target());
                 }
@@ -273,7 +273,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<vertex_id_pair> expected_edges;
     for (const auto vertex_id : sut.vertex_ids())
-        for (const auto& edge : sut.adjacent_edges(vertex_id))
+        for (const auto& edge : sut.incidenct_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
     const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -138,13 +138,13 @@ TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directi
         CHECK_EQ(sut.target(), fixture.v2);
     }
 
-    SUBCASE("incident_vertex should throw if input vertex is not incident with the edge") {
-        CHECK_THROWS_AS(discard_result(sut.incident_vertex(fixture.v3)), std::invalid_argument);
+    SUBCASE("other should throw if input vertex is not incident with the edge") {
+        CHECK_THROWS_AS(discard_result(sut.other(fixture.v3)), std::invalid_argument);
     }
 
-    SUBCASE("incident_vertex should return the vertex incident with the input vertex") {
-        CHECK_EQ(sut.incident_vertex(fixture.v1), fixture.v2);
-        CHECK_EQ(sut.incident_vertex(fixture.v2), fixture.v1);
+    SUBCASE("other should return the vertex adjacent with the input vertex") {
+        CHECK_EQ(sut.other(fixture.v1), fixture.v2);
+        CHECK_EQ(sut.other(fixture.v2), fixture.v1);
     }
 
     SUBCASE("is_incident_with should return true when the given vertex is one of the connected "

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -499,7 +499,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             }));
         }
 
-        SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
+        SUBCASE("remove_edge should properly remove the edge for both of its incident vertices") {
             const auto added_edge = sut.add_edge(vertex_1, vertex_2);
 
             REQUIRE_EQ(sut.size(), 1uz);
@@ -632,7 +632,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             }
         }
 
-        SUBCASE("remove_edge should properly remove the edge for both incident vertices") {
+        SUBCASE("remove_edge should properly remove the edge for both of its incident vertices") {
             const auto added_edge = sut.add_edge_with(vertex_1, vertex_2, constants::used);
 
             REQUIRE_EQ(sut.size(), 1uz);
@@ -730,14 +730,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
     }
 
-    SUBCASE("get_edge(vertex, vertex) should return nullopt if the given vertices are not incident"
+    SUBCASE("get_edge(vertex, vertex) should return nullopt if the given vertices are not adjacent"
     ) {
         sut_type sut{constants::n_elements};
         CHECK_FALSE(sut.get_edge(sut.get_vertex(constants::v1_id), sut.get_vertex(constants::v2_id))
         );
     }
 
-    SUBCASE("get_edge(vertex, vertex) should return a valid edge if the given vetices are incident"
+    SUBCASE("get_edge(vertex, vertex) should return a valid edge if the given vetices are adjacent"
     ) {
         sut_type sut{constants::n_elements};
         const auto vd_1 = sut.get_vertex(constants::v1_id);
@@ -772,14 +772,14 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
     }
 
-    SUBCASE("get_edges(id, id) should return an empty vector if the given vertices are not incident"
+    SUBCASE("get_edges(id, id) should return an empty vector if the given vertices are not adjacent"
     ) {
         sut_type sut{constants::n_elements};
         CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
     }
 
     SUBCASE("get_edges(id, id) should return a valid edge reference vector if the given vertices "
-            "are incident") {
+            "are adjacent") {
         sut_type sut{constants::n_elements};
         std::vector<edge_type> expected_edges;
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -92,7 +92,7 @@ struct test_graph {
             [&graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
                 const gl::default_id_type vertex_id
             ) {
-                return static_cast<std::size_t>(gl::util::range_size(graph.adjacent_edges(vertex_id)))
+                return static_cast<std::size_t>(gl::util::range_size(graph.incidenct_edges(vertex_id)))
                     == expected_n_edges;
             }
         ));
@@ -148,7 +148,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(std::ranges::all_of(
             constants::vertex_id_view,
             [&sut](const gl::default_id_type vertex_id) {
-                return sut.adjacent_edges(vertex_id).empty();
+                return sut.incidenct_edges(vertex_id).empty();
             }
         ));
     }
@@ -163,7 +163,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
             CHECK_EQ(sut.order(), v_id + 1u);
-            CHECK(sut.adjacent_edges(v_id).empty());
+            CHECK(sut.incidenct_edges(v_id).empty());
         }
 
         CHECK_EQ(sut.order(), target_n_vertices);
@@ -272,7 +272,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const gl::default_id_type vertex_id) {
-                return static_cast<std::size_t>(gl::util::range_size(sut.adjacent_edges(vertex_id)))
+                return static_cast<std::size_t>(gl::util::range_size(sut.incidenct_edges(vertex_id))
+                       )
                     == expected_n_incident_edges;
             }
         ));
@@ -304,7 +305,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const gl::default_id_type vertex_id) {
-                return static_cast<std::size_t>(gl::util::range_size(sut.adjacent_edges(vertex_id)))
+                return static_cast<std::size_t>(gl::util::range_size(sut.incidenct_edges(vertex_id))
+                       )
                     == expected_n_incident_edges;
             }
         ));
@@ -326,12 +328,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto expected_n_vertices = n_vertices - 2uz;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
-        constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;
+        constexpr auto expected_n_incident_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(
             sut.vertices(),
-            [&sut, expected_n_adjacent_edges](const auto& vertex) {
-                return gl::util::range_size(sut.adjacent_edges(vertex))
-                    == expected_n_adjacent_edges;
+            [&sut, expected_n_incident_edges](const auto& vertex) {
+                return gl::util::range_size(sut.incidenct_edges(vertex))
+                    == expected_n_incident_edges;
             }
         ));
     }
@@ -351,12 +353,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         constexpr auto expected_n_vertices = n_vertices - 2uz;
         REQUIRE_EQ(sut.order(), expected_n_vertices);
 
-        constexpr auto expected_n_adjacent_edges = expected_n_vertices - 1uz;
+        constexpr auto expected_n_incident_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(
             sut.vertices(),
-            [&sut, expected_n_adjacent_edges](const auto& vertex) {
-                return gl::util::range_size(sut.adjacent_edges(vertex))
-                    == expected_n_adjacent_edges;
+            [&sut, expected_n_incident_edges](const auto& vertex) {
+                return gl::util::range_size(sut.incidenct_edges(vertex))
+                    == expected_n_incident_edges;
             }
         ));
     }
@@ -387,19 +389,19 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-            const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
+            const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
-                const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
+                const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
             }
         }
 
@@ -415,19 +417,19 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-            const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
+            const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
-                const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
+                const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
             }
         }
 
@@ -502,21 +504,21 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+            REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
-                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
+                REQUIRE_EQ(gl::util::range_size(incident_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), 0uz);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 0uz);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 0uz);
+            CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
@@ -579,19 +581,19 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-            const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
+            const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
-                const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
+                const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
             }
         }
 
@@ -614,19 +616,19 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
-            const auto new_edge_extracted_1 = *std::ranges::begin(adjacent_edges_1);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
+            const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
-                const auto new_edge_extracted_2 = *std::ranges::begin(adjacent_edges_2);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
+                const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
                 CHECK_EQ(new_edge_extracted_2, new_edge);
             }
             else {
-                CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+                CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
             }
         }
 
@@ -635,21 +637,21 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            auto adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-            REQUIRE_EQ(gl::util::range_size(adjacent_edges_1), 1uz);
+            REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
-                REQUIRE_EQ(gl::util::range_size(adjacent_edges_2), 1uz);
+                REQUIRE_EQ(gl::util::range_size(incident_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), 0uz);
 
-            adjacent_edges_1 = sut.adjacent_edges(constants::v1_id);
-            adjacent_edges_2 = sut.adjacent_edges(constants::v2_id);
+            incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            incident_edges_2 = sut.incidenct_edges(constants::v2_id);
 
-            CHECK_EQ(gl::util::range_size(adjacent_edges_1), 0uz);
-            CHECK_EQ(gl::util::range_size(adjacent_edges_2), 0uz);
+            CHECK_EQ(gl::util::range_size(incident_edges_1), 0uz);
+            CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
@@ -816,33 +818,34 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
     }
 
-    SUBCASE("adjacent_edges(id) should throw if the vertex_id is invalid") {
+    SUBCASE("incidenct_edges(id) should throw if the vertex_id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            discard_result(sut.adjacent_edges(constants::out_of_rng_idx)), std::out_of_range
+            discard_result(sut.incidenct_edges(constants::out_of_rng_idx)), std::out_of_range
         );
     }
 
-    SUBCASE("adjacent_edges(id) should return a proper iterator range for a valid vertex") {
+    SUBCASE("incidenct_edges(id) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
 
-        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.adjacent_edges(0uz)), 0uz); }());
-    }
-
-    SUBCASE("adjacent_edges(vertex) should throw if the vertex is invalid") {
-        sut_type sut{constants::n_elements};
-
-        CHECK_THROWS_AS(
-            discard_result(sut.adjacent_edges(fixture.out_of_range_vertex)), std::out_of_range
+        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.incidenct_edges(0uz)), 0uz); }()
         );
     }
 
-    SUBCASE("adjacent_edges(vertex) should return a proper iterator range for a valid vertex") {
+    SUBCASE("incidenct_edges(vertex) should throw if the vertex is invalid") {
+        sut_type sut{constants::n_elements};
+
+        CHECK_THROWS_AS(
+            discard_result(sut.incidenct_edges(fixture.out_of_range_vertex)), std::out_of_range
+        );
+    }
+
+    SUBCASE("incidenct_edges(vertex) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
         const auto vertex = sut.get_vertex(0uz);
 
         CHECK_NOTHROW([&sut, &vertex]() {
-            CHECK_EQ(gl::util::range_size(sut.adjacent_edges(vertex)), 0uz);
+            CHECK_EQ(gl::util::range_size(sut.incidenct_edges(vertex)), 0uz);
         }());
     }
 

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -92,7 +92,7 @@ struct test_graph {
             [&graph, expected_n_edges = n_incident_edges_for_fully_connected_vertex(graph)](
                 const gl::default_id_type vertex_id
             ) {
-                return static_cast<std::size_t>(gl::util::range_size(graph.incidenct_edges(vertex_id)))
+                return static_cast<std::size_t>(gl::util::range_size(graph.incident_edges(vertex_id)))
                     == expected_n_edges;
             }
         ));
@@ -148,7 +148,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(std::ranges::all_of(
             constants::vertex_id_view,
             [&sut](const gl::default_id_type vertex_id) {
-                return sut.incidenct_edges(vertex_id).empty();
+                return sut.incident_edges(vertex_id).empty();
             }
         ));
     }
@@ -163,7 +163,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
             CHECK_EQ(sut.order(), v_id + 1u);
-            CHECK(sut.incidenct_edges(v_id).empty());
+            CHECK(sut.incident_edges(v_id).empty());
         }
 
         CHECK_EQ(sut.order(), target_n_vertices);
@@ -272,8 +272,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const gl::default_id_type vertex_id) {
-                return static_cast<std::size_t>(gl::util::range_size(sut.incidenct_edges(vertex_id))
-                       )
+                return static_cast<std::size_t>(gl::util::range_size(sut.incident_edges(vertex_id)))
                     == expected_n_incident_edges;
             }
         ));
@@ -305,8 +304,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         REQUIRE(std::ranges::all_of(
             vertex_id_view,
             [&sut, expected_n_incident_edges](const gl::default_id_type vertex_id) {
-                return static_cast<std::size_t>(gl::util::range_size(sut.incidenct_edges(vertex_id))
-                       )
+                return static_cast<std::size_t>(gl::util::range_size(sut.incident_edges(vertex_id)))
                     == expected_n_incident_edges;
             }
         ));
@@ -332,7 +330,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(std::ranges::all_of(
             sut.vertices(),
             [&sut, expected_n_incident_edges](const auto& vertex) {
-                return gl::util::range_size(sut.incidenct_edges(vertex))
+                return gl::util::range_size(sut.incident_edges(vertex))
                     == expected_n_incident_edges;
             }
         ));
@@ -357,7 +355,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         CHECK(std::ranges::all_of(
             sut.vertices(),
             [&sut, expected_n_incident_edges](const auto& vertex) {
-                return gl::util::range_size(sut.incidenct_edges(vertex))
+                return gl::util::range_size(sut.incident_edges(vertex))
                     == expected_n_incident_edges;
             }
         ));
@@ -389,12 +387,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
@@ -417,12 +415,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
@@ -504,8 +502,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
 
             REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
@@ -514,8 +512,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), 0uz);
 
-            incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-            incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            incident_edges_1 = sut.incident_edges(constants::v1_id);
+            incident_edges_2 = sut.incident_edges(constants::v2_id);
 
             CHECK_EQ(gl::util::range_size(incident_edges_1), 0uz);
             CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
@@ -581,12 +579,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
@@ -616,12 +614,12 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(incident_edges_1), 1uz);
             const auto new_edge_extracted_1 = *std::ranges::begin(incident_edges_1);
             CHECK_EQ(new_edge_extracted_1, new_edge);
 
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
             if constexpr (gl::traits::c_undirected_edge<edge_type>) {
                 CHECK_EQ(gl::util::range_size(incident_edges_2), 1uz);
                 const auto new_edge_extracted_2 = *std::ranges::begin(incident_edges_2);
@@ -637,8 +635,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
 
             REQUIRE_EQ(sut.size(), 1uz);
 
-            auto incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-            auto incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            auto incident_edges_1 = sut.incident_edges(constants::v1_id);
+            auto incident_edges_2 = sut.incident_edges(constants::v2_id);
 
             REQUIRE_EQ(gl::util::range_size(incident_edges_1), 1uz);
             if constexpr (gl::traits::c_undirected_edge<edge_type>)
@@ -647,8 +645,8 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
             sut.remove_edge(added_edge);
             CHECK_EQ(sut.size(), 0uz);
 
-            incident_edges_1 = sut.incidenct_edges(constants::v1_id);
-            incident_edges_2 = sut.incidenct_edges(constants::v2_id);
+            incident_edges_1 = sut.incident_edges(constants::v1_id);
+            incident_edges_2 = sut.incident_edges(constants::v2_id);
 
             CHECK_EQ(gl::util::range_size(incident_edges_1), 0uz);
             CHECK_EQ(gl::util::range_size(incident_edges_2), 0uz);
@@ -818,34 +816,33 @@ TEST_CASE_TEMPLATE_DEFINE("graph structure tests", TraitsType, graph_traits_temp
         );
     }
 
-    SUBCASE("incidenct_edges(id) should throw if the vertex_id is invalid") {
+    SUBCASE("incident_edges(id) should throw if the vertex_id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            discard_result(sut.incidenct_edges(constants::out_of_rng_idx)), std::out_of_range
+            discard_result(sut.incident_edges(constants::out_of_rng_idx)), std::out_of_range
         );
     }
 
-    SUBCASE("incidenct_edges(id) should return a proper iterator range for a valid vertex") {
+    SUBCASE("incident_edges(id) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
 
-        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.incidenct_edges(0uz)), 0uz); }()
-        );
+        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.incident_edges(0uz)), 0uz); }());
     }
 
-    SUBCASE("incidenct_edges(vertex) should throw if the vertex is invalid") {
+    SUBCASE("incident_edges(vertex) should throw if the vertex is invalid") {
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(sut.incidenct_edges(fixture.out_of_range_vertex)), std::out_of_range
+            discard_result(sut.incident_edges(fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
-    SUBCASE("incidenct_edges(vertex) should return a proper iterator range for a valid vertex") {
+    SUBCASE("incident_edges(vertex) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
         const auto vertex = sut.get_vertex(0uz);
 
         CHECK_NOTHROW([&sut, &vertex]() {
-            CHECK_EQ(gl::util::range_size(sut.incidenct_edges(vertex)), 0uz);
+            CHECK_EQ(gl::util::range_size(sut.incident_edges(vertex)), 0uz);
         }());
     }
 

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -46,7 +46,7 @@ struct test_graph_file_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.adjacent_edges(vertex))
+            for (const auto& edge : sut_out.incidenct_edges(vertex))
                 edge.properties() = std::format("edge_{}", e_idx++);
         }
     }

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -46,7 +46,7 @@ struct test_graph_file_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.incidenct_edges(vertex))
+            for (const auto& edge : sut_out.incident_edges(vertex))
                 edge.properties() = std::format("edge_{}", e_idx++);
         }
     }

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -28,7 +28,7 @@ struct test_directed_graph_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.incidenct_edges(vertex))
+            for (const auto& edge : sut_out.incident_edges(vertex))
                 edge.properties() = std::format("edge_{}", e_idx++);
         }
     }
@@ -137,7 +137,7 @@ struct test_undirected_graph_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.incidenct_edges(vertex))
+            for (const auto& edge : sut_out.incident_edges(vertex))
                 if (edge.source() == vertex.id())
                     edge.properties() = std::format("edge_{}", e_idx++);
         }

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -28,7 +28,7 @@ struct test_directed_graph_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.adjacent_edges(vertex))
+            for (const auto& edge : sut_out.incidenct_edges(vertex))
                 edge.properties() = std::format("edge_{}", e_idx++);
         }
     }
@@ -137,7 +137,7 @@ struct test_undirected_graph_io {
         std::size_t v_idx = 0, e_idx = 0;
         for (const auto& vertex : sut_out.vertices()) {
             vertex.properties() = std::format("vertex_{}", v_idx++);
-            for (const auto& edge : sut_out.adjacent_edges(vertex))
+            for (const auto& edge : sut_out.incidenct_edges(vertex))
                 if (edge.source() == vertex.id())
                     edge.properties() = std::format("edge_{}", e_idx++);
         }

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -157,7 +157,7 @@ template <gl::traits::c_graph GraphType>
             auto incidenct_edges = graph.incidenct_edges(source_id);
 
             return gl::util::range_size(incidenct_edges) == 1uz
-               and (*std::ranges::begin(incidenct_edges)).incident_vertex(source_id) == parent_id;
+               and (*std::ranges::begin(incidenct_edges)).other(source_id) == parent_id;
         }
 
         const auto target_1 = target_ids.first;

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -133,7 +133,7 @@ template <gl::traits::c_graph GraphType>
 
         if (target_ids.first >= graph.order())
             // no need to check second as second = first + 1
-            return gl::util::range_size(graph.adjacent_edges(source)) == 0uz;
+            return gl::util::range_size(graph.incidenct_edges(source)) == 0uz;
 
         const auto target_1 = graph.get_vertex(target_ids.first);
         const auto target_2 = graph.get_vertex(target_ids.second);
@@ -154,10 +154,10 @@ template <gl::traits::c_graph GraphType>
 
         if (target_ids.first >= graph.order()) {
             // no need to check second as second = first + 1
-            auto adjacent_edges = graph.adjacent_edges(source_id);
+            auto incidenct_edges = graph.incidenct_edges(source_id);
 
-            return gl::util::range_size(adjacent_edges) == 1uz
-               and (*std::ranges::begin(adjacent_edges)).incident_vertex(source_id) == parent_id;
+            return gl::util::range_size(incidenct_edges) == 1uz
+               and (*std::ranges::begin(incidenct_edges)).incident_vertex(source_id) == parent_id;
         }
 
         const auto target_1 = target_ids.first;

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -133,7 +133,7 @@ template <gl::traits::c_graph GraphType>
 
         if (target_ids.first >= graph.order())
             // no need to check second as second = first + 1
-            return gl::util::range_size(graph.incidenct_edges(source)) == 0uz;
+            return gl::util::range_size(graph.incident_edges(source)) == 0uz;
 
         const auto target_1 = graph.get_vertex(target_ids.first);
         const auto target_2 = graph.get_vertex(target_ids.second);
@@ -154,10 +154,10 @@ template <gl::traits::c_graph GraphType>
 
         if (target_ids.first >= graph.order()) {
             // no need to check second as second = first + 1
-            auto incidenct_edges = graph.incidenct_edges(source_id);
+            auto incident_edges = graph.incident_edges(source_id);
 
-            return gl::util::range_size(incidenct_edges) == 1uz
-               and (*std::ranges::begin(incidenct_edges)).other(source_id) == parent_id;
+            return gl::util::range_size(incident_edges) == 1uz
+               and (*std::ranges::begin(incident_edges)).other(source_id) == parent_id;
         }
 
         const auto target_1 = target_ids.first;


### PR DESCRIPTION
- Corrected the names of the edge getter methods in the gl module: from adjacent_edges to incident_edges
- Changed the name of the incident_vertex method of the edge_descriptor class to other
- Align the variables, comments, etc. to be consistent with the new naming scheme