### PR TITLE
YT-CPPGL-75: GL module API refinement

### DIFF
--- a/benchmarks/suites/is_bipartite.cpp
+++ b/benchmarks/suites/is_bipartite.cpp
@@ -27,8 +27,8 @@ void bm_gl_is_bipartite(benchmark::State& state) {
         benchmark::DoNotOptimize(is_bip);
     }
 
-    state.counters["Vertices"] = static_cast<double>(graph.order());
-    state.counters["Edges"] = static_cast<double>(graph.size());
+    state.counters["Vertices"] = static_cast<double>(graph.n_vertices());
+    state.counters["Edges"] = static_cast<double>(graph.n_edges());
 }
 
 #ifdef GL_BENCH_INCLUDE_BGL

--- a/include/gl/algorithm/pathfinding/dijkstra.hpp
+++ b/include/gl/algorithm/pathfinding/dijkstra.hpp
@@ -31,7 +31,7 @@ using paths_descriptor_type = paths_descriptor<G, vertex_distance_type<G>>;
 
 template <traits::c_graph G>
 [[nodiscard]] gl_attr_force_inline paths_descriptor_type<G> make_paths_descriptor(const G& graph) {
-    return paths_descriptor_type<G>{graph.order()};
+    return paths_descriptor_type<G>{graph.n_vertices()};
 }
 
 template <

--- a/include/gl/algorithm/spanning_tree/prim_mst.hpp
+++ b/include/gl/algorithm/spanning_tree/prim_mst.hpp
@@ -42,7 +42,7 @@ template <traits::c_undirected_graph G>
     using queue_type = std::priority_queue<edge_type, std::vector<edge_type>, edge_comparator>;
 
     // prepare the necessary utility
-    const auto n_vertices = graph.order();
+    const auto n_vertices = graph.n_vertices();
     mst_descriptor<G> mst(n_vertices);
     std::vector<bool> visited(n_vertices, false);
     queue_type edge_queue;
@@ -92,7 +92,7 @@ requires traits::c_has_numeric_limits_max<vertex_distance_type<G>>
     using distance_type = vertex_distance_type<G>;
 
     // Prepare the necessary utility
-    const auto n_vertices = graph.order();
+    const auto n_vertices = graph.n_vertices();
     mst_descriptor<G> mst(n_vertices);
 
     std::vector<bool> in_mst(n_vertices, false);

--- a/include/gl/algorithm/topology/coloring.hpp
+++ b/include/gl/algorithm/topology/coloring.hpp
@@ -20,7 +20,7 @@ template <
 ) {
     using edge_type = typename G::edge_type;
 
-    bicoloring_type coloring(graph.order(), binary_color::value::unset);
+    bicoloring_type coloring(graph.n_vertices(), binary_color::value::unset);
     for (const auto root_id : graph.vertex_ids()) {
         if (coloring[root_id].is_set())
             continue;
@@ -71,7 +71,7 @@ template <
 template <traits::c_graph G, traits::c_sized_range_of<binary_color> ColorRange>
 requires(traits::c_binary_color_properties_type<typename G::vertex_properties_type>)
 bool apply_coloring(G& graph, const ColorRange& color_range) {
-    if (std::ranges::size(color_range) != graph.order())
+    if (std::ranges::size(color_range) != graph.n_vertices())
         return false;
 
     auto vertices = graph.vertices(); // store the view to extend its lifetime

--- a/include/gl/algorithm/topology/topological_sort.hpp
+++ b/include/gl/algorithm/topology/topological_sort.hpp
@@ -24,13 +24,13 @@ template <
 
     // prepare the initial queue content (source vertices)
     std::vector<search_node<G>> source_vertex_list;
-    source_vertex_list.reserve(graph.order());
+    source_vertex_list.reserve(graph.n_vertices());
     for (const auto id : graph.vertex_ids())
         if (in_degree_map[to_idx(id)] == 0uz)
             source_vertex_list.emplace_back(id);
 
     std::vector<id_type> topological_order{};
-    topological_order.reserve(graph.order());
+    topological_order.reserve(graph.n_vertices());
 
     bfs(
         graph,
@@ -50,7 +50,7 @@ template <
         post_visit
     );
 
-    if (topological_order.size() != graph.order())
+    if (topological_order.size() != graph.n_vertices())
         return std::nullopt;
 
     return topological_order;

--- a/include/gl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/gl/algorithm/traversal/breadth_first_search.hpp
@@ -22,8 +22,8 @@ return_type<Result, predecessors_map<G>> breadth_first_search(
     PreVisitCallback pre_visit = {},
     PostVisitCallback post_visit = {}
 ) {
-    std::vector<bool> visited(graph.order(), false);
-    std::vector<typename G::id_type> sources(graph.order());
+    std::vector<bool> visited(graph.n_vertices(), false);
+    std::vector<typename G::id_type> sources(graph.n_vertices());
 
     auto pred_map = init_predecessors_map<Result>(graph);
 

--- a/include/gl/algorithm/traversal/depth_first_search.hpp
+++ b/include/gl/algorithm/traversal/depth_first_search.hpp
@@ -22,8 +22,8 @@ return_type<Result, predecessors_map<G>> depth_first_search(
     PreVisitCallback pre_visit = {},
     PostVisitCallback post_visit = {}
 ) {
-    std::vector<bool> visited(graph.order(), false);
-    std::vector<typename G::id_type> sources(graph.order());
+    std::vector<bool> visited(graph.n_vertices(), false);
+    std::vector<typename G::id_type> sources(graph.n_vertices());
 
     auto pred_map = init_predecessors_map<Result>(graph);
 
@@ -70,8 +70,8 @@ return_type<Result, predecessors_map<G>> recursive_depth_first_search(
     PreVisitCallback pre_visit = {},
     PostVisitCallback post_visit = {}
 ) {
-    std::vector<bool> visited(graph.order(), false);
-    std::vector<typename G::id_type> sources(graph.order());
+    std::vector<bool> visited(graph.n_vertices(), false);
+    std::vector<typename G::id_type> sources(graph.n_vertices());
 
     auto pred_map = init_predecessors_map<Result>(graph);
 

--- a/include/gl/algorithm/util.hpp
+++ b/include/gl/algorithm/util.hpp
@@ -16,7 +16,7 @@ template <result_discriminator Result, traits::c_graph G>
 init_predecessors_map(const G& graph) {
     using return_t = non_void_return_type<Result, predecessors_map<G>>;
     if constexpr (Result == ret)
-        return return_t(graph.order(), invalid_id);
+        return return_t(graph.n_vertices(), invalid_id);
     else
         return return_t();
 }

--- a/include/gl/conversion.hpp
+++ b/include/gl/conversion.hpp
@@ -54,7 +54,7 @@ template <traits::c_graph_impl_tag TargetImplTag, traits::c_graph_impl_tag Sourc
 struct to_impl {
     template <typename TargetGraph, typename SourceGraph>
     static void convert(TargetGraph& target, SourceGraph& source) {
-        target._impl.add_vertices(source.order());
+        target._impl.add_vertices(source.n_vertices());
 
         for (const auto u : source.vertex_ids()) {
             for (const auto& edge : source.out_edges(u)) {

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -156,10 +156,24 @@ public:
         return this->_vertices.first == this->_vertices.second;
     }
 
-    [[nodiscard]] properties_ref_type properties() const {
-        if (not this->is_valid())
-            throw std::logic_error("Cannot access properties of an invalid edge");
+    [[nodiscard]] gl_attr_force_inline properties_ref_type properties() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return this->_properties.get();
+    }
 
+    [[nodiscard]] gl_attr_force_inline properties_type* operator->() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return &this->_properties.get();
+    }
+
+    [[nodiscard]] gl_attr_force_inline properties_type& operator*() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
         return this->_properties.get();
     }
 
@@ -173,6 +187,15 @@ public:
     }
 
 private:
+    [[noreturn]] void _throw_invalid_access() const {
+        throw std::logic_error("Cannot access properties of an invalid edge");
+    }
+
+    gl_attr_force_inline void _validate() const {
+        if (not this->is_valid())
+            this->_throw_invalid_access();
+    }
+
     std::ostream& _verbose_write(std::ostream& os) const
     requires std::same_as<directional_tag, undirected_t>
     {

--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -238,12 +238,6 @@ private:
 };
 
 template <
-    traits::c_graph_directional_tag DirectionalTag = directed_t,
-    traits::c_properties Properties = empty_properties,
-    traits::c_id_type IdType = default_id_type>
-using edge = edge_descriptor<DirectionalTag, Properties, IdType>;
-
-template <
     traits::c_properties Properties = empty_properties,
     traits::c_id_type IdType = default_id_type>
 using directed_edge = edge_descriptor<directed_t, Properties, IdType>;

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -235,7 +235,7 @@ public:
 
     [[nodiscard]] gl_attr_force_inline auto neighbors(const id_type vertex_id) const {
         return this->neighbor_ids(vertex_id)
-             | std::views::transform([this](const id_type id) { return this->get_vertex(id); });
+             | std::views::transform([this](const id_type id) { return this->vertex(id); });
     }
 
     [[nodiscard]] gl_attr_force_inline auto neighbor_ids(const id_type vertex_id) const {
@@ -245,7 +245,7 @@ public:
 
     [[nodiscard]] gl_attr_force_inline auto predecessors(const id_type vertex_id) const {
         return this->predecessor_ids(vertex_id)
-             | std::views::transform([this](const id_type id) { return this->get_vertex(id); });
+             | std::views::transform([this](const id_type id) { return this->vertex(id); });
     }
 
     [[nodiscard]] gl_attr_force_inline auto predecessor_ids(const id_type vertex_id) const {
@@ -255,7 +255,7 @@ public:
 
     [[nodiscard]] gl_attr_force_inline auto successors(const id_type vertex_id) const {
         return this->successor_ids(vertex_id)
-             | std::views::transform([this](const id_type id) { return this->get_vertex(id); });
+             | std::views::transform([this](const id_type id) { return this->vertex(id); });
     }
 
     [[nodiscard]] gl_attr_force_inline auto successor_ids(const id_type vertex_id) const {
@@ -263,7 +263,7 @@ public:
         return this->_impl.successor_ids(vertex_id);
     }
 
-    [[nodiscard]] vertex_type get_vertex(const id_type vertex_id) const {
+    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_descriptor{vertex_id, *this->_vertex_properties[vertex_id]};
@@ -489,40 +489,39 @@ public:
         return this->_impl.has_edge(edge);
     }
 
-    [[nodiscard]] std::optional<edge_type> get_edge(
+    [[nodiscard]] std::optional<edge_type> edge(const id_type source_id, const id_type target_id)
+        const {
+        this->_verify_vertex_id(source_id);
+        this->_verify_vertex_id(target_id);
+
+        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.edge(source_id, target_id, this->_edge_properties);
+        else
+            return this->_impl.edge(source_id, target_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline std::optional<edge_type> edge(
+        const vertex_type& source, const vertex_type& target
+    ) const {
+        return this->edge(source.id(), target.id());
+    }
+
+    [[nodiscard]] inline std::vector<edge_type> edges(
         const id_type source_id, const id_type target_id
     ) const {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
 
         if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.get_edge(source_id, target_id, this->_edge_properties);
+            return this->_impl.edges(source_id, target_id, this->_edge_properties);
         else
-            return this->_impl.get_edge(source_id, target_id);
+            return this->_impl.edges(source_id, target_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::optional<edge_type> get_edge(
+    [[nodiscard]] gl_attr_force_inline std::vector<edge_type> edges(
         const vertex_type& source, const vertex_type& target
     ) const {
-        return this->get_edge(source.id(), target.id());
-    }
-
-    [[nodiscard]] inline std::vector<edge_type> get_edges(
-        const id_type source_id, const id_type target_id
-    ) const {
-        this->_verify_vertex_id(source_id);
-        this->_verify_vertex_id(target_id);
-
-        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.get_edges(source_id, target_id, this->_edge_properties);
-        else
-            return this->_impl.get_edges(source_id, target_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline std::vector<edge_type> get_edges(
-        const vertex_type& source, const vertex_type& target
-    ) const {
-        return this->get_edges(source.id(), target.id());
+        return this->edges(source.id(), target.id());
     }
 
     // --- adjacency and incidence methods ---
@@ -571,8 +570,7 @@ public:
         return util::deref_view(this->_vertex_properties);
     }
 
-    [[nodiscard]] gl_attr_force_inline vertex_properties_type& get_vertex_properties(
-        const id_type id
+    [[nodiscard]] gl_attr_force_inline vertex_properties_type& vertex_properties(const id_type id
     ) const
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -392,7 +392,7 @@ public:
         );
     }
 
-    gl_attr_force_inline void add_edges_from(
+    void add_edges_from(
         const vertex_type& source, const traits::c_sized_range_of<vertex_type> auto& target_rng
     ) {
         this->_verify_vertex_id(source.id());
@@ -473,9 +473,7 @@ public:
         return this->out_edges(vertex.id());
     }
 
-    [[nodiscard]] gl_attr_force_inline bool has_edge(
-        const id_type source_id, const id_type target_id
-    ) const {
+    [[nodiscard]] bool has_edge(const id_type source_id, const id_type target_id) const {
         this->_verify_vertex_id(source_id);
         this->_verify_vertex_id(target_id);
         return this->_impl.has_edge(source_id, target_id);
@@ -491,7 +489,7 @@ public:
         return this->_impl.has_edge(edge);
     }
 
-    [[nodiscard]] gl_attr_force_inline std::optional<edge_type> get_edge(
+    [[nodiscard]] std::optional<edge_type> get_edge(
         const id_type source_id, const id_type target_id
     ) const {
         this->_verify_vertex_id(source_id);
@@ -595,20 +593,6 @@ public:
             throw std::out_of_range(std::format("Got invalid edge id [{}]", id));
 
         return *this->_edge_properties[id];
-    }
-
-    // --- access operators ---
-
-    [[nodiscard]] inline auto at(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.at(vertex_id, this->_edge_properties);
-        else
-            return this->_impl.at(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto at(const vertex_type& vertex) const {
-        return this->at(vertex.id());
     }
 
     // --- comparison ---

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -114,11 +114,11 @@ public:
 
     // --- size methods ---
 
-    [[nodiscard]] gl_attr_force_inline size_type order() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type n_vertices() const noexcept {
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline size_type size() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type n_edges() const noexcept {
         return this->_n_edges;
     }
 
@@ -736,8 +736,8 @@ private:
     };
 
     std::ostream& _verbose_write(std::ostream& os) const {
-        os << "type: " << fmt_traits::type << ", |V| = " << this->order()
-           << ", |E| = " << this->size() << '\n';
+        os << "type: " << fmt_traits::type << ", |V| = " << this->_n_vertices
+           << ", |E| = " << this->_n_edges << '\n';
         for (const auto& vertex : this->vertices()) {
             os << "- " << vertex << "\n  " << fmt_traits::out_edges << ":\n";
             for (const auto& edge : this->out_edges(vertex.id()))
@@ -770,9 +770,9 @@ private:
         const bool with_e_props = io::is_option_set(os, with_connection_properties);
 
         // print graph metadata
-        os << traits::c_directed_edge<edge_type> << ' ' << this->order() << ' ' << this->size()
-           << ' ' << static_cast<int>(with_v_props) << ' ' << static_cast<int>(with_e_props)
-           << '\n';
+        os << traits::c_directed_edge<edge_type> << ' ' << this->_n_vertices << ' '
+           << this->_n_edges << ' ' << static_cast<int>(with_v_props) << ' '
+           << static_cast<int>(with_e_props) << '\n';
 
         if constexpr (traits::c_writable<vertex_properties_type>)
             if (with_v_props)

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -897,6 +897,56 @@ template <traits::c_graph Graph>
     return Graph(source);
 }
 
+template <
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_graph_impl_tag ImplTag = impl::list_t,
+    traits::c_id_type IdType = default_id_type>
+using directed_graph =
+    graph<directed_graph_traits<VertexProperties, EdgeProperties, ImplTag, IdType>>;
+
+template <
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_graph_impl_tag ImplTag = impl::list_t,
+    traits::c_id_type IdType = default_id_type>
+using undirected_graph =
+    graph<undirected_graph_traits<VertexProperties, EdgeProperties, ImplTag, IdType>>;
+
+template <
+    traits::c_graph_directional_tag DirectionalTag = directed_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using list_graph =
+    graph<list_graph_traits<DirectionalTag, VertexProperties, EdgeProperties, IdType>>;
+
+template <
+    traits::c_graph_directional_tag DirectionalTag = directed_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using matrix_graph =
+    graph<matrix_graph_traits<DirectionalTag, VertexProperties, EdgeProperties, IdType>>;
+
+template <
+    traits::c_graph_directional_tag DirectionalTag = directed_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using flat_list_graph =
+    graph<flat_list_graph_traits<DirectionalTag, VertexProperties, EdgeProperties, IdType>>;
+
+template <
+    traits::c_graph_directional_tag DirectionalTag = directed_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties EdgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using flat_matrix_graph =
+    graph<flat_matrix_graph_traits<DirectionalTag, VertexProperties, EdgeProperties, IdType>>;
+
+// --- vertex distance utility ---
+
 using default_vertex_distance_type = std::int64_t;
 
 template <traits::c_graph GraphType>

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -212,6 +212,36 @@ public:
 
     // --- vertex getters ---
 
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
+        return vertex_id < this->_n_vertices;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const vertex_type& vertex) const {
+        return this->has_vertex(vertex.id());
+    }
+
+    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        return this->vertex_unchecked(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_type at(const id_type vertex_id) const {
+        return this->vertex(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_type vertex_unchecked(const id_type vertex_id
+    ) const noexcept {
+        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
+            return vertex_descriptor{vertex_id, *this->_vertex_properties[vertex_id]};
+        else
+            return vertex_descriptor{vertex_id};
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_type operator[](const id_type vertex_id
+    ) const noexcept {
+        return this->vertex_unchecked(vertex_id);
+    }
+
     [[nodiscard]] gl_attr_force_inline auto vertices() const noexcept
     requires(traits::c_empty_properties<vertex_properties_type>)
     {
@@ -261,22 +291,6 @@ public:
     [[nodiscard]] gl_attr_force_inline auto successor_ids(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         return this->_impl.successor_ids(vertex_id);
-    }
-
-    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            return vertex_descriptor{vertex_id, *this->_vertex_properties[vertex_id]};
-        else
-            return vertex_descriptor{vertex_id};
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
-        return vertex_id < this->_n_vertices;
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const vertex_type& vertex) const {
-        return this->has_vertex(vertex.id());
     }
 
     // --- degree getters ---
@@ -437,40 +451,8 @@ public:
         return std::views::iota(initial_id_v<id_type>, this->_n_edges);
     }
 
-    [[nodiscard]] inline auto incident_edges(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.incident_edges(vertex_id, this->_edge_properties);
-        else
-            return this->_impl.incident_edges(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto incident_edges(const vertex_type& vertex) const {
-        return this->incident_edges(vertex.id());
-    }
-
-    [[nodiscard]] inline auto in_edges(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.in_edges(vertex_id, this->_edge_properties);
-        else
-            return this->_impl.in_edges(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto in_edges(const vertex_type& vertex) const {
-        return this->in_edges(vertex.id());
-    }
-
-    [[nodiscard]] inline auto out_edges(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
-            return this->_impl.out_edges(vertex_id, this->_edge_properties);
-        else
-            return this->_impl.out_edges(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto out_edges(const vertex_type& vertex) const {
-        return this->out_edges(vertex.id());
+    [[nodiscard]] gl_attr_force_inline bool has_edge(const edge_type& edge) const {
+        return this->_impl.has_edge(edge);
     }
 
     [[nodiscard]] bool has_edge(const id_type source_id, const id_type target_id) const {
@@ -483,10 +465,6 @@ public:
         const vertex_type& source, const vertex_type& target
     ) const {
         return this->has_edge(source.id(), target.id());
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_edge(const edge_type& edge) const {
-        return this->_impl.has_edge(edge);
     }
 
     [[nodiscard]] std::optional<edge_type> edge(const id_type source_id, const id_type target_id)
@@ -522,6 +500,42 @@ public:
         const vertex_type& source, const vertex_type& target
     ) const {
         return this->edges(source.id(), target.id());
+    }
+
+    [[nodiscard]] inline auto incident_edges(const id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.incident_edges(vertex_id, this->_edge_properties);
+        else
+            return this->_impl.incident_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto incident_edges(const vertex_type& vertex) const {
+        return this->incident_edges(vertex.id());
+    }
+
+    [[nodiscard]] inline auto in_edges(const id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.in_edges(vertex_id, this->_edge_properties);
+        else
+            return this->_impl.in_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto in_edges(const vertex_type& vertex) const {
+        return this->in_edges(vertex.id());
+    }
+
+    [[nodiscard]] inline auto out_edges(const id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (traits::c_non_empty_properties<edge_properties_type>)
+            return this->_impl.out_edges(vertex_id, this->_edge_properties);
+        else
+            return this->_impl.out_edges(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto out_edges(const vertex_type& vertex) const {
+        return this->out_edges(vertex.id());
     }
 
     // --- adjacency and incidence methods ---

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -152,7 +152,7 @@ public:
         );
     }
 
-    [[nodiscard]] std::optional<edge_type> get_edge(id_type source_id, id_type target_id) const
+    [[nodiscard]] std::optional<edge_type> edge(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         const auto& out_edges = this->_list[to_idx(source_id)];
@@ -162,7 +162,7 @@ public:
         return std::make_optional<edge_type>(item_it->edge_id, source_id, target_id);
     }
 
-    [[nodiscard]] std::optional<edge_type> get_edge(
+    [[nodiscard]] std::optional<edge_type> edge(
         id_type source_id, id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
@@ -178,7 +178,7 @@ public:
         );
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(id_type source_id, id_type target_id) const
+    [[nodiscard]] std::vector<edge_type> edges(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         return this->_list[source_id] | std::views::filter([&target_id](const auto& item) {
@@ -190,7 +190,7 @@ public:
              | std::ranges::to<std::vector>();
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(
+    [[nodiscard]] std::vector<edge_type> edges(
         id_type source_id, id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)

--- a/include/gl/impl/adjacency_list.hpp
+++ b/include/gl/impl/adjacency_list.hpp
@@ -121,7 +121,7 @@ public:
         specialized_impl::add_edges_from(*this, edge_ids, source_id, target_ids);
     }
 
-    gl_attr_force_inline void remove_edge(const edge_type& edge) {
+    void remove_edge(const edge_type& edge) {
         specialized_impl::remove_edge(*this, edge);
         for (auto&& inc : this->_list)
             for (auto& item : inc)
@@ -268,21 +268,6 @@ public:
                        *edge_properties_map[to_idx(item.edge_id)]
                    };
                });
-    }
-
-    // --- access operators ---
-
-    [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id) const
-    requires(traits::c_has_empty_properties<edge_type>)
-    {
-        return this->out_edges(vertex_id);
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id, const auto& edge_properties_map)
-        const
-    requires(traits::c_has_non_empty_properties<edge_type>)
-    {
-        return this->out_edges(vertex_id, edge_properties_map);
     }
 
     // --- comparison ---

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -151,7 +151,7 @@ public:
         return specialized_impl::get_entry(*this, edge.source(), edge.target()) == edge.id();
     }
 
-    [[nodiscard]] std::optional<edge_type> get_edge(id_type source_id, id_type target_id) const
+    [[nodiscard]] std::optional<edge_type> edge(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         const auto edge_id = specialized_impl::get_entry(*this, source_id, target_id);
@@ -160,7 +160,7 @@ public:
         return std::make_optional<edge_type>(edge_id, source_id, target_id);
     }
 
-    [[nodiscard]] std::optional<edge_type> get_edge(
+    [[nodiscard]] std::optional<edge_type> edge(
         id_type source_id, id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)
@@ -173,7 +173,7 @@ public:
         );
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(id_type source_id, id_type target_id) const
+    [[nodiscard]] std::vector<edge_type> edges(id_type source_id, id_type target_id) const
     requires(traits::c_has_empty_properties<edge_type>)
     {
         const auto edge_id = specialized_impl::get_entry(*this, source_id, target_id);
@@ -184,7 +184,7 @@ public:
         };
     }
 
-    [[nodiscard]] std::vector<edge_type> get_edges(
+    [[nodiscard]] std::vector<edge_type> edges(
         id_type source_id, id_type target_id, const auto& edge_properties_map
     ) const
     requires(traits::c_has_non_empty_properties<edge_type>)

--- a/include/gl/impl/adjacency_matrix.hpp
+++ b/include/gl/impl/adjacency_matrix.hpp
@@ -123,7 +123,7 @@ public:
         specialized_impl::add_edges_from(*this, edge_ids, source_id, target_ids);
     }
 
-    gl_attr_force_inline void remove_edge(const edge_type& edge) {
+    void remove_edge(const edge_type& edge) {
         specialized_impl::remove_edge(*this, edge);
         for (auto&& row : this->_matrix)
             for (auto& edge_id : row)
@@ -276,38 +276,6 @@ public:
                        static_cast<id_type>(target_id),
                        *edge_properties_map[to_idx(edge_id)]
                    };
-               });
-    }
-
-    // --- access operators ---
-
-    [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id) const
-    requires(traits::c_has_empty_properties<edge_type>)
-    {
-        return this->_matrix[to_idx(vertex_id)] | std::views::enumerate
-             | std::views::transform([vertex_id](const auto& edge_info) {
-                   const auto& [target_id, edge_id] = edge_info;
-                   return edge_id == invalid_id
-                            ? edge_type::invalid()
-                            : edge_type{edge_id, vertex_id, static_cast<id_type>(target_id)};
-               });
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto at(id_type vertex_id, const auto& edge_properties_map)
-        const
-    requires(traits::c_has_non_empty_properties<edge_type>)
-    {
-        return this->_matrix[to_idx(vertex_id)] | std::views::enumerate
-             | std::views::transform([vertex_id, &edge_properties_map](const auto& edge_info) {
-                   const auto& [target_id, edge_id] = edge_info;
-                   return edge_id == invalid_id
-                            ? edge_type::invalid()
-                            : edge_type{
-                                  edge_id,
-                                  vertex_id,
-                                  static_cast<id_type>(target_id),
-                                  *edge_properties_map[to_idx(edge_id)]
-                              };
                });
     }
 

--- a/include/gl/types/flat_matrix.hpp
+++ b/include/gl/types/flat_matrix.hpp
@@ -1140,7 +1140,7 @@ public:
     /// @warning This operation forces a reallocation and structural shift. All iterators, pointers, and references are invalidated.
     /// @note **Time Complexity:** $O(R \times C)$ where $R$ and $C$ are dimensions of the matrix.
     void pop_col() {
-        if (this->empty() || this->_n_cols == 0uz)
+        if (this->empty() or this->_n_cols == 0uz)
             return;
 
         this->erase_col(this->_n_cols - 1uz);

--- a/include/gl/util/ranges.hpp
+++ b/include/gl/util/ranges.hpp
@@ -65,7 +65,7 @@ public:
     }
 
     constexpr auto begin() const
-    requires std::ranges::range<const V1> && std::ranges::range<const V2>
+    requires std::ranges::range<const V1> and std::ranges::range<const V2>
     {
         return iterator<true>(
             std::ranges::begin(this->_v1),
@@ -79,7 +79,7 @@ public:
     }
 
     constexpr auto end() const
-    requires std::ranges::range<const V1> && std::ranges::range<const V2>
+    requires std::ranges::range<const V1> and std::ranges::range<const V2>
     {
         return sentinel<true>(std::ranges::end(this->_v2));
     }
@@ -137,11 +137,11 @@ private:
         }
 
         constexpr bool operator==(const iterator& other) const {
-            return this->_it1 == other._it1 && this->_it2 == other._it2;
+            return this->_it1 == other._it1 and this->_it2 == other._it2;
         }
 
         constexpr bool operator==(const sentinel<Const>& s) const {
-            return this->_it1 == this->_end1 && this->_it2 == s.end2();
+            return this->_it1 == this->_end1 and this->_it2 == s.end2();
         }
 
     private:

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -78,7 +78,7 @@ public:
         return this->is_valid();
     }
 
-    [[nodiscard]] bool is_valid() const noexcept {
+    [[nodiscard]] gl_attr_force_inline bool is_valid() const noexcept {
         return this->_id != invalid_id;
     }
 
@@ -86,10 +86,24 @@ public:
         return this->_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline properties_ref_type properties() const {
-        if (not this->is_valid())
-            throw std::logic_error("Cannot access properties of an invalid vertex");
+    [[nodiscard]] gl_attr_force_inline properties_ref_type properties() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return this->_properties.get();
+    }
 
+    [[nodiscard]] gl_attr_force_inline properties_type* operator->() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return &this->_properties.get();
+    }
+
+    [[nodiscard]] gl_attr_force_inline properties_type& operator*() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
         return this->_properties.get();
     }
 
@@ -103,6 +117,15 @@ public:
     }
 
 private:
+    [[noreturn]] void _throw_invalid_access() const {
+        throw std::logic_error("Cannot access properties of an invalid vertex");
+    }
+
+    gl_attr_force_inline void _validate() const {
+        if (not this->is_valid())
+            this->_throw_invalid_access();
+    }
+
     std::ostream& _verbose_write(std::ostream& os) const {
         using enum io::detail::option_bit;
 

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -133,9 +133,4 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
-template <
-    traits::c_properties Properties = empty_properties,
-    traits::c_id_type IdType = default_id_type>
-using vertex = vertex_descriptor<Properties, IdType>;
-
 } // namespace gl

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -1,4 +1,4 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#include <doctest.h>
+#include "doctest.h"

--- a/tests/include/testing/common/functional.hpp
+++ b/tests/include/testing/common/functional.hpp
@@ -1,7 +1,3 @@
 #pragma once
 
-// TODO: discard
-template <typename T>
-void discard_result(T&&) {
-    // do nothing
-}
+void discard(auto&&) { /* do nothing */ }

--- a/tests/include/testing/common/functional.hpp
+++ b/tests/include/testing/common/functional.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+// TODO: discard
 template <typename T>
 void discard_result(T&&) {
     // do nothing

--- a/tests/include/testing/gl/io.hpp
+++ b/tests/include/testing/gl/io.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <gl/graph.hpp>
+#include "doctest.h"
 
-#include <doctest.h>
+#include <gl/graph.hpp>
 
 namespace gl_testing {
 

--- a/tests/include/testing/gl/io.hpp
+++ b/tests/include/testing/gl/io.hpp
@@ -36,8 +36,7 @@ template <gl::traits::c_graph GraphType>
 void verify_edge_properties(const GraphType& actual, const GraphType& expected) {
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {
         return std::ranges::all_of(actual.out_edges(v_actual), [&](const auto& edge) {
-            return edge.properties()
-                == expected.get_edge(edge.source(), edge.target())->properties();
+            return edge.properties() == expected.edge(edge.source(), edge.target())->properties();
         });
     }));
 }

--- a/tests/include/testing/gl/io.hpp
+++ b/tests/include/testing/gl/io.hpp
@@ -8,8 +8,8 @@ namespace gl_testing {
 
 template <gl::traits::c_graph GraphType>
 void verify_graph_structure(const GraphType& actual, const GraphType& expected) {
-    REQUIRE_EQ(actual.order(), expected.order());
-    REQUIRE_EQ(actual.size(), expected.size());
+    REQUIRE_EQ(actual.n_vertices(), expected.n_vertices());
+    REQUIRE_EQ(actual.n_edges(), expected.n_edges());
 
     // verify that the edges of the in graph are equivalent to the edges of the out graph
     CHECK(std::ranges::all_of(actual.vertices(), [&](const auto& v_actual) {

--- a/tests/include/testing/gl/types.hpp
+++ b/tests/include/testing/gl/types.hpp
@@ -3,13 +3,13 @@
 namespace gl_testing {
 
 struct visited_property {
-    bool operator==(const visited_property&) const = default;
     bool visited;
+    bool operator==(const visited_property&) const = default;
 };
 
 struct used_property {
-    bool operator==(const used_property&) const = default;
     bool used;
+    bool operator==(const used_property&) const = default;
 };
 
 } // namespace gl_testing

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -388,42 +388,39 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
-    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+    SUBCASE("edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v1_id, constants::v2_id));
     }
 
-    SUBCASE("get_edge(id, id) should return the first valid edge if the given vertices are "
+    SUBCASE("edge(id, id) should return the first valid edge if the given vertices are "
             "connected") {
         const auto& edge_1 = add_edge(constants::v1_id, constants::v2_id);
         const auto& edge_2 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
+        const auto edge_opt = sut.edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt.has_value());
         CHECK_EQ(*edge_opt, edge_1);
         CHECK_NE(*edge_opt, edge_2);
 
-        CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v2_id, constants::v2_id));
     }
 
-    SUBCASE("get_edges(id, id) should return an empty if there is no edge connecting the given "
+    SUBCASE("edges(id, id) should return an empty if there is no edge connecting the given "
             "vertices") {
-        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
+        CHECK(sut.edges(constants::v1_id, constants::v2_id).empty());
     }
 
-    SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
-    ) {
+    SUBCASE("edges(id, id) should return a valid edge view if the given vertices are connected") {
         std::vector<edge_type> expected_edges;
         for (auto _ = 0uz; _ < constants::n_elements; _++)
             expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::v1_id, constants::v2_id),
-            expected_edges,
-            std::ranges::equal_to{}
+            sut.edges(constants::v1_id, constants::v2_id), expected_edges, std::ranges::equal_to{}
         ));
 
-        CHECK(sut.get_edges(constants::v2_id, constants::v2_id).empty());
+        CHECK(sut.edges(constants::v2_id, constants::v2_id).empty());
     }
 
     SUBCASE("incident_edges should return edges incident with the vertex") {
@@ -729,48 +726,43 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
-    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+    SUBCASE("edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v1_id, constants::v2_id));
     }
 
-    SUBCASE("get_edge(id, id) should return the first valid edge if the given vertices are "
+    SUBCASE("edge(id, id) should return the first valid edge if the given vertices are "
             "connected") {
         const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
         const auto edge_2 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
+        const auto edge_opt_1 = sut.edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt_1.has_value());
         CHECK_EQ(*edge_opt_1, edge_1);
         CHECK_NE(*edge_opt_1, edge_2);
 
-        const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
+        const auto edge_opt_2 = sut.edge(constants::v2_id, constants::v1_id);
         REQUIRE(edge_opt_2.has_value());
         CHECK_EQ(*edge_opt_2, edge_1);
         CHECK_NE(*edge_opt_2, edge_2);
     }
 
-    SUBCASE("get_edges(id, id) should return an empty if there is no edge connecting the given "
+    SUBCASE("edges(id, id) should return an empty if there is no edge connecting the given "
             "vertices") {
-        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
+        CHECK(sut.edges(constants::v1_id, constants::v2_id).empty());
     }
 
-    SUBCASE("get_edges(id, id) should return a valid edge view if the given vertices are connected"
-    ) {
+    SUBCASE("edges(id, id) should return a valid edge view if the given vertices are connected") {
         std::vector<edge_type> expected_edges;
         for (auto _ = 0uz; _ < constants::n_elements; _++)
             expected_edges.push_back(add_edge(constants::v1_id, constants::v2_id));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::v1_id, constants::v2_id),
-            expected_edges,
-            std::ranges::equal_to{}
+            sut.edges(constants::v1_id, constants::v2_id), expected_edges, std::ranges::equal_to{}
         ));
 
         CHECK(std::ranges::equal(
-            sut.get_edges(constants::v2_id, constants::v1_id),
-            expected_edges,
-            std::ranges::equal_to{}
+            sut.edges(constants::v2_id, constants::v1_id), expected_edges, std::ranges::equal_to{}
         ));
     }
 

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/graph_traits.hpp>
 #include <gl/impl/adjacency_list.hpp>
-
-#include <doctest.h>
 
 #include <algorithm>
 #include <functional>

--- a/tests/source/gl/test_adjacency_list.cpp
+++ b/tests/source/gl/test_adjacency_list.cpp
@@ -459,14 +459,6 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency list tests", SutType, directed_adj
         CHECK(std::ranges::contains(out_edges, edge1));
         CHECK(std::ranges::contains(out_edges, edge2));
     }
-
-    // --- access operators ---
-
-    SUBCASE("at should return the incident edges of a vertex") {
-        init_complete_graph();
-        for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.out_edges(vertex_id)));
-    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -790,14 +782,6 @@ TEST_CASE_TEMPLATE_DEFINE("undirected adjacency list tests", SutType, undirected
         CHECK(std::ranges::equal(sut.incident_edges(constants::v1_id), expected_edges));
         CHECK(std::ranges::equal(sut.in_edges(constants::v1_id), expected_edges));
         CHECK(std::ranges::equal(sut.out_edges(constants::v1_id), expected_edges));
-    }
-
-    // --- access operators ---
-
-    SUBCASE("at should return the incident edges of a vertex") {
-        init_complete_graph();
-        for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements))
-            CHECK(std::ranges::equal(sut.at(vertex_id), sut.incident_edges(vertex_id)));
     }
 }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -1,3 +1,4 @@
+#include "doctest.h"
 #include "gl/types/core.hpp"
 #include "testing/common/functional.hpp"
 #include "testing/gl/constants.hpp"
@@ -5,8 +6,6 @@
 #include <gl/graph_traits.hpp>
 #include <gl/impl/adjacency_matrix.hpp>
 #include <gl/util/ranges.hpp>
-
-#include <doctest.h>
 
 #include <algorithm>
 #include <functional>

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -477,23 +477,6 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         CHECK(std::ranges::contains(out_edges, edge1));
         CHECK(std::ranges::contains(out_edges, edge2));
     }
-
-    // --- access operators ---
-
-    SUBCASE("at should return a view equivalent to the matrix row of the given vertex") {
-        for (const auto vertex_id : std::views::iota(constants::v1_id, constants::n_elements)) {
-            const auto target_id =
-                static_cast<gl::default_id_type>((vertex_id + 1u) % constants::n_elements);
-            const auto edge = add_edge(vertex_id, target_id);
-            auto row_view = sut.at(vertex_id);
-
-            REQUIRE_EQ(std::ranges::count_if(row_view, &edge_type::is_valid), 1uz);
-
-            const auto edge_it = std::ranges::find_if(row_view, &edge_type::is_valid);
-            REQUIRE_NE(edge_it, row_view.end());
-            REQUIRE_EQ(*edge_it, edge);
-        }
-    }
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(
@@ -813,29 +796,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK(std::ranges::equal(sut.incident_edges(constants::v1_id), expected_edges));
         CHECK(std::ranges::equal(sut.in_edges(constants::v1_id), expected_edges));
         CHECK(std::ranges::equal(sut.out_edges(constants::v1_id), expected_edges));
-    }
-
-    // --- access operators ---
-
-    SUBCASE("at should return a view equivalent to the matrix row of the given vertex") {
-        const auto edge1 = add_edge(constants::v1_id, constants::v2_id);
-        const auto edge2 = add_edge(constants::v2_id, constants::v3_id);
-        const auto edge3 = add_edge(constants::v3_id, constants::v1_id);
-
-        auto v1_row_view = sut.at(constants::v1_id);
-        REQUIRE_EQ(std::ranges::count_if(v1_row_view, &edge_type::is_valid), 2uz);
-        CHECK_EQ(v1_row_view[constants::v2_id], edge1);
-        CHECK_EQ(v1_row_view[constants::v3_id], edge3);
-
-        auto v2_row_view = sut.at(constants::v2_id);
-        REQUIRE_EQ(std::ranges::count_if(v2_row_view, &edge_type::is_valid), 2uz);
-        CHECK_EQ(v2_row_view[constants::v1_id], edge1);
-        CHECK_EQ(v2_row_view[constants::v3_id], edge2);
-
-        auto v3_row_view = sut.at(constants::v3_id);
-        REQUIRE_EQ(std::ranges::count_if(v3_row_view, &edge_type::is_valid), 2uz);
-        CHECK_EQ(v3_row_view[constants::v1_id], edge3);
-        CHECK_EQ(v3_row_view[constants::v2_id], edge2);
     }
 }
 

--- a/tests/source/gl/test_adjacency_matrix.cpp
+++ b/tests/source/gl/test_adjacency_matrix.cpp
@@ -429,19 +429,19 @@ TEST_CASE_TEMPLATE_DEFINE("directed adjacency matrix tests", SutType, directed_a
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
-    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+    SUBCASE("edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v1_id, constants::v2_id));
     }
 
-    SUBCASE("get_edge(id, id) should return a valid edge if the given vertices are connected") {
+    SUBCASE("edge(id, id) should return a valid edge if the given vertices are connected") {
         const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt = sut.get_edge(constants::v1_id, constants::v2_id);
+        const auto edge_opt = sut.edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt.has_value());
         CHECK_EQ(*edge_opt, edge_1);
 
-        CHECK_FALSE(sut.get_edge(constants::v2_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v2_id, constants::v2_id));
     }
 
     SUBCASE("incident_edges should return edges incident with the vertex") {
@@ -761,19 +761,19 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_FALSE(sut.has_edge(not_present_edge));
     }
 
-    SUBCASE("get_edge(id, id) should return nullopt if there is no edge connecting the given "
+    SUBCASE("edge(id, id) should return nullopt if there is no edge connecting the given "
             "vertices") {
-        CHECK_FALSE(sut.get_edge(constants::v1_id, constants::v2_id));
+        CHECK_FALSE(sut.edge(constants::v1_id, constants::v2_id));
     }
 
-    SUBCASE("get_edge(id, id) should return a valid edge if the given vertices are connected") {
+    SUBCASE("edge(id, id) should return a valid edge if the given vertices are connected") {
         const auto edge_1 = add_edge(constants::v1_id, constants::v2_id);
 
-        const auto edge_opt_1 = sut.get_edge(constants::v1_id, constants::v2_id);
+        const auto edge_opt_1 = sut.edge(constants::v1_id, constants::v2_id);
         REQUIRE(edge_opt_1.has_value());
         CHECK_EQ(*edge_opt_1, edge_1);
 
-        const auto edge_opt_2 = sut.get_edge(constants::v2_id, constants::v1_id);
+        const auto edge_opt_2 = sut.edge(constants::v2_id, constants::v1_id);
         REQUIRE(edge_opt_2.has_value());
         CHECK_EQ(*edge_opt_2, edge_1);
     }

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_alg_bfs.cpp
+++ b/tests/source/gl/test_alg_bfs.cpp
@@ -181,7 +181,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         gl::algorithm::breadth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pred_map.size(), graph.order());
+    REQUIRE_EQ(pred_map.size(), graph.n_vertices());
     CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -83,7 +83,8 @@ TEST_CASE_TEMPLATE_DEFINE("bipartite coloring tests", TraitsType, traits_type_te
 
             fs::path coloring_file_path = data_path / "bicoloring_bipartite_graph_coloring.txt";
 
-            const auto coloring_values = load_list<std::uint16_t>(sut.order(), coloring_file_path);
+            const auto coloring_values =
+                load_list<std::uint16_t>(sut.n_vertices(), coloring_file_path);
 
             std::transform(
                 coloring_values.begin(),

--- a/tests/source/gl/test_alg_coloring.cpp
+++ b/tests/source/gl/test_alg_coloring.cpp
@@ -1,11 +1,10 @@
+#include "doctest.h"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
 #include <gl/io/graph_fio.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -187,7 +187,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     const auto pred_map = gl::algorithm::depth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pred_map.size(), graph.order());
+    REQUIRE_EQ(pred_map.size(), graph.n_vertices());
     CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 
@@ -391,7 +391,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         gl::algorithm::recursive_depth_first_search<gl::algorithm::ret, graph_type>(graph);
 
     // verify the predecessors of each vertex
-    REQUIRE_EQ(pred_map.size(), graph.order());
+    REQUIRE_EQ(pred_map.size(), graph.n_vertices());
     CHECK(std::ranges::all_of(graph.vertex_ids(), has_correct_bin_predecessor(pred_map)));
 }
 

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -29,7 +29,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("should throw if there is an edge with a negative weight") {
         const auto sut = gl::topology::clique<sut_type>(constants::n_elements_alg);
-        sut.get_edge(constants::v1_id, constants::v2_id)->properties().weight =
+        sut.edge(constants::v1_id, constants::v2_id)->properties().weight =
             -static_cast<weight_type>(constants::n_elements_alg);
 
         CHECK_THROWS_AS(
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             expected_distances.push_back(source_distance);
             const auto edge_weight = static_cast<weight_type>(constants::n_elements_alg);
             for (auto id = constants::v2_id; id < constants::n_elements_alg; id++) {
-                sut.get_edge(constants::v1_id, id)->properties().weight = edge_weight;
+                sut.edge(constants::v1_id, id)->properties().weight = edge_weight;
                 expected_distances.push_back(edge_weight);
             }
         }

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -33,7 +33,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             -static_cast<weight_type>(constants::n_elements_alg);
 
         CHECK_THROWS_AS(
-            discard_result(gl::algorithm::dijkstra_shortest_paths(sut, constants::v1_id)),
+            discard(gl::algorithm::dijkstra_shortest_paths(sut, constants::v1_id)),
             std::invalid_argument
         );
     }
@@ -224,8 +224,7 @@ TEST_CASE("reconstruct_path should thow if the vertex is not reachable") {
     const auto vertex_id = static_cast<gl::default_id_type>(predecessor_map.size() - 1uz);
 
     CHECK_THROWS_AS(
-        discard_result(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)),
-        std::invalid_argument
+        discard(gl::algorithm::reconstruct_path(predecessor_map, vertex_id)), std::invalid_argument
     );
 }
 

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -89,10 +89,10 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path predecessors_file_path =
                 data_path / (file_name_prefix + "predecessors.txt");
             expected_predecessors =
-                load_list<gl::default_id_type>(sut.order(), predecessors_file_path);
+                load_list<gl::default_id_type>(sut.n_vertices(), predecessors_file_path);
 
             const fs::path distances_file_path = data_path / (file_name_prefix + "distances.txt");
-            expected_distances = load_list<distance_type>(sut.order(), distances_file_path);
+            expected_distances = load_list<distance_type>(sut.n_vertices(), distances_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_dijkstra.cpp
+++ b/tests/source/gl/test_alg_dijkstra.cpp
@@ -1,14 +1,13 @@
-#include "gl/constants.hpp"
-#include "gl/types/core.hpp"
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
+#include <gl/constants.hpp>
 #include <gl/io/graph_fio.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
+#include <gl/types/core.hpp>
 
 #include <cmath>
 

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -1,13 +1,12 @@
-#include "gl/impl/impl_tags.hpp"
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
+#include <gl/impl/impl_tags.hpp>
 #include <gl/io/graph_fio.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 #include <cmath>
 

--- a/tests/source/gl/test_alg_prim_mst.cpp
+++ b/tests/source/gl/test_alg_prim_mst.cpp
@@ -46,7 +46,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * static_cast<weight_type>(sut.order() - 1uz);
+            expected_weight = edge_weight * static_cast<weight_type>(sut.n_vertices() - 1uz);
         }
 
         SUBCASE("custom graph") {
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = 0u;
 
             const fs::path edges_file_path = data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
+            const auto n_vertex_ids = (sut.n_vertices() - 1uz) * 2uz;
             const auto vertex_id_list =
                 load_list<gl::default_id_type>(n_vertex_ids, edges_file_path);
             for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
@@ -73,7 +73,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
+        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - 1uz);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -131,11 +131,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.incident_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);
+    const auto expected_weight = static_cast<weight_type>(sut.n_vertices() - 1uz);
 
     const auto mst = gl::algorithm::edge_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
+    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - 1uz);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -191,7 +191,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 }
             }
 
-            expected_weight = edge_weight * static_cast<weight_type>(sut.order() - 1uz);
+            expected_weight = edge_weight * static_cast<weight_type>(sut.n_vertices() - 1uz);
         }
 
         SUBCASE("custom graph") {
@@ -201,7 +201,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             source_id = 0u;
 
             const fs::path edges_file_path = data_path / "mst_edges.txt";
-            const auto n_vertex_ids = (sut.order() - 1uz) * 2uz;
+            const auto n_vertex_ids = (sut.n_vertices() - 1uz) * 2uz;
             const auto vertex_id_list =
                 load_list<gl::default_id_type>(n_vertex_ids, edges_file_path);
             for (auto i = 0uz; i < n_vertex_ids; i += 2uz)
@@ -218,7 +218,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-        REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
+        REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - 1uz);
         REQUIRE_EQ(mst.weight, expected_weight);
 
         CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {
@@ -276,11 +276,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (const auto& edge : sut.incident_edges(vertex_id))
             expected_edges.emplace_back(edge.source(), edge.target());
 
-    const auto expected_weight = static_cast<weight_type>(sut.order() - 1uz);
+    const auto expected_weight = static_cast<weight_type>(sut.n_vertices() - 1uz);
 
     const auto mst = gl::algorithm::vertex_heap_prim_mst(sut, source_id);
 
-    REQUIRE_EQ(mst.edges.size(), sut.order() - 1uz);
+    REQUIRE_EQ(mst.edges.size(), sut.n_vertices() - 1uz);
     REQUIRE_EQ(mst.weight, expected_weight);
 
     CHECK(std::ranges::all_of(mst.edges, [&expected_edges](const auto& edge) {

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -56,7 +56,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const fs::path order_file_path =
                 data_path / "topological_sort_directed_acyclic_order.txt";
             expected_topological_order =
-                load_list<gl::default_id_type>(sut.order(), order_file_path);
+                load_list<gl::default_id_type>(sut.n_vertices(), order_file_path);
         }
 
         CAPTURE(sut);

--- a/tests/source/gl/test_alg_topological_sort.cpp
+++ b/tests/source/gl/test_alg_topological_sort.cpp
@@ -1,11 +1,10 @@
+#include "doctest.h"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm.hpp>
 #include <gl/io/graph_fio.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 #include <numeric>
 

--- a/tests/source/gl/test_alg_types.cpp
+++ b/tests/source/gl/test_alg_types.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/gl/alg_utils.hpp"
 #include "testing/gl/constants.hpp"
 
 #include <gl/algorithm/core.hpp>
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 using gl::algorithm::decision;
 

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -38,7 +38,7 @@ struct test_conversion {
                           typename std::decay_t<decltype(graph)>::vertex_properties_type,
                           property_type>)
             for (const auto& vid : graph.vertex_ids())
-                graph.get_vertex_properties(vid) = property_type("vertex_" + std::to_string(vid));
+                graph.vertex_properties(vid) = property_type("vertex_" + std::to_string(vid));
 
         if constexpr (std::same_as<
                           typename std::decay_t<decltype(graph)>::edge_properties_type,
@@ -61,7 +61,7 @@ struct test_conversion {
                           typename std::decay_t<decltype(graph)>::vertex_properties_type,
                           property_type>)
             for (const auto& vid : graph.vertex_ids())
-                CHECK_EQ(graph.get_vertex_properties(vid), "vertex_" + std::to_string(vid));
+                CHECK_EQ(graph.vertex_properties(vid), "vertex_" + std::to_string(vid));
 
         if constexpr (std::same_as<
                           typename std::decay_t<decltype(graph)>::edge_properties_type,

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -1,10 +1,10 @@
-#include "gl/conversion.hpp"
-#include "gl/directional_tags.hpp"
-#include "gl/graph.hpp"
-#include "gl/impl/impl_tags.hpp"
+#include "doctest.h"
 #include "testing/gl/types.hpp"
 
-#include <doctest.h>
+#include <gl/conversion.hpp>
+#include <gl/directional_tags.hpp>
+#include <gl/graph.hpp>
+#include <gl/impl/impl_tags.hpp>
 
 #include <algorithm>
 #include <concepts>

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -48,8 +48,8 @@ struct test_conversion {
     }
 
     void validate_graph(const gl::traits::c_graph auto& graph) {
-        REQUIRE_EQ(graph.order(), this->test_order);
-        REQUIRE_EQ(graph.size(), this->test_edges.size());
+        REQUIRE_EQ(graph.n_vertices(), this->test_order);
+        REQUIRE_EQ(graph.n_edges(), this->test_edges.size());
         for (const auto& [source, target] : this->test_edges)
             CHECK(graph.has_edge(source, target));
 

--- a/tests/source/gl/test_directional_tags.cpp
+++ b/tests/source/gl/test_directional_tags.cpp
@@ -1,9 +1,8 @@
+#include "doctest.h"
 #include "testing/gl/constants.hpp"
 #include "testing/gl/types.hpp"
 
 #include <gl/edge_descriptor.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -70,30 +70,47 @@ TEST_CASE_TEMPLATE_DEFINE(
     "properties accessing tests", EdgeType, properties_directional_tag_template
 ) {
     test_edge_descriptor fixture;
-    used_property used{true};
+    used_property property{true};
 
     SUBCASE("properties should be properly initialized for valid edges") {
-        const EdgeType sut{fixture.id1, fixture.v1, fixture.v2, used};
-        CHECK_EQ(sut.properties(), used);
+        const EdgeType sut{fixture.id1, fixture.v1, fixture.v2, property};
+        CHECK_EQ(&sut.properties(), &property);
+    }
+
+    SUBCASE("operator* should return a reference to the properties") {
+        const EdgeType sut{fixture.id1, fixture.v1, fixture.v2, property};
+        CHECK_EQ(&(*sut), &property);
+    }
+
+    SUBCASE("operator-> should return a pointer to the properties") {
+        const EdgeType sut{fixture.id1, fixture.v1, fixture.v2, property};
+        CHECK_EQ(sut.operator->(), &property);
+        CHECK_EQ(sut->used, property.used);
     }
 
     SUBCASE("accessing properties should throw for invalid edges") {
-        CHECK_THROWS_AS(
-            discard_result(EdgeType(gl::invalid_id, fixture.v1, fixture.v2, used).properties()),
-            std::logic_error
-        );
+        const auto invalid_edge = EdgeType::invalid();
+        const EdgeType invalid_id_edge{gl::invalid_id, fixture.v1, fixture.v2, property};
+        const EdgeType invalid_v1_edge{fixture.id1, gl::invalid_id, fixture.v2, property};
+        const EdgeType invalid_v2_edge{fixture.id1, fixture.v1, gl::invalid_id, property};
 
-        CHECK_THROWS_AS(
-            discard_result(EdgeType(fixture.id1, gl::invalid_id, fixture.v2, used).properties()),
-            std::logic_error
-        );
+        // .properties()
+        CHECK_THROWS_AS(discard_result(invalid_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_id_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_v1_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_v2_edge.properties()), std::logic_error);
 
-        CHECK_THROWS_AS(
-            discard_result(EdgeType(fixture.id1, fixture.v1, gl::invalid_id, used).properties()),
-            std::logic_error
-        );
+        // operator*
+        CHECK_THROWS_AS(discard_result(*invalid_edge), std::logic_error);
+        CHECK_THROWS_AS(discard_result(*invalid_id_edge), std::logic_error);
+        CHECK_THROWS_AS(discard_result(*invalid_v1_edge), std::logic_error);
+        CHECK_THROWS_AS(discard_result(*invalid_v2_edge), std::logic_error);
 
-        CHECK_THROWS_AS(discard_result(EdgeType::invalid().properties()), std::logic_error);
+        // operator->
+        CHECK_THROWS_AS(discard_result(invalid_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_id_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_v1_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(invalid_v2_edge.operator->()), std::logic_error);
     }
 }
 

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -95,22 +95,22 @@ TEST_CASE_TEMPLATE_DEFINE(
         const EdgeType invalid_v2_edge{fixture.id1, fixture.v1, gl::invalid_id, property};
 
         // .properties()
-        CHECK_THROWS_AS(discard_result(invalid_edge.properties()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_id_edge.properties()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_v1_edge.properties()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_v2_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_id_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_v1_edge.properties()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_v2_edge.properties()), std::logic_error);
 
         // operator*
-        CHECK_THROWS_AS(discard_result(*invalid_edge), std::logic_error);
-        CHECK_THROWS_AS(discard_result(*invalid_id_edge), std::logic_error);
-        CHECK_THROWS_AS(discard_result(*invalid_v1_edge), std::logic_error);
-        CHECK_THROWS_AS(discard_result(*invalid_v2_edge), std::logic_error);
+        CHECK_THROWS_AS(discard(*invalid_edge), std::logic_error);
+        CHECK_THROWS_AS(discard(*invalid_id_edge), std::logic_error);
+        CHECK_THROWS_AS(discard(*invalid_v1_edge), std::logic_error);
+        CHECK_THROWS_AS(discard(*invalid_v2_edge), std::logic_error);
 
         // operator->
-        CHECK_THROWS_AS(discard_result(invalid_edge.operator->()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_id_edge.operator->()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_v1_edge.operator->()), std::logic_error);
-        CHECK_THROWS_AS(discard_result(invalid_v2_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_id_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_v1_edge.operator->()), std::logic_error);
+        CHECK_THROWS_AS(discard(invalid_v2_edge.operator->()), std::logic_error);
     }
 }
 
@@ -156,7 +156,7 @@ TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directi
     }
 
     SUBCASE("other should throw if input vertex is not incident with the edge") {
-        CHECK_THROWS_AS(discard_result(sut.other(fixture.v3)), std::invalid_argument);
+        CHECK_THROWS_AS(discard(sut.other(fixture.v3)), std::invalid_argument);
     }
 
     SUBCASE("other should return the vertex adjacent with the input vertex") {

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 #include "testing/gl/constants.hpp"
 #include "testing/gl/types.hpp"
 
 #include <gl/edge_descriptor.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_flat_jagged_vector.cpp
+++ b/tests/source/gl/test_flat_jagged_vector.cpp
@@ -1,7 +1,7 @@
 #include "doctest.h"
-#include "gl/types/core.hpp"
 
 #include <gl/attributes/diagnostics.hpp>
+#include <gl/types/core.hpp>
 #include <gl/types/flat_jagged_vector.hpp>
 
 #include <algorithm>

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -143,7 +143,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
         REQUIRE(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
 
-        CHECK_THROWS_AS(discard_result(sut.at(constants::out_of_rng_idx)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.at(constants::out_of_rng_idx)), std::out_of_range);
         CHECK(std::ranges::all_of(
             constants::vertex_id_view,
             [&sut](const gl::default_id_type vertex_id) { return sut.out_edges(vertex_id).empty(); }
@@ -236,7 +236,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.at(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.at(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should throw if the given id is invalid") {
@@ -267,7 +267,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.at(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.at(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vetices_from(ids) should properly remove elements at given indices (ignoring "
@@ -327,12 +327,11 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("vertex/at should throw if the given id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            discard_result(sut.vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
+            discard(sut.vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.at(static_cast<gl::default_id_type>(sut.n_vertices()))),
-            std::out_of_range
+            discard(sut.at(static_cast<gl::default_id_type>(sut.n_vertices()))), std::out_of_range
         );
     }
 
@@ -345,10 +344,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     SUBCASE("vertex_unchecked/operator[] should not throw if the given id is invalid (UB)") {
         sut_type sut{constants::n_elements};
-        CHECK_NOTHROW(
-            discard_result(sut.vertex_unchecked(static_cast<gl::default_id_type>(sut.n_vertices())))
-        );
-        CHECK_NOTHROW(discard_result(sut[static_cast<gl::default_id_type>(sut.n_vertices())]));
+        CHECK_NOTHROW(discard(sut.vertex_unchecked(static_cast<gl::default_id_type>(sut.n_vertices()
+        ))));
+        CHECK_NOTHROW(discard(sut[static_cast<gl::default_id_type>(sut.n_vertices())]));
     }
 
     SUBCASE("vertex_unchecked/operator[] should return a vertex with the given id") {
@@ -375,15 +373,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("neighbor/predecessor/successor_ids should throw out_of_range if vertex does not exist"
     ) {
         sut_type sut{};
-        CHECK_THROWS_AS(
-            discard_result(sut.neighbor_ids(constants::out_of_rng_idx)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.predecessor_ids(constants::out_of_rng_idx)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.successor_ids(constants::out_of_rng_idx)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.neighbor_ids(constants::out_of_rng_idx)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.predecessor_ids(constants::out_of_rng_idx)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.successor_ids(constants::out_of_rng_idx)), std::out_of_range);
     }
     GL_SUPPRESS_WARNING_END;
 
@@ -401,15 +393,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("neighbors/predecessors/successors should throw out_of_range if vertex does not exist"
     ) {
         sut_type sut{};
-        CHECK_THROWS_AS(
-            discard_result(sut.neighbors(constants::out_of_rng_idx)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.predecessors(constants::out_of_rng_idx)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.successors(constants::out_of_rng_idx)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.neighbors(constants::out_of_rng_idx)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.predecessors(constants::out_of_rng_idx)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.successors(constants::out_of_rng_idx)), std::out_of_range);
     }
     GL_SUPPRESS_WARNING_END;
 
@@ -786,12 +772,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         const auto v1 = sut[constants::v1_id];
         const auto v2 = sut[constants::v2_id];
 
-        CHECK_THROWS_AS(
-            discard_result(sut.has_edge(fixture.out_of_range_vertex, v2)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.has_edge(v1, fixture.out_of_range_vertex)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.has_edge(fixture.out_of_range_vertex, v2)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.has_edge(v1, fixture.out_of_range_vertex)), std::out_of_range);
     }
 
     SUBCASE("has_edge(vertex, vertex) should return true if there is an edge connecting the given "
@@ -814,14 +796,10 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         const auto valid_vertex = sut[constants::v1_id];
 
         const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
+        CHECK_THROWS_AS(discard(sut.edge(valid_vertex, out_of_range_vertex)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.edge(out_of_range_vertex, valid_vertex)), std::out_of_range);
         CHECK_THROWS_AS(
-            discard_result(sut.edge(valid_vertex, out_of_range_vertex)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.edge(out_of_range_vertex, valid_vertex)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.edge(out_of_range_vertex, out_of_range_vertex)), std::out_of_range
+            discard(sut.edge(out_of_range_vertex, out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -855,12 +833,10 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(sut.edges(constants::out_of_rng_idx, constants::v2_id)),
-            std::out_of_range
+            discard(sut.edges(constants::out_of_rng_idx, constants::v2_id)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.edges(constants::v1_id, constants::out_of_rng_idx)),
-            std::out_of_range
+            discard(sut.edges(constants::v1_id, constants::out_of_rng_idx)), std::out_of_range
         );
     }
 
@@ -899,19 +875,13 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         const auto v1 = sut[constants::v1_id];
         const auto v2 = sut[constants::v2_id];
 
-        CHECK_THROWS_AS(
-            discard_result(sut.edges(fixture.out_of_range_vertex, v2)), std::out_of_range
-        );
-        CHECK_THROWS_AS(
-            discard_result(sut.edges(v1, fixture.out_of_range_vertex)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.edges(fixture.out_of_range_vertex, v2)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.edges(v1, fixture.out_of_range_vertex)), std::out_of_range);
     }
 
     SUBCASE("incident_edges(id) should throw if the vertex_id is invalid") {
         sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(
-            discard_result(sut.incident_edges(constants::out_of_rng_idx)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.incident_edges(constants::out_of_rng_idx)), std::out_of_range);
     }
 
     SUBCASE("incident_edges(id) should return a proper iterator range for a valid vertex") {
@@ -924,7 +894,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(sut.incident_edges(fixture.out_of_range_vertex)), std::out_of_range
+            discard(sut.incident_edges(fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -947,11 +917,11 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
         SUBCASE("are_adjacent(vertex_id, vertex_id) should throw for out of range vertex ids") {
             CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(constants::out_of_rng_idx, constants::v2_id)),
+                discard(sut.are_adjacent(constants::out_of_rng_idx, constants::v2_id)),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(constants::v1_id, constants::out_of_rng_idx)),
+                discard(sut.are_adjacent(constants::v1_id, constants::out_of_rng_idx)),
                 std::out_of_range
             );
         }
@@ -975,16 +945,14 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         SUBCASE("are_adjacent(vertex, vertex) should throw if at least one of the vertices is "
                 "invalid") {
             CHECK_THROWS_AS(
-                discard_result(
-                    sut.are_adjacent(fixture.out_of_range_vertex, fixture.out_of_range_vertex)
-                ),
+                discard(sut.are_adjacent(fixture.out_of_range_vertex, fixture.out_of_range_vertex)),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(fixture.out_of_range_vertex, v2)), std::out_of_range
+                discard(sut.are_adjacent(fixture.out_of_range_vertex, v2)), std::out_of_range
             );
             CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(v1, fixture.out_of_range_vertex)), std::out_of_range
+                discard(sut.are_adjacent(v1, fixture.out_of_range_vertex)), std::out_of_range
             );
         }
 
@@ -1008,12 +976,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             const auto edge = sut.add_edge(v1, v2);
             const edge_type invalid_edge{gl::invalid_id, v1.id(), v2.id()};
 
-            CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(edge, invalid_edge)), std::invalid_argument
-            );
-            CHECK_THROWS_AS(
-                discard_result(sut.are_adjacent(invalid_edge, edge)), std::invalid_argument
-            );
+            CHECK_THROWS_AS(discard(sut.are_adjacent(edge, invalid_edge)), std::invalid_argument);
+            CHECK_THROWS_AS(discard(sut.are_adjacent(invalid_edge, edge)), std::invalid_argument);
         }
 
         SUBCASE("are_adjacent(edge, edge) should return true only when the edges are distinct and "
@@ -1033,40 +997,28 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             const auto edge = sut.add_edge(v1, v2);
 
             CHECK_THROWS_AS(
-                discard_result(sut.are_incident(fixture.out_of_range_vertex, edge)),
-                std::out_of_range
+                discard(sut.are_incident(fixture.out_of_range_vertex, edge)), std::out_of_range
             );
             CHECK_THROWS_AS(
-                discard_result(sut.are_incident(fixture.out_of_range_vertex, edge)),
-                std::out_of_range
+                discard(sut.are_incident(fixture.out_of_range_vertex, edge)), std::out_of_range
             );
 
             CHECK_THROWS_AS(
-                discard_result(sut.are_incident(edge, fixture.out_of_range_vertex)),
-                std::out_of_range
+                discard(sut.are_incident(edge, fixture.out_of_range_vertex)), std::out_of_range
             );
             CHECK_THROWS_AS(
-                discard_result(sut.are_incident(edge, fixture.out_of_range_vertex)),
-                std::out_of_range
+                discard(sut.are_incident(edge, fixture.out_of_range_vertex)), std::out_of_range
             );
         }
 
         SUBCASE("are_incident(vertex and edge pair) should throw if the edge is invalid") {
             const edge_type invalid_edge{gl::invalid_id, v1.id(), v2.id()};
 
-            CHECK_THROWS_AS(
-                discard_result(sut.are_incident(v1, invalid_edge)), std::invalid_argument
-            );
-            CHECK_THROWS_AS(
-                discard_result(sut.are_incident(v1, invalid_edge)), std::invalid_argument
-            );
+            CHECK_THROWS_AS(discard(sut.are_incident(v1, invalid_edge)), std::invalid_argument);
+            CHECK_THROWS_AS(discard(sut.are_incident(v1, invalid_edge)), std::invalid_argument);
 
-            CHECK_THROWS_AS(
-                discard_result(sut.are_incident(invalid_edge, v2)), std::invalid_argument
-            );
-            CHECK_THROWS_AS(
-                discard_result(sut.are_incident(invalid_edge, v2)), std::invalid_argument
-            );
+            CHECK_THROWS_AS(discard(sut.are_incident(invalid_edge, v2)), std::invalid_argument);
+            CHECK_THROWS_AS(discard(sut.are_incident(invalid_edge, v2)), std::invalid_argument);
         }
 
         SUBCASE("are_incident(vertex and edge pair) should return true only when the edge and the "
@@ -1329,9 +1281,7 @@ TEST_CASE_TEMPLATE_DEFINE("property getter tests", TraitsType, property_graph_tr
         CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
     }
 
-    CHECK_THROWS_AS(
-        discard_result(sut.vertex_properties(constants::out_of_rng_idx)), std::out_of_range
-    );
+    CHECK_THROWS_AS(discard(sut.vertex_properties(constants::out_of_rng_idx)), std::out_of_range);
 
     auto emap = sut.edge_properties_map();
     CHECK(emap.size() == constants::n_elements);
@@ -1344,9 +1294,7 @@ TEST_CASE_TEMPLATE_DEFINE("property getter tests", TraitsType, property_graph_tr
         );
     }
 
-    CHECK_THROWS_AS(
-        discard_result(sut.get_edge_properties(constants::out_of_rng_idx)), std::out_of_range
-    );
+    CHECK_THROWS_AS(discard(sut.get_edge_properties(constants::out_of_rng_idx)), std::out_of_range);
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -144,7 +144,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         REQUIRE(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
 
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::out_of_rng_idx)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::out_of_rng_idx)), std::out_of_range
         );
 
         CHECK(std::ranges::all_of(
@@ -239,7 +239,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard_result(sut.vertex(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should throw if the given id is invalid") {
@@ -270,7 +270,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.get_vertex(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard_result(sut.vertex(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vetices_from(ids) should properly remove elements at given indices (ignoring "
@@ -300,8 +300,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut_type sut{n_vertices};
         fixture.init_complete_graph(sut);
 
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v3 = sut.get_vertex(constants::v3_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v3 = sut.vertex(constants::v3_id);
 
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
@@ -404,18 +404,18 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         CHECK_FALSE(sut.has_vertex(constants::out_of_rng_idx));
     }
 
-    SUBCASE("get_vertex should throw if the given id is invalid") {
+    SUBCASE("vertex should throw if the given id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
+            static_cast<void>(sut.vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
             std::out_of_range
         );
     }
 
-    SUBCASE("get_vertex should return a vertex with the given id") {
+    SUBCASE("vertex should return a vertex with the given id") {
         sut_type sut;
         const auto added_vertex = sut.add_vertex();
-        CHECK_EQ(sut.get_vertex(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
     }
 
     // --- degree getters ---
@@ -766,7 +766,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     SUBCASE("incident_edges(vertex) should return a proper iterator range for a valid vertex") {
         sut_type sut{1uz};
-        const auto vertex = sut.get_vertex(0uz);
+        const auto vertex = sut.vertex(0uz);
 
         CHECK_NOTHROW([&sut, &vertex]() {
             CHECK_EQ(gl::util::range_size(sut.incident_edges(vertex)), 0uz);
@@ -776,8 +776,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("has_edge(vertex, vertex) should throw if one of the vertices is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v2 = sut.get_vertex(constants::v2_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v2 = sut.vertex(constants::v2_id);
 
         CHECK_THROWS_AS(
             discard_result(sut.has_edge(fixture.out_of_range_vertex, v2)), std::out_of_range
@@ -791,9 +791,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             "vertices in the graph") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v2 = sut.get_vertex(constants::v2_id);
-        const auto v3 = sut.get_vertex(constants::v3_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v2 = sut.vertex(constants::v2_id);
+        const auto v3 = sut.vertex(constants::v3_id);
 
         sut.add_edge(v1, v2);
 
@@ -802,72 +802,67 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         CHECK_FALSE(sut.has_edge(v2, v3));
     }
 
-    SUBCASE("get_edge(vertex, vertex) should throw if either vertex is invalid") {
+    SUBCASE("edge(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
-        const auto valid_vertex = sut.get_vertex(constants::v1_id);
+        const auto valid_vertex = sut.vertex(constants::v1_id);
 
         const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
         CHECK_THROWS_AS(
-            discard_result(sut.get_edge(valid_vertex, out_of_range_vertex)), std::out_of_range
+            discard_result(sut.edge(valid_vertex, out_of_range_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.get_edge(out_of_range_vertex, valid_vertex)), std::out_of_range
+            discard_result(sut.edge(out_of_range_vertex, valid_vertex)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.get_edge(out_of_range_vertex, out_of_range_vertex)),
-            std::out_of_range
+            discard_result(sut.edge(out_of_range_vertex, out_of_range_vertex)), std::out_of_range
         );
     }
 
-    SUBCASE("get_edge(vertex, vertex) should return nullopt if the given vertices are not adjacent"
-    ) {
+    SUBCASE("edge(vertex, vertex) should return nullopt if the given vertices are not adjacent") {
         sut_type sut{constants::n_elements};
-        CHECK_FALSE(sut.get_edge(sut.get_vertex(constants::v1_id), sut.get_vertex(constants::v2_id))
-        );
+        CHECK_FALSE(sut.edge(sut.vertex(constants::v1_id), sut.vertex(constants::v2_id)));
     }
 
-    SUBCASE("get_edge(vertex, vertex) should return a valid edge if the given vetices are adjacent"
-    ) {
+    SUBCASE("edge(vertex, vertex) should return a valid edge if the given vetices are adjacent") {
         sut_type sut{constants::n_elements};
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v2 = sut.get_vertex(constants::v2_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v2 = sut.vertex(constants::v2_id);
 
         const auto edge = sut.add_edge(v1, v2);
 
-        const auto edge_opt_1 = sut.get_edge(v1, v2);
+        const auto edge_opt_1 = sut.edge(v1, v2);
         REQUIRE(edge_opt_1.has_value());
         CHECK_EQ(*edge_opt_1, edge);
 
         if constexpr (gl::traits::c_undirected_edge<edge_type>) {
-            const auto edge_opt_2 = sut.get_edge(v2, v1);
+            const auto edge_opt_2 = sut.edge(v2, v1);
             REQUIRE(edge_opt_2.has_value());
             CHECK_EQ(*edge_opt_2, edge);
         }
         else {
-            CHECK_FALSE(sut.get_edge(v2, v1).has_value());
+            CHECK_FALSE(sut.edge(v2, v1).has_value());
         }
     }
 
-    SUBCASE("get_edges(id, id) should return an empty list if either id is invalid") {
+    SUBCASE("edges(id, id) should return an empty list if either id is invalid") {
         sut_type sut{constants::n_elements};
 
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(constants::out_of_rng_idx, constants::v2_id)),
+            discard_result(sut.edges(constants::out_of_rng_idx, constants::v2_id)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(constants::v1_id, constants::out_of_rng_idx)),
+            discard_result(sut.edges(constants::v1_id, constants::out_of_rng_idx)),
             std::out_of_range
         );
     }
 
-    SUBCASE("get_edges(id, id) should return an empty vector if the given vertices are not adjacent"
-    ) {
+    SUBCASE("edges(id, id) should return an empty vector if the given vertices are not adjacent") {
         sut_type sut{constants::n_elements};
-        CHECK(sut.get_edges(constants::v1_id, constants::v2_id).empty());
+        CHECK(sut.edges(constants::v1_id, constants::v2_id).empty());
     }
 
-    SUBCASE("get_edges(id, id) should return a valid edge reference vector if the given vertices "
+    SUBCASE("edges(id, id) should return a valid edge reference vector if the given vertices "
             "are adjacent") {
         sut_type sut{constants::n_elements};
         std::vector<edge_type> expected_edges;
@@ -880,30 +875,28 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             expected_edges.emplace_back(sut.add_edge(constants::v1_id, constants::v2_id));
         }
 
-        CHECK(std::ranges::equal(sut.get_edges(constants::v1_id, constants::v2_id), expected_edges)
-        );
+        CHECK(std::ranges::equal(sut.edges(constants::v1_id, constants::v2_id), expected_edges));
 
         if constexpr (gl::traits::c_directed_edge<edge_type>) {
-            CHECK(sut.get_edges(constants::v2_id, constants::v2_id).empty());
+            CHECK(sut.edges(constants::v2_id, constants::v2_id).empty());
         }
         else {
-            CHECK(std::ranges::equal(
-                sut.get_edges(constants::v2_id, constants::v1_id), expected_edges
-            ));
+            CHECK(std::ranges::equal(sut.edges(constants::v2_id, constants::v1_id), expected_edges)
+            );
         }
     }
 
-    SUBCASE("get_edges(vertex, vertex) should throw if either vertex is invalid") {
+    SUBCASE("edges(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v2 = sut.get_vertex(constants::v2_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v2 = sut.vertex(constants::v2_id);
 
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(fixture.out_of_range_vertex, v2)), std::out_of_range
+            discard_result(sut.edges(fixture.out_of_range_vertex, v2)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            discard_result(sut.get_edges(v1, fixture.out_of_range_vertex)), std::out_of_range
+            discard_result(sut.edges(v1, fixture.out_of_range_vertex)), std::out_of_range
         );
     }
 
@@ -911,9 +904,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     SUBCASE("adjacency and incidence method tests") {
         sut_type sut{constants::n_elements};
-        const auto v1 = sut.get_vertex(constants::v1_id);
-        const auto v2 = sut.get_vertex(constants::v2_id);
-        const auto v3 = sut.get_vertex(constants::v3_id);
+        const auto v1 = sut.vertex(constants::v1_id);
+        const auto v2 = sut.vertex(constants::v2_id);
+        const auto v3 = sut.vertex(constants::v3_id);
 
         SUBCASE("are_adjacent(vertex_id, vertex_id) should throw for out of range vertex ids") {
             CHECK_THROWS_AS(
@@ -1091,7 +1084,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         }
 
         SUBCASE("graphs with different vertex properties are not equal") {
-            sut2.get_vertex_properties(0uz) = "dummy";
+            sut2.vertex_properties(0uz) = "dummy";
             CHECK_NE(sut1, sut2);
         }
 
@@ -1296,11 +1289,11 @@ TEST_CASE_TEMPLATE_DEFINE("property getter tests", TraitsType, property_graph_tr
     for (auto [id, property] : std::views::zip(sut.vertex_ids(), vmap)) {
         CHECK_EQ(property, std::format("vertex_{}", id));
         CHECK_EQ(vmap[id], std::format("vertex_{}", id));
-        CHECK_EQ(sut.get_vertex_properties(id), std::format("vertex_{}", id));
+        CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
     }
 
     CHECK_THROWS_AS(
-        discard_result(sut.get_vertex_properties(constants::out_of_rng_idx)), std::out_of_range
+        discard_result(sut.vertex_properties(constants::out_of_rng_idx)), std::out_of_range
     );
 
     auto emap = sut.edge_properties_map();

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -143,10 +143,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
         REQUIRE(std::ranges::equal(sut.vertex_ids(), constants::vertex_id_view));
 
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::out_of_rng_idx)), std::out_of_range
-        );
-
+        CHECK_THROWS_AS(discard_result(sut.at(constants::out_of_rng_idx)), std::out_of_range);
         CHECK(std::ranges::all_of(
             constants::vertex_id_view,
             [&sut](const gl::default_id_type vertex_id) { return sut.out_edges(vertex_id).empty(); }
@@ -239,7 +236,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.vertex(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard_result(sut.at(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should throw if the given id is invalid") {
@@ -270,7 +267,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             }
         ));
 
-        CHECK_THROWS_AS(discard_result(sut.vertex(n_vertices_after_remove)), std::out_of_range);
+        CHECK_THROWS_AS(discard_result(sut.at(n_vertices_after_remove)), std::out_of_range);
     }
 
     SUBCASE("remove_vetices_from(ids) should properly remove elements at given indices (ignoring "
@@ -300,8 +297,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut_type sut{n_vertices};
         fixture.init_complete_graph(sut);
 
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v3 = sut.vertex(constants::v3_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v3 = sut[constants::v3_id];
 
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
@@ -316,6 +313,50 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
 
     // --- vertex getters ---
+
+    SUBCASE("has_vertex(id) should return true when a vertex with the given id is present in "
+            "the graph") {
+        sut_type sut{constants::n_elements};
+
+        CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto vertex_id) {
+            return sut.has_vertex(vertex_id);
+        }));
+        CHECK_FALSE(sut.has_vertex(constants::out_of_rng_idx));
+    }
+
+    SUBCASE("vertex/at should throw if the given id is invalid") {
+        sut_type sut{constants::n_elements};
+        CHECK_THROWS_AS(
+            discard_result(sut.vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
+            std::out_of_range
+        );
+        CHECK_THROWS_AS(
+            discard_result(sut.at(static_cast<gl::default_id_type>(sut.n_vertices()))),
+            std::out_of_range
+        );
+    }
+
+    SUBCASE("vertex/at should return a vertex with the given id") {
+        sut_type sut;
+        const auto added_vertex = sut.add_vertex();
+        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut.at(added_vertex.id()), added_vertex);
+    }
+
+    SUBCASE("vertex_unchecked/operator[] should not throw if the given id is invalid (UB)") {
+        sut_type sut{constants::n_elements};
+        CHECK_NOTHROW(
+            discard_result(sut.vertex_unchecked(static_cast<gl::default_id_type>(sut.n_vertices())))
+        );
+        CHECK_NOTHROW(discard_result(sut[static_cast<gl::default_id_type>(sut.n_vertices())]));
+    }
+
+    SUBCASE("vertex_unchecked/operator[] should return a vertex with the given id") {
+        sut_type sut;
+        const auto added_vertex = sut.add_vertex();
+        CHECK_EQ(sut.vertex_unchecked(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut[added_vertex.id()], added_vertex);
+    }
 
     SUBCASE("vertices should return the correct vertex collection view") {
         sut_type sut{constants::n_elements};
@@ -394,31 +435,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             CHECK(v.is_valid());
     }
 
-    SUBCASE("has_vertex(id) should return true when a vertex with the given id is present in "
-            "the graph") {
-        sut_type sut{constants::n_elements};
-
-        CHECK(std::ranges::all_of(constants::vertex_id_view, [&sut](const auto vertex_id) {
-            return sut.has_vertex(vertex_id);
-        }));
-        CHECK_FALSE(sut.has_vertex(constants::out_of_rng_idx));
-    }
-
-    SUBCASE("vertex should throw if the given id is invalid") {
-        sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
-            std::out_of_range
-        );
-    }
-
-    SUBCASE("vertex should return a vertex with the given id") {
-        sut_type sut;
-        const auto added_vertex = sut.add_vertex();
-        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
-    }
-
     // --- degree getters ---
+
+    // TODO
 
     // --- edge modifiers ---
 
@@ -743,41 +762,29 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     // --- edge getters ---
 
-    SUBCASE("incident_edges(id) should throw if the vertex_id is invalid") {
-        sut_type sut{constants::n_elements};
-        CHECK_THROWS_AS(
-            discard_result(sut.incident_edges(constants::out_of_rng_idx)), std::out_of_range
-        );
-    }
-
-    SUBCASE("incident_edges(id) should return a proper iterator range for a valid vertex") {
-        sut_type sut{1uz};
-
-        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.incident_edges(0uz)), 0uz); }());
-    }
-
-    SUBCASE("incident_edges(vertex) should throw if the vertex is invalid") {
+    SUBCASE("has_edge(edge) should return true only if the given connection exists and has the "
+            "correct id") {
         sut_type sut{constants::n_elements};
 
-        CHECK_THROWS_AS(
-            discard_result(sut.incident_edges(fixture.out_of_range_vertex)), std::out_of_range
-        );
-    }
+        const auto v1 = sut[constants::v1_id].id();
+        const auto v2 = sut[constants::v2_id].id();
 
-    SUBCASE("incident_edges(vertex) should return a proper iterator range for a valid vertex") {
-        sut_type sut{1uz};
-        const auto vertex = sut.vertex(0uz);
+        const auto edge = sut.add_edge(v1, v2);
+        const auto invalid_id_edge = edge_type(edge.id() + 1u, v1, v2);
+        const auto invalid_v1_edge = edge_type(edge.id(), v2, v2);
+        const auto invalid_v2_edge = edge_type(edge.id(), v1, v1);
 
-        CHECK_NOTHROW([&sut, &vertex]() {
-            CHECK_EQ(gl::util::range_size(sut.incident_edges(vertex)), 0uz);
-        }());
+        CHECK(sut.has_edge(edge));
+        CHECK_FALSE(sut.has_edge(invalid_id_edge));
+        CHECK_FALSE(sut.has_edge(invalid_v1_edge));
+        CHECK_FALSE(sut.has_edge(invalid_v2_edge));
     }
 
     SUBCASE("has_edge(vertex, vertex) should throw if one of the vertices is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v2 = sut.vertex(constants::v2_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v2 = sut[constants::v2_id];
 
         CHECK_THROWS_AS(
             discard_result(sut.has_edge(fixture.out_of_range_vertex, v2)), std::out_of_range
@@ -791,9 +798,9 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             "vertices in the graph") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v2 = sut.vertex(constants::v2_id);
-        const auto v3 = sut.vertex(constants::v3_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v2 = sut[constants::v2_id];
+        const auto v3 = sut[constants::v3_id];
 
         sut.add_edge(v1, v2);
 
@@ -804,7 +811,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     SUBCASE("edge(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
-        const auto valid_vertex = sut.vertex(constants::v1_id);
+        const auto valid_vertex = sut[constants::v1_id];
 
         const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
         CHECK_THROWS_AS(
@@ -820,13 +827,13 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
     SUBCASE("edge(vertex, vertex) should return nullopt if the given vertices are not adjacent") {
         sut_type sut{constants::n_elements};
-        CHECK_FALSE(sut.edge(sut.vertex(constants::v1_id), sut.vertex(constants::v2_id)));
+        CHECK_FALSE(sut.edge(sut[constants::v1_id], sut[constants::v2_id]));
     }
 
     SUBCASE("edge(vertex, vertex) should return a valid edge if the given vetices are adjacent") {
         sut_type sut{constants::n_elements};
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v2 = sut.vertex(constants::v2_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v2 = sut[constants::v2_id];
 
         const auto edge = sut.add_edge(v1, v2);
 
@@ -889,8 +896,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("edges(vertex, vertex) should throw if either vertex is invalid") {
         sut_type sut{constants::n_elements};
 
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v2 = sut.vertex(constants::v2_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v2 = sut[constants::v2_id];
 
         CHECK_THROWS_AS(
             discard_result(sut.edges(fixture.out_of_range_vertex, v2)), std::out_of_range
@@ -900,13 +907,43 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         );
     }
 
+    SUBCASE("incident_edges(id) should throw if the vertex_id is invalid") {
+        sut_type sut{constants::n_elements};
+        CHECK_THROWS_AS(
+            discard_result(sut.incident_edges(constants::out_of_rng_idx)), std::out_of_range
+        );
+    }
+
+    SUBCASE("incident_edges(id) should return a proper iterator range for a valid vertex") {
+        sut_type sut{1uz};
+
+        CHECK_NOTHROW([&sut]() { CHECK_EQ(gl::util::range_size(sut.incident_edges(0uz)), 0uz); }());
+    }
+
+    SUBCASE("incident_edges(vertex) should throw if the vertex is invalid") {
+        sut_type sut{constants::n_elements};
+
+        CHECK_THROWS_AS(
+            discard_result(sut.incident_edges(fixture.out_of_range_vertex)), std::out_of_range
+        );
+    }
+
+    SUBCASE("incident_edges(vertex) should return a proper iterator range for a valid vertex") {
+        sut_type sut{1uz};
+        const auto vertex = sut[0uz];
+
+        CHECK_NOTHROW([&sut, &vertex]() {
+            CHECK_EQ(gl::util::range_size(sut.incident_edges(vertex)), 0uz);
+        }());
+    }
+
     // --- adjacency and incidence methods ---
 
     SUBCASE("adjacency and incidence method tests") {
         sut_type sut{constants::n_elements};
-        const auto v1 = sut.vertex(constants::v1_id);
-        const auto v2 = sut.vertex(constants::v2_id);
-        const auto v3 = sut.vertex(constants::v3_id);
+        const auto v1 = sut[constants::v1_id];
+        const auto v2 = sut[constants::v2_id];
+        const auto v3 = sut[constants::v3_id];
 
         SUBCASE("are_adjacent(vertex_id, vertex_id) should throw for out of range vertex ids") {
             CHECK_THROWS_AS(

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -63,9 +63,9 @@ struct test_graph {
                     graph.add_edge(first, second);
 
         const gl::size_type n_unique_edges_in_full_graph =
-            n_out_edges_for_fully_connected_vertex(graph) * graph.order();
+            n_out_edges_for_fully_connected_vertex(graph) * graph.n_vertices();
 
-        REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
+        REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
     }
 
@@ -79,9 +79,9 @@ struct test_graph {
                     graph.add_edge(first, second);
 
         const gl::size_type n_unique_edges_in_full_graph =
-            (n_out_edges_for_fully_connected_vertex(graph) * graph.order()) / 2;
+            (n_out_edges_for_fully_connected_vertex(graph) * graph.n_vertices()) / 2;
 
-        REQUIRE_EQ(graph.size(), n_unique_edges_in_full_graph);
+        REQUIRE_EQ(graph.n_edges(), n_unique_edges_in_full_graph);
         validate_full_graph_edges(graph);
     }
 
@@ -104,7 +104,7 @@ struct test_graph {
 
     template <gl::traits::c_instantiation_of<gl::graph> GraphType>
     gl::size_type n_out_edges_for_fully_connected_vertex(const GraphType& graph) {
-        return graph.order() - 1uz;
+        return graph.n_vertices() - 1uz;
     }
 
     const vertex_type out_of_range_vertex{constants::out_of_rng_idx};
@@ -129,8 +129,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("graph should be initialized with no vertices and no edges by default") {
         sut_type sut;
 
-        CHECK_EQ(sut.order(), 0uz);
-        CHECK_EQ(sut.size(), 0uz);
+        CHECK_EQ(sut.n_vertices(), 0uz);
+        CHECK_EQ(sut.n_edges(), 0uz);
     }
 
     SUBCASE("graph constructed with n_vertices parameter should contain n_vertices vertices and no "
@@ -162,11 +162,11 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         for (auto v_id = 0u; v_id < target_n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
-            CHECK_EQ(sut.order(), v_id + 1u);
+            CHECK_EQ(sut.n_vertices(), v_id + 1u);
             CHECK(sut.out_edges(v_id).empty());
         }
 
-        CHECK_EQ(sut.order(), target_n_vertices);
+        CHECK_EQ(sut.n_vertices(), target_n_vertices);
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
@@ -174,7 +174,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         gl::graph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::visited);
-        REQUIRE_EQ(sut.order(), 1uz);
+        REQUIRE_EQ(sut.n_vertices(), 1uz);
 
         CHECK_EQ(vertex.id(), constants::v1_id);
         CHECK_EQ(vertex.properties(), constants::visited);
@@ -184,8 +184,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut_type sut{};
         sut.add_vertices(constants::n_elements);
 
-        CHECK_EQ(sut.order(), constants::n_elements);
-        CHECK_EQ(sut.size(), 0uz);
+        CHECK_EQ(sut.n_vertices(), constants::n_elements);
+        CHECK_EQ(sut.n_edges(), 0uz);
     }
 
     SUBCASE("add_vertices_with should properly extend the current adjacency list with the given "
@@ -200,8 +200,8 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
         sut.add_vertices_with(properties_list);
 
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
-        CHECK_EQ(sut.size(), 0uz);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        CHECK_EQ(sut.n_edges(), 0uz);
 
         CHECK(std::ranges::equal(
             sut.vertices(),
@@ -285,7 +285,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         );
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
 
         constexpr auto expected_n_out_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(sut.vertices(), [&sut, expected_n_out_edges](const auto& vertex) {
@@ -306,7 +306,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
 
         constexpr auto expected_n_out_edges = expected_n_vertices - 1uz;
         CHECK(std::ranges::all_of(sut.vertices(), [&sut, expected_n_out_edges](const auto& vertex) {
@@ -407,7 +407,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
     SUBCASE("get_vertex should throw if the given id is invalid") {
         sut_type sut{constants::n_elements};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(static_cast<gl::default_id_type>(sut.order()))),
+            static_cast<void>(sut.get_vertex(static_cast<gl::default_id_type>(sut.n_vertices()))),
             std::out_of_range
         );
     }
@@ -444,7 +444,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             REQUIRE(new_edge.is_incident_from(constants::v1_id));
             REQUIRE(new_edge.is_incident_to(constants::v2_id));
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(out_edges_1), 1uz);
@@ -472,7 +472,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             REQUIRE(new_edge.is_incident_from(vertex_1.id()));
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(out_edges_1), 1uz);
@@ -491,12 +491,12 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         }
 
         SUBCASE("add_edges_from(ids) should throw if any id is invalid and not extend the graph") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(constants::out_of_rng_idx, vertex_id_list{}), std::out_of_range
             );
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -504,11 +504,11 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
         }
 
         SUBCASE("add_edges_from(ids) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             constexpr auto source_id = constants::v1_id;
             const std::vector<gl::default_id_type> target_id_list{
@@ -517,7 +517,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
             sut.add_edges_from(source_id, target_id_list);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements);
+            REQUIRE_EQ(sut.n_edges(), constants::n_elements);
             CHECK(std::ranges::all_of(target_id_list, [&sut, source_id](const auto vertex_id) {
                 return sut.has_edge(source_id, vertex_id);
             }));
@@ -525,13 +525,13 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
         SUBCASE("add_edges_from(vertices) should throw if any vertex is invalid and not extend the "
                 "graph") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(fixture.out_of_range_vertex, std::vector<vertex_type>{}),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
 
             CHECK_THROWS_AS(
                 sut.add_edges_from(
@@ -539,18 +539,18 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
                 ),
                 std::out_of_range
             );
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
         }
 
         SUBCASE("add_edges_from(vertices) should properly extend the graph if all ids are valid") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             const auto source = vertex_1;
             const std::vector<vertex_type> target_list{vertex_1, vertex_2, vertex_3};
 
             sut.add_edges_from(source, target_list);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements);
+            REQUIRE_EQ(sut.n_edges(), constants::n_elements);
             CHECK(std::ranges::all_of(target_list, [&sut, &source](const auto& vertex) {
                 return sut.has_edge(source, vertex);
             }));
@@ -559,7 +559,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         SUBCASE("remove_edge should properly remove the edge for both of its incident vertices") {
             const auto added_edge = sut.add_edge(vertex_1, vertex_2);
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             auto out_edges_2 = sut.out_edges(constants::v2_id);
@@ -569,7 +569,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
                 REQUIRE_EQ(gl::util::range_size(out_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
 
             out_edges_1 = sut.out_edges(constants::v1_id);
             out_edges_2 = sut.out_edges(constants::v2_id);
@@ -579,7 +579,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             const auto edge_1 = sut.add_edge(vertex_1, vertex_2);
             const auto edge_2 = sut.add_edge(vertex_2, vertex_3);
@@ -589,7 +589,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge(vertex_1, vertex_4);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements + 1uz);
+            REQUIRE_EQ(sut.n_edges(), constants::n_elements + 1uz);
 
             std::vector<edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -600,7 +600,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_edges(), 1uz);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
@@ -636,7 +636,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             REQUIRE(new_edge.is_incident_to(constants::v2_id));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(out_edges_1), 1uz);
@@ -671,7 +671,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             REQUIRE(new_edge.is_incident_to(vertex_2.id()));
             REQUIRE_EQ(new_edge.properties(), constants::used);
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             CHECK_EQ(gl::util::range_size(out_edges_1), 1uz);
@@ -692,7 +692,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         SUBCASE("remove_edge should properly remove the edge for both of its incident vertices") {
             const auto added_edge = sut.add_edge_with(vertex_1, vertex_2, constants::used);
 
-            REQUIRE_EQ(sut.size(), 1uz);
+            REQUIRE_EQ(sut.n_edges(), 1uz);
 
             auto out_edges_1 = sut.out_edges(constants::v1_id);
             auto out_edges_2 = sut.out_edges(constants::v2_id);
@@ -702,7 +702,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
                 REQUIRE_EQ(gl::util::range_size(out_edges_2), 1uz);
 
             sut.remove_edge(added_edge);
-            CHECK_EQ(sut.size(), 0uz);
+            CHECK_EQ(sut.n_edges(), 0uz);
 
             out_edges_1 = sut.out_edges(constants::v1_id);
             out_edges_2 = sut.out_edges(constants::v2_id);
@@ -712,7 +712,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         }
 
         SUBCASE("remove_edges should properly erase all given edges") {
-            REQUIRE_EQ(sut.size(), 0uz);
+            REQUIRE_EQ(sut.n_edges(), 0uz);
 
             const auto edge_1 = sut.add_edge_with(vertex_1, vertex_2, constants::not_used);
             const auto edge_2 = sut.add_edge_with(vertex_2, vertex_3, constants::not_used);
@@ -722,7 +722,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             const auto vertex_4 = sut.add_vertex();
             const auto edge_4 = sut.add_edge_with(vertex_1, vertex_4, constants::used);
 
-            REQUIRE_EQ(sut.size(), constants::n_elements + 1uz);
+            REQUIRE_EQ(sut.n_edges(), constants::n_elements + 1uz);
 
             const std::vector<property_edge_type> edges_to_remove{edge_1, edge_2, edge_3};
 
@@ -733,7 +733,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
 
             sut.remove_edges(edges_to_remove);
 
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_edges(), 1uz);
             CHECK_FALSE(sut.has_edge(vertex_1, vertex_2));
             CHECK_FALSE(sut.has_edge(vertex_2, vertex_3));
             CHECK_FALSE(sut.has_edge(vertex_3, vertex_1));
@@ -1080,7 +1080,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             CHECK_EQ(sut1, sut2);
         }
 
-        SUBCASE("graphs with different orders are not equal") {
+        SUBCASE("graphs with different numbers of vertices are not equal") {
             sut2.add_vertex();
             CHECK_NE(sut1, sut2);
         }

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -421,10 +421,6 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
             CHECK(v.is_valid());
     }
 
-    // --- degree getters ---
-
-    // TODO
-
     // --- edge modifiers ---
 
     SUBCASE("edge modifiers tests for default properties type") {

--- a/tests/source/gl/test_graph_file_io.cpp
+++ b/tests/source/gl/test_graph_file_io.cpp
@@ -69,8 +69,7 @@ TEST_CASE_TEMPLATE_DEFINE("graph file io tests", SutType, graph_file_io_template
 
     SUBCASE("load should throw if a file does not exist") {
         GL_REQUIRE_THROWS_FS_ERROR(
-            discard_result(gl::io::load<SutType>(fixture.path)),
-            std::errc::no_such_file_or_directory
+            discard(gl::io::load<SutType>(fixture.path)), std::errc::no_such_file_or_directory
         );
     }
 

--- a/tests/source/gl/test_graph_io.cpp
+++ b/tests/source/gl/test_graph_io.cpp
@@ -1,10 +1,10 @@
 #include "doctest.h"
-#include "gl/io/options.hpp"
-#include "gl/io/options_manip.hpp"
 #include "testing/gl/io.hpp"
 
 #include <gl/graph.hpp>
 #include <gl/io.hpp>
+#include <gl/io/options.hpp>
+#include <gl/io/options_manip.hpp>
 #include <gl/topology.hpp>
 
 #include <sstream>

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -85,7 +85,7 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
-        const auto next_vertex = graph.vertex(next_vertex_id);
+        const auto next_vertex = graph[next_vertex_id];
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == next_vertex) == graph.has_edge(source, vertex);
@@ -100,7 +100,7 @@ template <gl::traits::c_graph GraphType>
     return [&graph](const vertex_type& source) {
         const auto prev_vertex_id =
             static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
-        const auto prev_vertex = graph.vertex(prev_vertex_id);
+        const auto prev_vertex = graph[prev_vertex_id];
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex) == graph.has_edge(source, vertex);
@@ -114,11 +114,11 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
-        const auto next_vertex = graph.vertex(next_vertex_id);
+        const auto next_vertex = graph[next_vertex_id];
 
         const auto prev_vertex_id =
             static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
-        const auto prev_vertex = graph.vertex(prev_vertex_id);
+        const auto prev_vertex = graph[prev_vertex_id];
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex or vertex == next_vertex)
@@ -137,8 +137,8 @@ template <gl::traits::c_graph GraphType>
             // no need to check second as second = first + 1
             return gl::util::range_size(graph.out_edges(source)) == 0uz;
 
-        const auto target_1 = graph.vertex(target_ids.first);
-        const auto target_2 = graph.vertex(target_ids.second);
+        const auto target_1 = graph[target_ids.first];
+        const auto target_2 = graph[target_ids.second];
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             if (vertex == target_1 or vertex == target_2)

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -26,8 +26,8 @@ void verify_graph_size(
     const gl::size_type expected_n_vertices,
     const gl::size_type expected_n_connections
 ) {
-    REQUIRE_EQ(graph.order(), expected_n_vertices);
-    REQUIRE_EQ(graph.size(), expected_n_connections);
+    REQUIRE_EQ(graph.n_vertices(), expected_n_vertices);
+    REQUIRE_EQ(graph.n_edges(), expected_n_connections);
 }
 
 template <gl::traits::c_graph GraphType>
@@ -36,8 +36,10 @@ void verify_bidir_graph_size(
     const gl::size_type expected_n_vertices,
     const gl::size_type expected_n_connections
 ) {
-    REQUIRE_EQ(graph.order(), expected_n_vertices);
-    REQUIRE_EQ(graph.size(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections));
+    REQUIRE_EQ(graph.n_vertices(), expected_n_vertices);
+    REQUIRE_EQ(
+        graph.n_edges(), n_unique_edges_for_bidir_topology<GraphType>(expected_n_connections)
+    );
 }
 
 } // namespace
@@ -82,7 +84,7 @@ template <gl::traits::c_graph GraphType>
     using id_type = typename GraphType::id_type;
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
-        const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.order());
+        const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
         const auto next_vertex = graph.get_vertex(next_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
@@ -97,7 +99,7 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto prev_vertex_id =
-            static_cast<id_type>((source.id() + graph.order() - 1uz) % graph.order());
+            static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
         const auto prev_vertex = graph.get_vertex(prev_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
@@ -111,11 +113,11 @@ template <gl::traits::c_graph GraphType>
     using id_type = typename GraphType::id_type;
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
-        const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.order());
+        const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
         const auto next_vertex = graph.get_vertex(next_vertex_id);
 
         const auto prev_vertex_id =
-            static_cast<id_type>((source.id() + graph.order() - 1uz) % graph.order());
+            static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
         const auto prev_vertex = graph.get_vertex(prev_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
@@ -131,7 +133,7 @@ template <gl::traits::c_graph GraphType>
     return [&graph](const vertex_type& source) {
         const auto target_ids = gl::topology::detail::get_binary_target_ids(source.id());
 
-        if (target_ids.first >= graph.order())
+        if (target_ids.first >= graph.n_vertices())
             // no need to check second as second = first + 1
             return gl::util::range_size(graph.out_edges(source)) == 0uz;
 
@@ -152,7 +154,7 @@ template <gl::traits::c_graph GraphType>
         const auto target_ids = gl::topology::detail::get_binary_target_ids(source_id);
         const auto parent_id = source_id == 0u ? 0u : (source_id - 1u) / 2u;
 
-        if (target_ids.first >= graph.order()) {
+        if (target_ids.first >= graph.n_vertices()) {
             // no need to check second as second = first + 1
             auto out_edges = graph.out_edges(source_id);
 
@@ -234,14 +236,14 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("regular_binary_tree(depth) should return a regular binay tree with the given depth") {
         SUBCASE("depth = 0 : empty graph") {
             const auto complete_bin_tree = gl::topology::regular_binary_tree<graph_type>(0uz);
-            REQUIRE_EQ(complete_bin_tree.order(), 0uz);
-            REQUIRE_EQ(complete_bin_tree.size(), 0uz);
+            REQUIRE_EQ(complete_bin_tree.n_vertices(), 0uz);
+            REQUIRE_EQ(complete_bin_tree.n_edges(), 0uz);
         }
 
         SUBCASE("depth = 1 : graph with one vertex and no edges") {
             const auto complete_bin_tree = gl::topology::regular_binary_tree<graph_type>(1uz);
-            REQUIRE_EQ(complete_bin_tree.order(), 1uz);
-            REQUIRE_EQ(complete_bin_tree.size(), 0uz);
+            REQUIRE_EQ(complete_bin_tree.n_vertices(), 1uz);
+            REQUIRE_EQ(complete_bin_tree.n_edges(), 0uz);
         }
     }
 }
@@ -284,7 +286,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("path(n_vertices) should build a one-way path graph of size n_vertices") {
         const auto path = gl::topology::path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.order() - 1uz;
+        const auto n_source_vertices = path.n_vertices() - 1uz;
         const auto last_vertex_pos = gl::to_diff(n_source_vertices);
 
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
@@ -298,7 +300,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("bidirectional_path(n_vertices) should build a two-way path graph of size n_vertices") {
         const auto path = gl::topology::bidirectional_path<graph_type>(constants::n_elements_top);
-        const auto n_source_vertices = path.order() - 1uz;
+        const auto n_source_vertices = path.n_vertices() - 1uz;
         const auto last_vertex_pos = gl::to_diff(n_source_vertices);
 
         verify_graph_size(path, constants::n_elements_top, 2uz * n_source_vertices);
@@ -388,7 +390,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         CAPTURE(path);
 
-        const auto n_source_vertices = path.order() - 1uz;
+        const auto n_source_vertices = path.n_vertices() - 1uz;
         const auto last_vertex_pos = gl::to_diff(n_source_vertices);
         verify_graph_size(path, constants::n_elements_top, n_source_vertices);
 

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -85,7 +85,7 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
-        const auto next_vertex = graph.get_vertex(next_vertex_id);
+        const auto next_vertex = graph.vertex(next_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == next_vertex) == graph.has_edge(source, vertex);
@@ -100,7 +100,7 @@ template <gl::traits::c_graph GraphType>
     return [&graph](const vertex_type& source) {
         const auto prev_vertex_id =
             static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
-        const auto prev_vertex = graph.get_vertex(prev_vertex_id);
+        const auto prev_vertex = graph.vertex(prev_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex) == graph.has_edge(source, vertex);
@@ -114,11 +114,11 @@ template <gl::traits::c_graph GraphType>
     using vertex_type = typename GraphType::vertex_type;
     return [&graph](const vertex_type& source) {
         const auto next_vertex_id = static_cast<id_type>((source.id() + 1uz) % graph.n_vertices());
-        const auto next_vertex = graph.get_vertex(next_vertex_id);
+        const auto next_vertex = graph.vertex(next_vertex_id);
 
         const auto prev_vertex_id =
             static_cast<id_type>((source.id() + graph.n_vertices() - 1uz) % graph.n_vertices());
-        const auto prev_vertex = graph.get_vertex(prev_vertex_id);
+        const auto prev_vertex = graph.vertex(prev_vertex_id);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             return (vertex == prev_vertex or vertex == next_vertex)
@@ -137,8 +137,8 @@ template <gl::traits::c_graph GraphType>
             // no need to check second as second = first + 1
             return gl::util::range_size(graph.out_edges(source)) == 0uz;
 
-        const auto target_1 = graph.get_vertex(target_ids.first);
-        const auto target_2 = graph.get_vertex(target_ids.second);
+        const auto target_1 = graph.vertex(target_ids.first);
+        const auto target_2 = graph.vertex(target_ids.second);
 
         return std::ranges::all_of(graph.vertices(), [&](const auto& vertex) {
             if (vertex == target_1 or vertex == target_2)

--- a/tests/source/gl/test_graph_topology_builders.cpp
+++ b/tests/source/gl/test_graph_topology_builders.cpp
@@ -1,8 +1,7 @@
+#include "doctest.h"
 #include "testing/gl/constants.hpp"
 
 #include <gl/topology.hpp>
-
-#include <doctest.h>
 
 #include <cstddef>
 

--- a/tests/source/gl/test_properties.cpp
+++ b/tests/source/gl/test_properties.cpp
@@ -1,8 +1,7 @@
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 
 #include <gl/types/properties.hpp>
-
-#include <doctest.h>
 
 #include <algorithm>
 #include <sstream>

--- a/tests/source/gl/test_properties.cpp
+++ b/tests/source/gl/test_properties.cpp
@@ -91,12 +91,12 @@ TEST_CASE_FIXTURE(test_dynamic_properties, "is_present should return true for a 
 }
 
 TEST_CASE_FIXTURE(test_dynamic_properties, "get should throw for a not present key") {
-    CHECK_THROWS_AS(discard_result(sut.get<int>(not_present_key)), std::out_of_range);
+    CHECK_THROWS_AS(discard(sut.get<int>(not_present_key)), std::out_of_range);
 }
 
 TEST_CASE_FIXTURE(test_dynamic_properties, "get should throw for an invalid value type") {
     sut.underlying()[key] = std::any{value};
-    CHECK_THROWS_AS(discard_result(sut.get<double>(key)), std::bad_any_cast);
+    CHECK_THROWS_AS(discard(sut.get<double>(key)), std::bad_any_cast);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -46,13 +46,37 @@ TEST_CASE("properties should be properly initialized") {
     CHECK_EQ(&sut.properties(), &property);
 }
 
+TEST_CASE("operator* should return a reference to the properties") {
+    visited_property property{constants::visited};
+    const gl::vertex_descriptor<visited_property> sut{constants::v1_id, property};
+    CHECK_EQ(&(*sut), &property);
+}
+
+TEST_CASE("operator-> should return a pointer to the properties") {
+    visited_property property{constants::visited};
+    const gl::vertex_descriptor<visited_property> sut{constants::v1_id, property};
+    CHECK_EQ(sut.operator->(), &property);
+    CHECK_EQ(sut->visited, property.visited);
+}
+
 TEST_CASE("accessing properties should throw for an invalid vertex") {
     using sut_type = gl::vertex_descriptor<visited_property>;
     visited_property property{constants::visited};
 
+    // .properties()
     CHECK_THROWS_AS(discard_result(sut_type::invalid().properties()), std::logic_error);
     CHECK_THROWS_AS(
         discard_result(sut_type{gl::invalid_id, property}.properties()), std::logic_error
+    );
+
+    // operator*
+    CHECK_THROWS_AS(discard_result(*sut_type::invalid()), std::logic_error);
+    CHECK_THROWS_AS(discard_result(*sut_type{gl::invalid_id, property}), std::logic_error);
+
+    // operator->
+    CHECK_THROWS_AS(discard_result(sut_type::invalid().operator->()), std::logic_error);
+    CHECK_THROWS_AS(
+        discard_result(sut_type{gl::invalid_id, property}.operator->()), std::logic_error
     );
 }
 

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -1,10 +1,9 @@
+#include "doctest.h"
 #include "testing/common/functional.hpp"
 #include "testing/gl/constants.hpp"
 #include "testing/gl/types.hpp"
 
 #include <gl/vertex_descriptor.hpp>
-
-#include <doctest.h>
 
 namespace gl_testing {
 

--- a/tests/source/gl/test_vertex_descriptor.cpp
+++ b/tests/source/gl/test_vertex_descriptor.cpp
@@ -64,20 +64,16 @@ TEST_CASE("accessing properties should throw for an invalid vertex") {
     visited_property property{constants::visited};
 
     // .properties()
-    CHECK_THROWS_AS(discard_result(sut_type::invalid().properties()), std::logic_error);
-    CHECK_THROWS_AS(
-        discard_result(sut_type{gl::invalid_id, property}.properties()), std::logic_error
-    );
+    CHECK_THROWS_AS(discard(sut_type::invalid().properties()), std::logic_error);
+    CHECK_THROWS_AS(discard(sut_type{gl::invalid_id, property}.properties()), std::logic_error);
 
     // operator*
-    CHECK_THROWS_AS(discard_result(*sut_type::invalid()), std::logic_error);
-    CHECK_THROWS_AS(discard_result(*sut_type{gl::invalid_id, property}), std::logic_error);
+    CHECK_THROWS_AS(discard(*sut_type::invalid()), std::logic_error);
+    CHECK_THROWS_AS(discard(*sut_type{gl::invalid_id, property}), std::logic_error);
 
     // operator->
-    CHECK_THROWS_AS(discard_result(sut_type::invalid().operator->()), std::logic_error);
-    CHECK_THROWS_AS(
-        discard_result(sut_type{gl::invalid_id, property}.operator->()), std::logic_error
-    );
+    CHECK_THROWS_AS(discard(sut_type::invalid().operator->()), std::logic_error);
+    CHECK_THROWS_AS(discard(sut_type{gl::invalid_id, property}.operator->()), std::logic_error);
 }
 
 TEST_SUITE_END(); // test_vertex_descriptor

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -1,9 +1,9 @@
 #include "doctest.h"
-#include "hgl/algorithm/util.hpp"
 #include "testing/common/io.hpp"
 #include "testing/hgl/constants.hpp"
 
 #include <hgl/algorithm/traversal/breadth_first_search.hpp>
+#include <hgl/algorithm/util.hpp>
 #include <hgl/constants.hpp>
 
 #include <algorithm>

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -1,12 +1,13 @@
-#include "gl/directional_tags.hpp"
-#include "gl/graph_traits.hpp"
-#include "hgl/conversion.hpp"
-#include "hgl/hypergraph.hpp"
-#include "hgl/hypergraph_traits.hpp"
-#include "hgl/impl/layout_tags.hpp"
-#include "hgl/types.hpp"
+#include "doctest.h"
 
-#include <doctest.h>
+#include <gl/directional_tags.hpp>
+#include <gl/graph_traits.hpp>
+
+#include <hgl/conversion.hpp>
+#include <hgl/hypergraph.hpp>
+#include <hgl/hypergraph_traits.hpp>
+#include <hgl/impl/layout_tags.hpp>
+#include <hgl/types.hpp>
 
 #include <algorithm>
 #include <concepts>

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -317,8 +317,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto clique = hgl::projection<TargetGraph>(sut);
-                    CHECK_EQ(clique.order(), sut.order());
-                    CHECK_EQ(clique.size(), expected_edges.size());
+                    CHECK_EQ(clique.n_vertices(), sut.order());
+                    CHECK_EQ(clique.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(clique.has_edge(u, v));
                 }
@@ -358,8 +358,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto incidence = hgl::incidence_graph<TargetGraph>(sut);
-                    CHECK_EQ(incidence.order(), sut.order() + sut.size());
-                    CHECK_EQ(incidence.size(), expected_edges.size());
+                    CHECK_EQ(incidence.n_vertices(), sut.order() + sut.size());
+                    CHECK_EQ(incidence.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(incidence.has_edge(u, v));
                 }
@@ -445,8 +445,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto proj = hgl::projection<TargetGraph>(sut);
-                    CHECK_EQ(proj.order(), sut.order());
-                    CHECK_EQ(proj.size(), expected_edges.size());
+                    CHECK_EQ(proj.n_vertices(), sut.order());
+                    CHECK_EQ(proj.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(proj.has_edge(u, v));
                 }
@@ -488,8 +488,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto incidence = hgl::incidence_graph<TargetGraph>(sut);
-                    CHECK_EQ(incidence.order(), sut.order() + sut.size());
-                    CHECK_EQ(incidence.size(), expected_edges.size());
+                    CHECK_EQ(incidence.n_vertices(), sut.order() + sut.size());
+                    CHECK_EQ(incidence.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(incidence.has_edge(u, v));
                 }

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -1,6 +1,6 @@
+#include "doctest.h"
 #include "testing/hgl/constants.hpp"
 
-#include <doctest.h>
 #include <hgl/directional_tags.hpp>
 #include <hgl/impl/flat_incidence_list.hpp>
 #include <hgl/impl/impl_tags.hpp>

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -1,9 +1,9 @@
-#include "hgl/types.hpp"
+#include "doctest.h"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
 
-#include <doctest.h>
 #include <hgl/hypergraph_elements.hpp>
+#include <hgl/types.hpp>
 
 namespace hgl_testing {
 

--- a/tests/source/hgl/test_hypergraph_file_io.cpp
+++ b/tests/source/hgl/test_hypergraph_file_io.cpp
@@ -81,8 +81,7 @@ TEST_CASE_TEMPLATE_DEFINE("hypergraph file io tests", SutType, hypergraph_file_i
 
     SUBCASE("load should throw if a file does not exist") {
         GL_REQUIRE_THROWS_FS_ERROR(
-            discard_result(hgl::io::load<SutType>(fixture.path)),
-            std::errc::no_such_file_or_directory
+            discard(hgl::io::load<SutType>(fixture.path)), std::errc::no_such_file_or_directory
         );
     }
 

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -1,6 +1,6 @@
+#include "doctest.h"
 #include "testing/hgl/constants.hpp"
 
-#include <doctest.h>
 #include <hgl/impl/impl_tags.hpp>
 #include <hgl/impl/incidence_list.hpp>
 #include <hgl/impl/layout_tags.hpp>

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -1,10 +1,10 @@
-#include "hgl/impl/bf_incidence.hpp"
-#include "hgl/impl/layout_tags.hpp"
+#include "doctest.h"
 #include "testing/hgl/constants.hpp"
 
-#include <doctest.h>
+#include <hgl/impl/bf_incidence.hpp>
 #include <hgl/impl/impl_tags.hpp>
 #include <hgl/impl/incidence_matrix.hpp>
+#include <hgl/impl/layout_tags.hpp>
 
 #include <algorithm>
 #include <ranges>


### PR DESCRIPTION
- Added generic graph class aliases:
  - Directional: directed_graph, undirected_graph
  - Implementation: list_graph, flat_list_graph, matrix_graph, flat_matrix_graph
- Removed the generic vertex and edge aliases
- Renamed the order and size methods of the graph class to n_vertices and n_edges respectively (Least Astonishment)
- Removed the get_ prefixes from graph class getter methods
- Added new vertex_unchecked method and convenience vertex accessors: operator[id], at(id)
- Extended vertex and edge descriptor classes with operator* and operator-> property accessors
- Aligned the HGL module and the benchmarks project to use new method names