### PR TITLE
YT-CPPHGL-37: HGL module API refinement

### DIFF
--- a/include/gl/edge_descriptor.hpp
+++ b/include/gl/edge_descriptor.hpp
@@ -26,10 +26,6 @@ public:
     using id_type = IdType;
     using directional_tag = DirectionalTag;
     using properties_type = Properties;
-    using properties_ref_type = std::conditional_t<
-        traits::c_empty_properties<properties_type>,
-        empty_properties,
-        properties_type&>;
 
     friend directional_tag;
 
@@ -156,7 +152,7 @@ public:
         return this->_vertices.first == this->_vertices.second;
     }
 
-    [[nodiscard]] gl_attr_force_inline properties_ref_type properties() const
+    [[nodiscard]] gl_attr_force_inline properties_type& properties() const
     requires(traits::c_non_empty_properties<properties_type>)
     {
         this->_validate();

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -189,7 +189,7 @@ public:
     }
 
     void remove_vertices_from(const traits::c_forward_range_of<id_type> auto& vertex_id_rng) {
-        // sorts the ids in a descending order and removes duplicate ids
+        // sorts the ids in a descending n_vertices and removes duplicate ids
         std::set<id_type, std::greater<>> vertex_id_set(
             std::ranges::begin(vertex_id_rng), std::ranges::end(vertex_id_rng)
         );
@@ -201,7 +201,7 @@ public:
 
     void remove_vertices_from(const traits::c_sized_range_of<vertex_type> auto& vertex_rng) {
         // TODO: optimize
-        // sort the ids in a descending order and removes duplicate ids
+        // sort the ids in a descending n_vertices and removes duplicate ids
         std::set<vertex_type, std::greater<vertex_type>> vertex_set(
             std::ranges::begin(vertex_rng), std::ranges::end(vertex_rng)
         );

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -189,7 +189,7 @@ public:
     }
 
     void remove_vertices_from(const traits::c_forward_range_of<id_type> auto& vertex_id_rng) {
-        // sorts the ids in a descending n_vertices and removes duplicate ids
+        // sorts the ids in a descending order and removes duplicate ids
         std::set<id_type, std::greater<>> vertex_id_set(
             std::ranges::begin(vertex_id_rng), std::ranges::end(vertex_id_rng)
         );
@@ -201,7 +201,7 @@ public:
 
     void remove_vertices_from(const traits::c_sized_range_of<vertex_type> auto& vertex_rng) {
         // TODO: optimize
-        // sort the ids in a descending n_vertices and removes duplicate ids
+        // sort the ids in a descending order and removes duplicate ids
         std::set<vertex_type, std::greater<vertex_type>> vertex_set(
             std::ranges::begin(vertex_rng), std::ranges::end(vertex_rng)
         );
@@ -314,6 +314,20 @@ public:
 
     [[nodiscard]] gl_attr_force_inline auto successor_ids(vertex_type vertex) const {
         return this->successor_ids(vertex.id());
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_properties_type& vertex_properties(const id_type id
+    ) const
+    requires(traits::c_non_empty_properties<vertex_properties_type>)
+    {
+        this->_verify_vertex_id(id);
+        return *this->_vertex_properties[id];
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
+    requires(traits::c_non_empty_properties<vertex_properties_type>)
+    {
+        return util::deref_view(this->_vertex_properties);
     }
 
     // --- degree getters ---
@@ -559,6 +573,21 @@ public:
         return this->out_edges(vertex.id());
     }
 
+    [[nodiscard]] edge_properties_type& edge_properties(const id_type id) const
+    requires(traits::c_non_empty_properties<edge_properties_type>)
+    {
+        if (id >= this->_n_edges)
+            throw std::out_of_range(std::format("Got invalid edge id [{}]", id));
+
+        return *this->_edge_properties[id];
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto edge_properties_map() const noexcept
+    requires(traits::c_non_empty_properties<edge_properties_type>)
+    {
+        return util::deref_view(this->_edge_properties);
+    }
+
     // --- adjacency and incidence methods ---
 
     [[nodiscard]] gl_attr_force_inline bool are_adjacent(
@@ -593,38 +622,6 @@ public:
     [[nodiscard]] gl_attr_force_inline bool are_incident(const edge_type& edge, vertex_type vertex)
         const {
         return this->are_incident(vertex, edge);
-    }
-
-    // --- property getters ---
-    // TODO: move to vertex/edge getters
-
-    [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
-    requires(traits::c_non_empty_properties<vertex_properties_type>)
-    {
-        return util::deref_view(this->_vertex_properties);
-    }
-
-    [[nodiscard]] gl_attr_force_inline vertex_properties_type& vertex_properties(const id_type id
-    ) const
-    requires(traits::c_non_empty_properties<vertex_properties_type>)
-    {
-        this->_verify_vertex_id(id);
-        return *this->_vertex_properties[id];
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto edge_properties_map() const noexcept
-    requires(traits::c_non_empty_properties<edge_properties_type>)
-    {
-        return util::deref_view(this->_edge_properties);
-    }
-
-    [[nodiscard]] edge_properties_type& get_edge_properties(const id_type id) const
-    requires(traits::c_non_empty_properties<edge_properties_type>)
-    {
-        if (id >= this->_n_edges)
-            throw std::out_of_range(std::format("Got invalid edge id [{}]", id));
-
-        return *this->_edge_properties[id];
     }
 
     // --- comparison ---

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -596,6 +596,7 @@ public:
     }
 
     // --- property getters ---
+    // TODO: move to vertex/edge getters
 
     [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
     requires(traits::c_non_empty_properties<vertex_properties_type>)

--- a/include/gl/vertex_descriptor.hpp
+++ b/include/gl/vertex_descriptor.hpp
@@ -25,10 +25,6 @@ public:
     using type = std::type_identity_t<vertex_descriptor<Properties, IdType>>;
     using id_type = IdType;
     using properties_type = Properties;
-    using properties_ref_type = std::conditional_t<
-        traits::c_empty_properties<properties_type>,
-        empty_properties,
-        properties_type&>;
 
     vertex_descriptor() {
         *this = vertex_descriptor::invalid();
@@ -86,7 +82,7 @@ public:
         return this->_id;
     }
 
-    [[nodiscard]] gl_attr_force_inline properties_ref_type properties() const
+    [[nodiscard]] gl_attr_force_inline properties_type& properties() const
     requires(traits::c_non_empty_properties<properties_type>)
     {
         this->_validate();

--- a/include/hgl/algorithm/core.hpp
+++ b/include/hgl/algorithm/core.hpp
@@ -98,7 +98,7 @@ struct traversal_policy<H, traversal_direction::forward> {
     }
 
     static auto target_vertices(const H& h, typename H::id_type he_id) {
-        return h.head_vertex_ids(he_id);
+        return h.head_ids(he_id);
     }
 };
 
@@ -109,7 +109,7 @@ struct traversal_policy<H, traversal_direction::backward> {
     }
 
     static auto target_vertices(const H& h, typename H::id_type he_id) {
-        return h.tail_vertex_ids(he_id);
+        return h.tail_ids(he_id);
     }
 };
 

--- a/include/hgl/algorithm/traversal/backward_search.hpp
+++ b/include/hgl/algorithm/traversal/backward_search.hpp
@@ -26,7 +26,7 @@ return_type<Result, search_tree<H>> backward_bfs(
 ) {
     using id_type = typename H::id_type;
 
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
     auto tail_unvisited = hypergraph.tail_size_map() | std::ranges::to<std::vector>();
 
     auto stree = init_search_tree<Result>(hypergraph);
@@ -67,7 +67,7 @@ return_type<Result, search_tree<H>> backward_dfs(
 ) {
     using id_type = typename H::id_type;
 
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
     auto tail_unvisited = hypergraph.tail_size_map() | std::ranges::to<std::vector>();
 
     auto stree = init_search_tree<Result>(hypergraph);

--- a/include/hgl/algorithm/traversal/breadth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/breadth_first_search.hpp
@@ -21,8 +21,8 @@ return_type<Result, search_tree<H>> breadth_first_search(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
-    std::vector<bool> visited_hyperedges(hypergraph.size(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
+    std::vector<bool> visited_hyperedges(hypergraph.n_hyperedges(), false);
 
     auto stree = init_search_tree<Result>(hypergraph);
 

--- a/include/hgl/algorithm/traversal/depth_first_search.hpp
+++ b/include/hgl/algorithm/traversal/depth_first_search.hpp
@@ -21,8 +21,8 @@ return_type<Result, search_tree<H>> depth_first_search(
     const PreVisitCallback& pre_visit = {},
     const PostVisitCallback& post_visit = {}
 ) {
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
-    std::vector<bool> visited_hyperedges(hypergraph.size(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
+    std::vector<bool> visited_hyperedges(hypergraph.n_hyperedges(), false);
 
     auto stree = init_search_tree<Result>(hypergraph);
 

--- a/include/hgl/algorithm/traversal/forward_search.hpp
+++ b/include/hgl/algorithm/traversal/forward_search.hpp
@@ -26,7 +26,7 @@ return_type<Result, search_tree<H>> forward_bfs(
 ) {
     using id_type = typename H::id_type;
 
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
     auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
 
     auto stree = init_search_tree<Result>(hypergraph);
@@ -67,7 +67,7 @@ return_type<Result, search_tree<H>> forward_dfs(
 ) {
     using id_type = typename H::id_type;
 
-    std::vector<bool> visited_vertices(hypergraph.order(), false);
+    std::vector<bool> visited_vertices(hypergraph.n_vertices(), false);
     auto head_unvisited = hypergraph.head_size_map() | std::ranges::to<std::vector>();
 
     auto stree = init_search_tree<Result>(hypergraph);

--- a/include/hgl/algorithm/util.hpp
+++ b/include/hgl/algorithm/util.hpp
@@ -15,7 +15,7 @@ template <result_discriminator Result, traits::c_hypergraph H>
 ) {
     using return_t = non_void_return_type<Result, search_tree<H>>;
     if constexpr (Result == ret)
-        return return_t(hypergraph.order());
+        return return_t(hypergraph.n_vertices());
     else
         return return_t();
 }

--- a/include/hgl/conversion.hpp
+++ b/include/hgl/conversion.hpp
@@ -58,8 +58,8 @@ template <traits::c_hypergraph_impl_tag TargetImplTag, traits::c_hypergraph_impl
 struct to_impl {
     template <typename TargetHypergraph, typename SourceHypergraph>
     static void convert(TargetHypergraph& target, SourceHypergraph& source) {
-        target._impl.add_vertices(source.order());
-        target._impl.add_hyperedges(source.size());
+        target._impl.add_vertices(source.n_vertices());
+        target._impl.add_hyperedges(source.n_hyperedges());
 
         if constexpr (traits::c_undirected_hypergraph<TargetHypergraph>) {
             for (const auto eid : source.hyperedge_ids())
@@ -248,7 +248,7 @@ template <gl::traits::c_undirected_graph G>
     const auto rem = std::ranges::unique(edges);
     edges.erase(rem.begin(), rem.end());
 
-    G g{h.order()};
+    G g{h.n_vertices()};
     for (const auto& edge : edges)
         g.add_edge(edge.first, edge.second);
     return g;
@@ -278,7 +278,7 @@ template <gl::traits::c_directed_graph G>
     const auto rem = std::ranges::unique(edges);
     edges.erase(rem.begin(), rem.end());
 
-    G g{h.order()};
+    G g{h.n_vertices()};
     for (const auto& [u, v] : edges)
         g.add_edge(u, v);
 
@@ -296,9 +296,9 @@ template <gl::traits::c_undirected_graph G>
 [[nodiscard]] G incidence_graph(const traits::c_undirected_hypergraph auto& h) {
     using g_id_type = typename G::id_type;
 
-    G g{h.order() + h.size()};
+    G g{h.n_vertices() + h.n_hyperedges()};
     const auto align_edge_id =
-        [shift = static_cast<g_id_type>(h.order())](const auto eid) -> g_id_type {
+        [shift = static_cast<g_id_type>(h.n_vertices())](const auto eid) -> g_id_type {
         return eid + shift;
     };
 
@@ -323,9 +323,9 @@ template <gl::traits::c_directed_graph G>
 [[nodiscard]] G incidence_graph(const traits::c_bf_directed_hypergraph auto& h) {
     using g_id_type = typename G::id_type;
 
-    G g{h.order() + h.size()};
+    G g{h.n_vertices() + h.n_hyperedges()};
     const auto align_edge_id =
-        [shift = static_cast<g_id_type>(h.order())](const auto eid) -> g_id_type {
+        [shift = static_cast<g_id_type>(h.n_vertices())](const auto eid) -> g_id_type {
         return eid + shift;
     };
 

--- a/include/hgl/conversion.hpp
+++ b/include/hgl/conversion.hpp
@@ -68,9 +68,9 @@ struct to_impl {
         }
         else {
             for (const auto eid : source.hyperedge_ids()) {
-                for (const auto vid : source.tail_vertex_ids(eid))
+                for (const auto vid : source.tail_ids(eid))
                     target._impl.bind_tail(vid, eid);
-                for (const auto vid : source.head_vertex_ids(eid))
+                for (const auto vid : source.head_ids(eid))
                     target._impl.bind_head(vid, eid);
             }
         }
@@ -267,8 +267,8 @@ template <gl::traits::c_directed_graph G>
     std::vector<edge_vertices> edges;
 
     for (const auto eid : h.hyperedge_ids()) {
-        auto sources = h.tail_vertex_ids(eid);
-        const auto targets = h.head_vertex_ids(eid) | std::ranges::to<std::vector>();
+        auto sources = h.tail_ids(eid);
+        const auto targets = h.head_ids(eid) | std::ranges::to<std::vector>();
         for (const auto u : sources)
             for (const auto v : targets)
                 edges.emplace_back(u, v);
@@ -336,7 +336,7 @@ template <gl::traits::c_directed_graph G>
         g.add_edges_from(vid, targets);
     }
     for (const auto eid : h.hyperedge_ids()) {
-        const auto targets = h.head_vertex_ids(eid) | std::ranges::to<std::vector<g_id_type>>();
+        const auto targets = h.head_ids(eid) | std::ranges::to<std::vector<g_id_type>>();
         g.add_edges_from(align_edge_id(eid), targets);
     }
 

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -1567,6 +1567,64 @@ template <traits::c_hypergraph Hypergraph>
     return Hypergraph(source);
 }
 
+template <
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<>>
+using undirected_hypergraph =
+    hypergraph<undirected_hypergraph_traits<VertexProperties, HyperedgeProperties, ImplTag>>;
+
+template <
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_hypergraph_impl_tag ImplTag = impl::list_t<>>
+using bf_directed_hypergraph =
+    hypergraph<bf_directed_hypergraph_traits<VertexProperties, HyperedgeProperties, ImplTag>>;
+
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
+    traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using list_hypergraph = hypergraph<
+    list_hypergraph_traits<LayoutTag, DirectionalTag, VertexProperties, HyperedgeProperties, IdType>>;
+
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
+    traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using flat_list_hypergraph = hypergraph<flat_list_hypergraph_traits<
+    LayoutTag,
+    DirectionalTag,
+    VertexProperties,
+    HyperedgeProperties,
+    IdType>>;
+
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
+    traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using matrix_hypergraph = hypergraph<
+    matrix_hypergraph_traits<LayoutTag, DirectionalTag, VertexProperties, HyperedgeProperties, IdType>>;
+
+template <
+    traits::c_hypergraph_layout_tag LayoutTag = impl::bidirectional_t,
+    traits::c_hypergraph_directional_tag DirectionalTag = undirected_t,
+    traits::c_properties VertexProperties = empty_properties,
+    traits::c_properties HyperedgeProperties = empty_properties,
+    traits::c_id_type IdType = default_id_type>
+using flat_matrix_hypergraph = hypergraph<flat_matrix_hypergraph_traits<
+    LayoutTag,
+    DirectionalTag,
+    VertexProperties,
+    HyperedgeProperties,
+    IdType>>;
+
 // --- degree bounds ---
 
 [[nodiscard]] size_type max_degree(const traits::c_hypergraph auto& hypergraph) noexcept {

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -123,7 +123,7 @@ public:
 
     ~hypergraph() = default;
 
-    // --- general methods ---
+    // --- size methods ---
 
     [[nodiscard]] gl_attr_force_inline size_type n_vertices() const noexcept {
         return this->_n_vertices;
@@ -133,31 +133,7 @@ public:
         return this->_n_hyperedges;
     }
 
-    // --- vertex methods ---
-
-    [[nodiscard]] gl_attr_force_inline auto vertices() const noexcept {
-        return this->vertex_ids() | std::views::transform(this->_create_vertex_descriptor());
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto vertex_ids() const noexcept {
-        return std::views::iota(initial_id_v<id_type>, this->_n_vertices);
-    }
-
-    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
-        this->_verify_vertex_id(vertex_id);
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
-        else
-            return vertex_type{vertex_id};
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
-        return vertex_id < this->_n_vertices;
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_vertex(const vertex_type& vertex) const {
-        return this->has_vertex(vertex.id());
-    }
+    // --- vertex modifiers ---
 
     vertex_type add_vertex() {
         this->_impl.add_vertices(1uz);
@@ -243,6 +219,32 @@ public:
         // TODO: optimize
         for (const auto& vertex : vertex_set)
             this->_remove_vertex_impl(vertex.id());
+    }
+
+    // --- vertex getters ---
+
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const id_type vertex_id) const {
+        return vertex_id < this->_n_vertices;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool has_vertex(const vertex_type& vertex) const {
+        return this->has_vertex(vertex.id());
+    }
+
+    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
+        this->_verify_vertex_id(vertex_id);
+        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
+            return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
+        else
+            return vertex_type{vertex_id};
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto vertices() const noexcept {
+        return this->vertex_ids() | std::views::transform(this->_create_vertex_descriptor());
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto vertex_ids() const noexcept {
+        return std::views::iota(initial_id_v<id_type>, this->_n_vertices);
     }
 
     [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
@@ -547,7 +549,7 @@ public:
         return *this->_hyperedge_properties[id];
     }
 
-    // --- incidence methods ---
+    // --- incidence modifiers ---
 
     void bind(const id_type vertex_id, const id_type hyperedge_id)
     requires std::same_as<directional_tag, undirected_t>
@@ -823,6 +825,8 @@ public:
         this->unbind(vertex.id(), hyperedge.id());
     }
 
+    // --- incidence validators ---
+
     [[nodiscard]] bool are_incident(const id_type vertex_id, const id_type hyperedge_id) const {
         this->_verify_vertex_id(vertex_id);
         this->_verify_hyperedge_id(hyperedge_id);
@@ -866,6 +870,8 @@ public:
     {
         return this->is_head(vertex.id(), hyperedge.id());
     }
+
+    // --- incidence getters ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id) {
         return this->incident_hyperedge_ids(vertex_id)
@@ -1266,6 +1272,20 @@ private:
             this->_vertex_properties.erase(this->_vertex_properties.begin() + vertex_id);
     }
 
+    gl_attr_force_inline auto _create_vertex_descriptor() const noexcept
+    requires(traits::c_empty_properties<vertex_properties_type>)
+    {
+        return [](const id_type id) { return vertex_type{id}; };
+    }
+
+    gl_attr_force_inline auto _create_vertex_descriptor() const noexcept
+    requires(traits::c_non_empty_properties<vertex_properties_type>)
+    {
+        return [&pmap = this->_vertex_properties](const id_type id) {
+            return vertex_type{id, *pmap[to_idx(id)]};
+        };
+    }
+
     // --- hyperedge methods ---
 
     gl_attr_force_inline void _verify_hyperedge_id(const id_type hyperedge_id) const {
@@ -1281,22 +1301,6 @@ private:
         this->_n_hyperedges--;
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
             this->_hyperedge_properties.erase(this->_hyperedge_properties.begin() + hyperedge_id);
-    }
-
-    // --- transformations ---
-
-    gl_attr_force_inline auto _create_vertex_descriptor() const noexcept
-    requires(traits::c_empty_properties<vertex_properties_type>)
-    {
-        return [](const id_type id) { return vertex_type{id}; };
-    }
-
-    gl_attr_force_inline auto _create_vertex_descriptor() const noexcept
-    requires(traits::c_non_empty_properties<vertex_properties_type>)
-    {
-        return [&pmap = this->_vertex_properties](const id_type id) {
-            return vertex_type{id, *pmap[to_idx(id)]};
-        };
     }
 
     gl_attr_force_inline auto _create_hyperedge_descriptor() const noexcept

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -260,12 +260,6 @@ public:
         return std::views::iota(initial_id_v<id_type>, this->_n_vertices);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
-    requires(traits::c_non_empty_properties<vertex_properties_type>)
-    {
-        return util::deref_view(this->_vertex_properties);
-    }
-
     [[nodiscard]] gl_attr_force_inline vertex_properties_type& vertex_properties(
         const id_type vertex_id
     ) const
@@ -273,6 +267,12 @@ public:
     {
         this->_verify_vertex_id(vertex_id);
         return *this->_vertex_properties[vertex_id];
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
+    requires(traits::c_non_empty_properties<vertex_properties_type>)
+    {
+        return util::deref_view(this->_vertex_properties);
     }
 
     // --- hyperedge modifiers ---
@@ -562,12 +562,6 @@ public:
         return std::views::iota(initial_id_v<id_type>, this->_n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto hyperedge_properties_map() const noexcept
-    requires(traits::c_non_empty_properties<hyperedge_properties_type>)
-    {
-        return util::deref_view(this->_hyperedge_properties);
-    }
-
     [[nodiscard]] gl_attr_force_inline hyperedge_properties_type& hyperedge_properties(
         const id_type id
     ) const
@@ -575,6 +569,12 @@ public:
     {
         this->_verify_hyperedge_id(id);
         return *this->_hyperedge_properties[id];
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto hyperedge_properties_map() const noexcept
+    requires(traits::c_non_empty_properties<hyperedge_properties_type>)
+    {
+        return util::deref_view(this->_hyperedge_properties);
     }
 
     // --- incidence modifiers ---

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -233,6 +233,10 @@ public:
 
     [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
+        return this->vertex_unchecked(vertex_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_type vertex_unchecked(const id_type vertex_id) const {
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
         else
@@ -262,31 +266,7 @@ public:
         return *this->_vertex_properties[vertex_id];
     }
 
-    // --- hyperedge methods ---
-
-    [[nodiscard]] gl_attr_force_inline auto hyperedges() const noexcept {
-        return this->hyperedge_ids() | std::views::transform(this->_create_hyperedge_descriptor());
-    }
-
-    [[nodiscard]] gl_attr_force_inline auto hyperedge_ids() const noexcept {
-        return std::views::iota(initial_id_v<id_type>, this->_n_hyperedges);
-    }
-
-    [[nodiscard]] hyperedge_type hyperedge(const id_type hyperedge_id) const {
-        this->_verify_hyperedge_id(hyperedge_id);
-        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
-            return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
-        else
-            return hyperedge_type{hyperedge_id};
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const id_type hyperedge_id) const {
-        return hyperedge_id < this->_n_hyperedges;
-    }
-
-    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const hyperedge_type& hyperedge) const {
-        return this->has_hyperedge(hyperedge.id());
-    }
+    // --- hyperedge modifiers ---
 
     hyperedge_type add_hyperedge() {
         this->_impl.add_hyperedges(1uz);
@@ -532,6 +512,37 @@ public:
         // TODO: optimize
         for (const auto& hyperedge : hyperedge_set)
             this->_remove_hyperedge_impl(hyperedge.id());
+    }
+
+    // --- hyperedge getters ---
+
+    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const id_type hyperedge_id) const {
+        return hyperedge_id < this->_n_hyperedges;
+    }
+
+    [[nodiscard]] gl_attr_force_inline bool has_hyperedge(const hyperedge_type& hyperedge) const {
+        return this->has_hyperedge(hyperedge.id());
+    }
+
+    [[nodiscard]] hyperedge_type hyperedge(const id_type hyperedge_id) const {
+        this->_verify_hyperedge_id(hyperedge_id);
+        return this->hyperedge_unchecked(hyperedge_id);
+    }
+
+    [[nodiscard]] gl_attr_force_inline hyperedge_type hyperedge_unchecked(const id_type hyperedge_id
+    ) const {
+        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
+            return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
+        else
+            return hyperedge_type{hyperedge_id};
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto hyperedges() const noexcept {
+        return this->hyperedge_ids() | std::views::transform(this->_create_hyperedge_descriptor());
+    }
+
+    [[nodiscard]] gl_attr_force_inline auto hyperedge_ids() const noexcept {
+        return std::views::iota(initial_id_v<id_type>, this->_n_hyperedges);
     }
 
     [[nodiscard]] gl_attr_force_inline auto hyperedge_properties_map() const noexcept

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -236,11 +236,20 @@ public:
         return this->vertex_unchecked(vertex_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline vertex_type at(vertex_t, const id_type vertex_id) const {
+        return this->vertex(vertex_id);
+    }
+
     [[nodiscard]] gl_attr_force_inline vertex_type vertex_unchecked(const id_type vertex_id) const {
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
         else
             return vertex_type{vertex_id};
+    }
+
+    [[nodiscard]] gl_attr_force_inline vertex_type
+    operator[](vertex_t, const id_type vertex_id) const {
+        return this->vertex_unchecked(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto vertices() const noexcept {
@@ -527,12 +536,22 @@ public:
         return this->hyperedge_unchecked(hyperedge_id);
     }
 
+    [[nodiscard]] gl_attr_force_inline hyperedge_type
+    at(hyperedge_t, const id_type hyperedge_id) const {
+        return this->hyperedge(hyperedge_id);
+    }
+
     [[nodiscard]] gl_attr_force_inline hyperedge_type hyperedge_unchecked(const id_type hyperedge_id
     ) const {
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
             return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
         else
             return hyperedge_type{hyperedge_id};
+    }
+
+    [[nodiscard]] gl_attr_force_inline hyperedge_type
+    operator[](hyperedge_t, const id_type hyperedge_id) const {
+        return this->hyperedge_unchecked(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto hyperedges() const noexcept {

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -125,11 +125,11 @@ public:
 
     // --- general methods ---
 
-    [[nodiscard]] gl_attr_force_inline size_type order() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type n_vertices() const noexcept {
         return this->_n_vertices;
     }
 
-    [[nodiscard]] gl_attr_force_inline size_type size() const noexcept {
+    [[nodiscard]] gl_attr_force_inline size_type n_hyperedges() const noexcept {
         return this->_n_hyperedges;
     }
 
@@ -224,7 +224,7 @@ public:
     }
 
     void remove_vertices_from(const traits::c_forward_range_of<id_type> auto& vertex_id_rng) {
-        // sorts ids in a descending order and removes duplicate ids
+        // sorts ids in a descending n_vertices and removes duplicate ids
         std::set<id_type, std::greater<id_type>> vertex_id_set(
             std::ranges::begin(vertex_id_rng), std::ranges::end(vertex_id_rng)
         );
@@ -235,7 +235,7 @@ public:
     }
 
     void remove_vertices_from(const traits::c_sized_range_of<vertex_type> auto& vertex_rng) {
-        // sort vertices in a descending order (by id) and removes duplicate ids
+        // sort vertices in a descending n_vertices (by id) and removes duplicate ids
         std::set<vertex_type, std::greater<vertex_type>> vertex_set(
             std::ranges::begin(vertex_rng), std::ranges::end(vertex_rng)
         );
@@ -510,7 +510,7 @@ public:
     }
 
     void remove_hyperedges_from(const traits::c_forward_range_of<id_type> auto& hyperedge_id_rng) {
-        // sorts ids in a descending order and removes duplicate ids
+        // sorts ids in a descending n_vertices and removes duplicate ids
         std::set<id_type, std::greater<id_type>> hyperedge_id_set(
             std::ranges::begin(hyperedge_id_rng), std::ranges::end(hyperedge_id_rng)
         );
@@ -522,7 +522,7 @@ public:
 
     void remove_hyperedges_from(const traits::c_sized_range_of<hyperedge_type> auto& hyperedge_rng
     ) {
-        // sort hyperedges in a descending order (by id) and removes duplicate ids
+        // sort hyperedges in a descending n_vertices (by id) and removes duplicate ids
         std::set<hyperedge_type, std::greater<hyperedge_type>> hyperedge_set(
             std::ranges::begin(hyperedge_rng), std::ranges::end(hyperedge_rng)
         );
@@ -1319,8 +1319,8 @@ private:
         using enum io::detail::option_bit;
         using fmt_traits = io::detail::hypergraph_fmt_traits<directional_tag>;
 
-        os << "type: " << fmt_traits::type << ", |V| = " << this->order()
-           << ", |E| = " << this->size() << '\n';
+        os << "type: " << fmt_traits::type << ", |V| = " << this->_n_vertices
+           << ", |E| = " << this->_n_hyperedges << '\n';
 
         os << "vertices: ";
         if constexpr (traits::c_writable<vertex_properties_type>) {
@@ -1330,14 +1330,14 @@ private:
                     os << "  - " << vertex << '\n';
             }
             else {
-                os << io::implicit_range(this->order()) << '\n';
+                os << io::implicit_range(this->_n_vertices) << '\n';
             }
         }
         else {
-            os << io::implicit_range(this->order()) << '\n';
+            os << io::implicit_range(this->_n_vertices) << '\n';
         }
 
-        if (this->size() == 0uz) {
+        if (this->_n_hyperedges == 0uz) {
             os << "hyperedges: {}";
         }
         else {
@@ -1357,13 +1357,13 @@ private:
             if (io::is_option_set(os, with_vertex_properties))
                 os << io::multiline_set_formatter(this->vertices()) << '\n';
             else
-                os << io::implicit_range(this->order()) << '\n';
+                os << io::implicit_range(this->_n_vertices) << '\n';
         }
         else {
-            os << io::implicit_range(this->order()) << '\n';
+            os << io::implicit_range(this->_n_vertices) << '\n';
         }
 
-        if (this->size() == 0uz) {
+        if (this->_n_hyperedges == 0uz) {
             os << "E = {}\n";
         }
         else {
@@ -1385,8 +1385,9 @@ private:
         const bool with_he_props = io::is_option_set(os, with_connection_properties);
 
         // print hypergraph metadata
-        os << fmt_traits::discriminator << ' ' << this->order() << ' ' << this->size() << ' '
-           << static_cast<int>(with_v_props) << ' ' << static_cast<int>(with_he_props) << '\n';
+        os << fmt_traits::discriminator << ' ' << this->_n_vertices << ' ' << this->_n_hyperedges
+           << ' ' << static_cast<int>(with_v_props) << ' ' << static_cast<int>(with_he_props)
+           << '\n';
 
         if constexpr (traits::c_writable<vertex_properties_type>)
             if (with_v_props)

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -391,13 +391,11 @@ public:
         );
     }
 
-    gl_attr_force_inline hyperedge_type add_hyperedge(
-        std::initializer_list<vertex_type> tail_vertices,
-        std::initializer_list<vertex_type> head_vertices
-    )
+    gl_attr_force_inline hyperedge_type
+    add_hyperedge(std::initializer_list<vertex_type> tail, std::initializer_list<vertex_type> head)
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->add_hyperedge(std::views::all(tail_vertices), std::views::all(head_vertices));
+        return this->add_hyperedge(std::views::all(tail), std::views::all(head));
     }
 
     hyperedge_type add_hyperedge_with(
@@ -440,14 +438,14 @@ public:
     }
 
     gl_attr_force_inline hyperedge_type add_hyperedge_with(
-        std::initializer_list<vertex_type> tail_vertices,
-        std::initializer_list<vertex_type> head_vertices,
+        std::initializer_list<vertex_type> tail,
+        std::initializer_list<vertex_type> head,
         hyperedge_properties_type properties
     )
     requires(std::same_as<directional_tag, bf_directed_t> and traits::c_non_empty_properties<hyperedge_properties_type>)
     {
         return this->add_hyperedge_with(
-            std::views::all(tail_vertices), std::views::all(head_vertices), std::move(properties)
+            std::views::all(tail), std::views::all(head), std::move(properties)
         );
     }
 
@@ -1040,30 +1038,30 @@ public:
         return this->_impl.hyperedge_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id) const
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->tail_vertex_ids(hyperedge_id)
+        return this->tail_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const hyperedge_type& hyperedge) const
+    [[nodiscard]] gl_attr_force_inline auto tail(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->tail_vertices(hyperedge.id());
+        return this->tail(hyperedge.id());
     }
 
-    [[nodiscard]] auto tail_vertex_ids(const id_type hyperedge_id) const
+    [[nodiscard]] auto tail_ids(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
-        return this->_impl.tail_vertices(hyperedge_id);
+        return this->_impl.tail(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertex_ids(const hyperedge_type& hyperedge) const
+    [[nodiscard]] gl_attr_force_inline auto tail_ids(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->tail_vertex_ids(hyperedge.id());
+        return this->tail_ids(hyperedge.id());
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const
@@ -1085,30 +1083,30 @@ public:
         return this->_impl.tail_size_map(this->_n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id) const
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->head_vertex_ids(hyperedge_id)
+        return this->head_ids(hyperedge_id)
              | std::views::transform(this->_create_vertex_descriptor());
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const hyperedge_type& hyperedge) const
+    [[nodiscard]] gl_attr_force_inline auto head(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->head_vertices(hyperedge.id());
+        return this->head(hyperedge.id());
     }
 
-    [[nodiscard]] auto head_vertex_ids(const id_type hyperedge_id) const
+    [[nodiscard]] auto head_ids(const id_type hyperedge_id) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
         this->_verify_hyperedge_id(hyperedge_id);
-        return this->_impl.head_vertices(hyperedge_id);
+        return this->_impl.head(hyperedge_id);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertex_ids(const hyperedge_type& hyperedge) const
+    [[nodiscard]] gl_attr_force_inline auto head_ids(const hyperedge_type& hyperedge) const
     requires std::same_as<directional_tag, bf_directed_t>
     {
-        return this->head_vertex_ids(hyperedge.id());
+        return this->head_ids(hyperedge.id());
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const
@@ -1189,19 +1187,17 @@ public:
             using io::detail::option_bit;
 
             if (io::is_option_set(os, option_bit::verbose)) {
-                os << "[id: " << proxy.hyperedge.id() << " | tail: "
-                   << io::set_formatter(proxy.hg.tail_vertex_ids(proxy.hyperedge.id()))
-                   << ", head: "
-                   << io::set_formatter(proxy.hg.head_vertex_ids(proxy.hyperedge.id()));
+                os << "[id: " << proxy.hyperedge.id()
+                   << " | tail: " << io::set_formatter(proxy.hg.tail_ids(proxy.hyperedge.id()))
+                   << ", head: " << io::set_formatter(proxy.hg.head_ids(proxy.hyperedge.id()));
                 if constexpr (traits::c_writable<hyperedge_properties_type>)
                     if (io::is_option_set(os, option_bit::with_connection_properties))
                         os << " | " << proxy.hyperedge.properties();
                 os << "]";
             }
             else { // concise
-                os << '(' << io::set_formatter(proxy.hg.tail_vertex_ids(proxy.hyperedge.id()))
-                   << " -> " << io::set_formatter(proxy.hg.head_vertex_ids(proxy.hyperedge.id()))
-                   << ')';
+                os << '(' << io::set_formatter(proxy.hg.tail_ids(proxy.hyperedge.id())) << " -> "
+                   << io::set_formatter(proxy.hg.head_ids(proxy.hyperedge.id())) << ')';
                 if constexpr (traits::c_writable<hyperedge_properties_type>)
                     if (io::is_option_set(os, option_bit::with_connection_properties))
                         os << '[' << proxy.hyperedge.properties() << ']';
@@ -1419,9 +1415,9 @@ private:
             }
             else if constexpr (std::same_as<directional_tag, bf_directed_t>) {
                 os << this->tail_size(he_id) << ' ' << this->head_size(he_id);
-                for (const auto v : this->tail_vertex_ids(he_id))
+                for (const auto v : this->tail_ids(he_id))
                     os << ' ' << v;
-                for (const auto v : this->head_vertex_ids(he_id))
+                for (const auto v : this->head_ids(he_id))
                     os << ' ' << v;
             }
 

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -143,7 +143,7 @@ public:
         return std::views::iota(initial_id_v<id_type>, this->_n_vertices);
     }
 
-    [[nodiscard]] vertex_type get_vertex(const id_type vertex_id) const {
+    [[nodiscard]] vertex_type vertex(const id_type vertex_id) const {
         this->_verify_vertex_id(vertex_id);
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
             return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
@@ -251,7 +251,7 @@ public:
         return util::deref_view(this->_vertex_properties);
     }
 
-    [[nodiscard]] gl_attr_force_inline vertex_properties_type& get_vertex_properties(
+    [[nodiscard]] gl_attr_force_inline vertex_properties_type& vertex_properties(
         const id_type vertex_id
     ) const
     requires(traits::c_non_empty_properties<vertex_properties_type>)
@@ -270,7 +270,7 @@ public:
         return std::views::iota(initial_id_v<id_type>, this->_n_hyperedges);
     }
 
-    [[nodiscard]] hyperedge_type get_hyperedge(const id_type hyperedge_id) const {
+    [[nodiscard]] hyperedge_type hyperedge(const id_type hyperedge_id) const {
         this->_verify_hyperedge_id(hyperedge_id);
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
             return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
@@ -538,7 +538,7 @@ public:
         return util::deref_view(this->_hyperedge_properties);
     }
 
-    [[nodiscard]] gl_attr_force_inline hyperedge_properties_type& get_hyperedge_properties(
+    [[nodiscard]] gl_attr_force_inline hyperedge_properties_type& hyperedge_properties(
         const id_type id
     ) const
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -27,10 +27,6 @@ public:
     using type = hyperedge_descriptor<Properties>;
     using id_type = IdType;
     using properties_type = Properties;
-    using properties_ref_type = std::conditional_t<
-        traits::c_empty_properties<properties_type>,
-        empty_properties,
-        properties_type&>;
 
     hyperedge_descriptor() {
         *this = hyperedge_descriptor::invalid();
@@ -87,10 +83,24 @@ public:
         return this->_id;
     }
 
-    [[nodiscard]] properties_ref_type properties() const {
-        if (not this->is_valid())
-            throw std::logic_error("Cannot access properties of an invalid hyperedge");
+    [[nodiscard]] gl_attr_force_inline properties_type& properties() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return this->_properties.get();
+    }
 
+    [[nodiscard]] gl_attr_force_inline properties_type* operator->() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
+        return &this->_properties.get();
+    }
+
+    [[nodiscard]] gl_attr_force_inline properties_type& operator*() const
+    requires(traits::c_non_empty_properties<properties_type>)
+    {
+        this->_validate();
         return this->_properties.get();
     }
 
@@ -104,6 +114,15 @@ public:
     }
 
 private:
+    [[noreturn]] void _throw_invalid_access() const {
+        throw std::logic_error("Cannot access properties of an invalid hyperedge");
+    }
+
+    gl_attr_force_inline void _validate() const {
+        if (not this->is_valid())
+            this->_throw_invalid_access();
+    }
+
     std::ostream& _verbose_write(std::ostream& os) const {
         using enum io::detail::option_bit;
 

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "gl/traits.hpp"
 #include "gl/types/core.hpp"
 #include "gl/vertex_descriptor.hpp"
 #include "hgl/constants.hpp"
@@ -13,11 +14,9 @@
 
 namespace hgl {
 
-// hypergraph vertex descriptor
+// --- hypergraph elements ---
 
 using gl::vertex_descriptor;
-
-// hyperedge descriptor
 
 template <
     traits::c_properties Properties = empty_properties,
@@ -153,4 +152,19 @@ private:
         std::reference_wrapper<properties_type>> _properties;
 };
 
+// --- hypergraph element tags ---
+
+struct vertex_t {};
+
+struct hyperedge_t {};
+
+inline constexpr vertex_t vertex{};
+inline constexpr hyperedge_t hyperedge{};
+
+namespace traits {
+
+template <typename T>
+concept c_hypergraph_element_tag = c_one_of<T, vertex_t, hyperedge_t>;
+
+} // namespace traits
 } // namespace hgl

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -121,51 +121,51 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<element_type::vertex>(vertex_id);
+        return this->_incident_with<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id);
+        return this->_size<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices);
+        return this->_size_map<vertex_t>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id);
+        return this->_size<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
         const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<hyperedge_t>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -217,23 +217,23 @@ private:
     using storage_segment_type = typename storage_type::segment_type;
     using storage_const_segment_type = typename storage_type::const_segment_type;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // add major
             this->_storage.resize(this->_storage.size() + n);
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // remove major
             this->_storage.erase(to_idx(id));
         else // remove minor
             detail::remove_minor(this->_storage, id);
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // incident with major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // incident with major
             return this->_storage[to_idx(id)];
         }
         else { // incident with minor
@@ -244,9 +244,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             return this->_storage[to_idx(id)].size();
         }
         else { // size minor
@@ -258,9 +258,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
 
             const size_type n_segments = this->_storage.size();
@@ -307,118 +307,102 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id);
+        return this->_get<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id);
+        return this->_size<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices);
+        return this->_size_map<vertex_t>(n_vertices);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id, &flat_incidence_list::_tail_storage);
+        return this->_get<vertex_t>(vertex_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id, &flat_incidence_list::_tail_storage);
+        return this->_size<vertex_t>(vertex_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(
-            n_vertices, &flat_incidence_list::_tail_storage
-        );
+        return this->_size_map<vertex_t>(n_vertices, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id, &flat_incidence_list::_head_storage);
+        return this->_get<vertex_t>(vertex_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id, &flat_incidence_list::_head_storage);
+        return this->_size<vertex_t>(vertex_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(
-            n_vertices, &flat_incidence_list::_head_storage
-        );
+        return this->_size_map<vertex_t>(n_vertices, &flat_incidence_list::_head_storage);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<element_type::hyperedge>(hyperedge_id);
+        return this->_get<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id);
+        return this->_size<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<hyperedge_t>(n_hyperedges);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
-        return this->_get<element_type::hyperedge>(
-            hyperedge_id, &flat_incidence_list::_tail_storage
-        );
+        return this->_get<hyperedge_t>(hyperedge_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(
-            hyperedge_id, &flat_incidence_list::_tail_storage
-        );
+        return this->_size<hyperedge_t>(hyperedge_id, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(
-            n_hyperedges, &flat_incidence_list::_tail_storage
-        );
+        return this->_size_map<hyperedge_t>(n_hyperedges, &flat_incidence_list::_tail_storage);
     }
 
     [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
-        return this->_get<element_type::hyperedge>(
-            hyperedge_id, &flat_incidence_list::_head_storage
-        );
+        return this->_get<hyperedge_t>(hyperedge_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(
-            hyperedge_id, &flat_incidence_list::_head_storage
-        );
+        return this->_size<hyperedge_t>(hyperedge_id, &flat_incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(
-            n_hyperedges, &flat_incidence_list::_head_storage
-        );
+        return this->_size_map<hyperedge_t>(n_hyperedges, &flat_incidence_list::_head_storage);
     }
 
     // --- binding methods ---
@@ -499,17 +483,17 @@ private:
             return (this->*storage_proj)[idx];
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) {
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) {
             this->_tail_storage.resize(this->_tail_storage.size() + n);
             this->_head_storage.resize(this->_head_storage.size() + n);
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) {
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) {
             const auto idx = to_idx(id);
             this->_tail_storage.erase(idx);
             this->_head_storage.erase(idx);
@@ -532,9 +516,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // get major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // get major
             const auto idx = to_idx(id);
             return util::concat(this->_tail_storage[idx], this->_head_storage[idx]);
         }
@@ -547,10 +531,10 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const auto&& storage_proj)
         const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // get major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // get major
             return (this->*storage_proj)[to_idx(id)];
         }
         else { // get minor
@@ -562,9 +546,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             const auto idx = to_idx(id);
             return this->_tail_storage[idx].size() + this->_head_storage[idx].size();
         }
@@ -580,10 +564,10 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const auto&& storage_proj) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             return (this->*storage_proj)[to_idx(id)].size();
         }
         else { // size minor
@@ -595,9 +579,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
 
             const auto n_segments = this->_tail_storage.size();
@@ -619,12 +603,12 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _size_map(
         const size_type n_elements, const auto&& storage_proj
     ) const noexcept {
         const auto& storage = this->*storage_proj;
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
 
             const auto n_segments = storage.size();

--- a/include/hgl/impl/flat_incidence_list.hpp
+++ b/include/hgl/impl/flat_incidence_list.hpp
@@ -383,8 +383,7 @@ public:
         return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
         return this->_get<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_tail_storage
         );
@@ -403,8 +402,7 @@ public:
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
         return this->_get<element_type::hyperedge>(
             hyperedge_id, &flat_incidence_list::_head_storage
         );
@@ -766,10 +764,10 @@ public:
         return this->_e_list.hyperedge_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
-        return this->_e_list.tail_vertices(hyperedge_id);
+        return this->_e_list.tail(hyperedge_id);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept
@@ -784,10 +782,10 @@ public:
         return this->_e_list.tail_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
-        return this->_e_list.head_vertices(hyperedge_id);
+        return this->_e_list.head(hyperedge_id);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept

--- a/include/hgl/impl/flat_incidence_matrix.hpp
+++ b/include/hgl/impl/flat_incidence_matrix.hpp
@@ -320,8 +320,7 @@ public:
         return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_incident);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
         return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_tail);
     }
 
@@ -334,8 +333,7 @@ public:
         return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
         return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_head);
     }
 

--- a/include/hgl/impl/flat_incidence_matrix.hpp
+++ b/include/hgl/impl/flat_incidence_matrix.hpp
@@ -68,48 +68,48 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<element_type::vertex>(vertex_id);
+        return this->_incident_with<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id);
+        return this->_count<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices);
+        return this->_count_map<vertex_t>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id);
+        return this->_count<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges);
+        return this->_count_map<hyperedge_t>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -151,25 +151,25 @@ private:
     // using matrix_row_type = std::vector<bool>;
     using hypergraph_storage_type = flat_matrix<bool>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // add major
             this->_matrix.resize(this->_matrix.n_rows() + n, this->_matrix.n_cols(), false);
         else // add minor
             this->_matrix.resize(this->_matrix.n_rows(), this->_matrix.n_cols() + n, false);
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // remove major
             this->_matrix.erase_row(to_idx(id));
         else // remove minor
             this->_matrix.erase_col(to_idx(id));
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // incident with major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // incident with major
             return std::views::iota(initial_id_v<id_type>, this->_matrix.n_cols())
                  | std::views::filter([row = this->_matrix[to_idx(id)]](const id_type minor_id) {
                        return row[to_diff(minor_id)];
@@ -183,9 +183,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type _count(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // count major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count major
             return static_cast<size_type>(std::ranges::count(this->_matrix[to_idx(id)], true));
         }
         else { // count minor
@@ -197,11 +197,11 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _count_map(const size_type n_elements) const noexcept {
         std::vector<size_type> size_map(n_elements, 0uz);
 
-        if constexpr (Element == layout_tag::major_element) { // count map major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count map major
             const size_type limit = std::min(n_elements, this->_matrix.n_rows());
             for (auto i = 0uz; i < limit; ++i)
                 size_map[i] = static_cast<size_type>(std::ranges::count(this->_matrix[i], true));
@@ -248,102 +248,102 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_incident);
+        return this->_query<vertex_t>(vertex_id, bf_is_incident);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_incident);
+        return this->_count<vertex_t>(vertex_id, bf_is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_incident);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_tail);
+        return this->_query<vertex_t>(vertex_id, bf_is_tail);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_tail);
+        return this->_count<vertex_t>(vertex_id, bf_is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_tail);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_head);
+        return this->_query<vertex_t>(vertex_id, bf_is_head);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_head);
+        return this->_count<vertex_t>(vertex_id, bf_is_head);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_head);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_head);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_incident);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_incident);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_incident);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_incident);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_tail);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_tail);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_tail);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_tail);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_head);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_head);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_head);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_head);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_head);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_head);
     }
 
     // --- binding methods ---
@@ -409,9 +409,9 @@ private:
 
     using hypergraph_storage_type = flat_matrix<bf_incidence>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // add major
             this->_matrix.resize(
                 this->_matrix.n_rows() + n, this->_matrix.n_cols(), bf_incidence::none
             );
@@ -421,19 +421,19 @@ private:
             );
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // remove major
             this->_matrix.erase_row(to_idx(id));
         else // remove minor
             this->_matrix.erase_col(to_idx(id));
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _query(
         const id_type id, std::predicate<bf_incidence> auto&& pred
     ) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // query major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // query major
             return std::views::iota(initial_id_v<id_type>, this->_matrix.n_cols())
                  | std::views::filter(
                        [row = this->_matrix[to_idx(id)],
@@ -452,10 +452,10 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type
     _count(const id_type id, std::predicate<bf_incidence> auto&& pred) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // count major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count major
             size_type count = 0uz;
             for (const bf_incidence t : this->_matrix[to_idx(id)])
                 count += static_cast<size_type>(pred(t));
@@ -470,13 +470,13 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _count_map(
         const size_type n_elements, std::predicate<bf_incidence> auto&& pred
     ) const noexcept {
         std::vector<size_type> size_map(n_elements, 0uz);
 
-        if constexpr (Element == layout_tag::major_element) { // count map major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count map major
             const size_type limit = std::min(n_elements, this->_matrix.n_rows());
             for (auto i = 0uz; i < limit; ++i)
                 for (const bf_incidence val : this->_matrix[i])

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -63,51 +63,51 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<element_type::vertex>(vertex_id);
+        return this->_incident_with<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id);
+        return this->_size<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> degree_map(const size_type n_vertices
     ) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices);
+        return this->_size_map<vertex_t>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline size_type hyperedge_size(const id_type hyperedge_id
     ) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id);
+        return this->_size<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline std::vector<size_type> hyperedge_size_map(
         const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<hyperedge_t>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -160,15 +160,15 @@ private:
     using major_element_type = minor_storage_type;
     using major_storage_type = std::vector<major_element_type>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) // add major
             this->_major_storage.resize(this->_major_storage.size() + n);
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // remove major
             this->_major_storage.erase(this->_major_storage.begin() + to_diff(id));
         }
         else { // remove minor
@@ -182,9 +182,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // incident with major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // incident with major
             return std::views::all(this->_major_storage[to_idx(id)]);
         }
         else { // incident with minor
@@ -195,9 +195,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] size_type _size(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             return this->_major_storage[to_idx(id)].size();
         }
         else { // size minor
@@ -209,9 +209,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             auto size_map = this->_major_storage | std::views::transform(&major_element_type::size)
                           | std::ranges::to<std::vector<size_type>>();
             size_map.resize(n_elements, 0uz);
@@ -262,106 +262,102 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id);
+        return this->_get<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id);
+        return this->_size<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices);
+        return this->_size_map<vertex_t>(n_vertices);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
+        return this->_get<vertex_t>(vertex_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id, &incidence_list::_tail_storage);
+        return this->_size<vertex_t>(vertex_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices, &incidence_list::_tail_storage);
+        return this->_size_map<vertex_t>(n_vertices, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_get<element_type::vertex>(vertex_id, &incidence_list::_head_storage);
+        return this->_get<vertex_t>(vertex_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_size<element_type::vertex>(vertex_id, &incidence_list::_head_storage);
+        return this->_size<vertex_t>(vertex_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_size_map<element_type::vertex>(n_vertices, &incidence_list::_head_storage);
+        return this->_size_map<vertex_t>(n_vertices, &incidence_list::_head_storage);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_get<element_type::hyperedge>(hyperedge_id);
+        return this->_get<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id);
+        return this->_size<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(n_hyperedges);
+        return this->_size_map<hyperedge_t>(n_hyperedges);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
-        return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_tail_storage);
+        return this->_get<hyperedge_t>(hyperedge_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id, &incidence_list::_tail_storage);
+        return this->_size<hyperedge_t>(hyperedge_id, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(
-            n_hyperedges, &incidence_list::_tail_storage
-        );
+        return this->_size_map<hyperedge_t>(n_hyperedges, &incidence_list::_tail_storage);
     }
 
     [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
-        return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_head_storage);
+        return this->_get<hyperedge_t>(hyperedge_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_size<element_type::hyperedge>(hyperedge_id, &incidence_list::_head_storage);
+        return this->_size<hyperedge_t>(hyperedge_id, &incidence_list::_head_storage);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_size_map<element_type::hyperedge>(
-            n_hyperedges, &incidence_list::_head_storage
-        );
+        return this->_size_map<hyperedge_t>(n_hyperedges, &incidence_list::_head_storage);
     }
 
     // --- binding methods ---
@@ -434,17 +430,17 @@ private:
     using minor_storage_type = std::vector<minor_element_type>;
     using major_storage_type = std::vector<minor_storage_type>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // add major
             this->_tail_storage.resize(this->_tail_storage.size() + n);
             this->_head_storage.resize(this->_head_storage.size() + n);
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // remove major
             this->_tail_storage.erase(this->_tail_storage.begin() + to_diff(id));
             this->_head_storage.erase(this->_head_storage.begin() + to_diff(id));
         }
@@ -469,9 +465,9 @@ private:
         return minor_it;
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // get major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // get major
             const auto idx = to_idx(id);
             return util::concat(this->_tail_storage[idx], this->_head_storage[idx]);
         }
@@ -484,10 +480,10 @@ private:
         }
     }
 
-    template <element_type Element, typename Projection = std::identity>
+    template <traits::c_hypergraph_element_tag Element, typename Projection = std::identity>
     [[nodiscard]] gl_attr_force_inline auto _get(const id_type id, const Projection storage_proj)
         const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // get major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // get major
             return std::views::all((this->*storage_proj)[to_idx(id)]);
         }
         else { // get minor
@@ -500,9 +496,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type _size(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             const auto idx = to_idx(id);
             return this->_tail_storage[idx].size() + this->_head_storage[idx].size();
         }
@@ -518,10 +514,10 @@ private:
         }
     }
 
-    template <element_type Element, typename Projection = std::identity>
+    template <traits::c_hypergraph_element_tag Element, typename Projection = std::identity>
     [[nodiscard]] gl_attr_force_inline size_type
     _size(const id_type id, const Projection storage_proj) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             return (this->*storage_proj)[to_idx(id)].size();
         }
         else { // size minor
@@ -533,9 +529,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _size_map(const size_type n_elements) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
             const auto n_segments = this->_tail_storage.size();
             for (auto i = 0uz; i < n_segments; ++i)
@@ -554,11 +550,11 @@ private:
         }
     }
 
-    template <element_type Element, typename Projection = std::identity>
+    template <traits::c_hypergraph_element_tag Element, typename Projection = std::identity>
     [[nodiscard]] std::vector<size_type> _size_map(
         const size_type n_elements, const Projection storage_proj
     ) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // size major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // size major
             std::vector<size_type> size_map(n_elements, 0uz);
             const auto& storage = this->*storage_proj;
             const auto n_segments = storage.size();

--- a/include/hgl/impl/incidence_list.hpp
+++ b/include/hgl/impl/incidence_list.hpp
@@ -334,8 +334,7 @@ public:
         return this->_size_map<element_type::hyperedge>(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
         return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_tail_storage);
     }
 
@@ -350,8 +349,7 @@ public:
         );
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
         return this->_get<element_type::hyperedge>(hyperedge_id, &incidence_list::_head_storage);
     }
 
@@ -710,10 +708,10 @@ public:
         return this->_e_list.hyperedge_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
-        return this->_e_list.tail_vertices(hyperedge_id);
+        return this->_e_list.tail(hyperedge_id);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept
@@ -728,10 +726,10 @@ public:
         return this->_e_list.tail_size_map(n_hyperedges);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id) const noexcept
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept
     requires std::same_as<DirectionalTag, hgl::bf_directed_t>
     {
-        return this->_e_list.head_vertices(hyperedge_id);
+        return this->_e_list.head(hyperedge_id);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -337,8 +337,7 @@ public:
         return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_incident);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto tail_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
         return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_tail);
     }
 
@@ -351,8 +350,7 @@ public:
         return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_tail);
     }
 
-    [[nodiscard]] gl_attr_force_inline auto head_vertices(const id_type hyperedge_id
-    ) const noexcept {
+    [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
         return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_head);
     }
 

--- a/include/hgl/impl/incidence_matrix.hpp
+++ b/include/hgl/impl/incidence_matrix.hpp
@@ -68,48 +68,48 @@ public:
     // --- vertex methods ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_incident_with<element_type::vertex>(vertex_id);
+        return this->_incident_with<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id);
+        return this->_count<vertex_t>(vertex_id);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices);
+        return this->_count_map<vertex_t>(n_vertices);
     }
 
     // --- hyperedge methods ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_incident_with<element_type::hyperedge>(hyperedge_id);
+        return this->_incident_with<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id);
+        return this->_count<hyperedge_t>(hyperedge_id);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges);
+        return this->_count_map<hyperedge_t>(n_hyperedges);
     }
 
     // --- binding methods ---
@@ -151,9 +151,9 @@ private:
     using matrix_row_type = std::vector<bool>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // add major
             this->_matrix.resize(
                 this->_matrix.size() + n, matrix_row_type(this->_matrix_row_size, false)
             );
@@ -165,9 +165,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // remove major
             this->_matrix.erase(this->_matrix.begin() + to_diff(id));
         }
         else { // remove minor
@@ -181,9 +181,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     gl_attr_force_inline auto _incident_with(const id_type id) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // incident with major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // incident with major
             return std::views::iota(initial_id_v<id_type>, this->_matrix_row_size)
                  | std::views::filter([&row = this->_matrix[to_idx(id)]](id_type minor_id) {
                        return row[to_idx(minor_id)];
@@ -197,10 +197,10 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type _count(const id_type id) const noexcept {
         size_type count = 0uz;
-        if constexpr (Element == layout_tag::major_element) { // count major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count major
             for (const bool bit : this->_matrix[to_idx(id)])
                 count += static_cast<size_type>(bit);
         }
@@ -212,11 +212,11 @@ private:
         return count;
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _count_map(const size_type n_elements) const noexcept {
         std::vector<size_type> size_map(n_elements, 0uz);
 
-        if constexpr (Element == layout_tag::major_element) { // count map major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count map major
             const size_type limit = std::min(n_elements, this->_matrix.size());
             for (auto i = 0uz; i < limit; ++i) {
                 size_map[i] = static_cast<size_type>(std::ranges::count(this->_matrix[i], true));
@@ -265,102 +265,102 @@ public:
     // --- vertex methods : general ---
 
     gl_attr_force_inline void add_vertices(const size_type n) noexcept {
-        this->_add<element_type::vertex>(n);
+        this->_add<vertex_t>(n);
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) noexcept {
-        this->_remove<element_type::vertex>(vertex_id);
+        this->_remove<vertex_t>(vertex_id);
     }
 
     // --- vertex methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_hyperedges(const id_type vertex_id
     ) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_incident);
+        return this->_query<vertex_t>(vertex_id, bf_is_incident);
     }
 
     [[nodiscard]] size_type degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_incident);
+        return this->_count<vertex_t>(vertex_id, bf_is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_incident);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto out_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_tail);
+        return this->_query<vertex_t>(vertex_id, bf_is_tail);
     }
 
     [[nodiscard]] size_type out_degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_tail);
+        return this->_count<vertex_t>(vertex_id, bf_is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> out_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_tail);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto in_hyperedges(const id_type vertex_id) const noexcept {
-        return this->_query<element_type::vertex>(vertex_id, bf_is_head);
+        return this->_query<vertex_t>(vertex_id, bf_is_head);
     }
 
     [[nodiscard]] size_type in_degree(const id_type vertex_id) const noexcept {
-        return this->_count<element_type::vertex>(vertex_id, bf_is_head);
+        return this->_count<vertex_t>(vertex_id, bf_is_head);
     }
 
     [[nodiscard]] std::vector<size_type> in_degree_map(const size_type n_vertices) const noexcept {
-        return this->_count_map<element_type::vertex>(n_vertices, bf_is_head);
+        return this->_count_map<vertex_t>(n_vertices, bf_is_head);
     }
 
     // --- hyperedge methods : general ---
 
     gl_attr_force_inline void add_hyperedges(const size_type n) noexcept {
-        this->_add<element_type::hyperedge>(n);
+        this->_add<hyperedge_t>(n);
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) noexcept {
-        this->_remove<element_type::hyperedge>(hyperedge_id);
+        this->_remove<hyperedge_t>(hyperedge_id);
     }
 
     // --- hyperedge methods : incidence queries ---
 
     [[nodiscard]] gl_attr_force_inline auto incident_vertices(const id_type hyperedge_id
     ) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_incident);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_incident);
     }
 
     [[nodiscard]] size_type hyperedge_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_incident);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_incident);
     }
 
     [[nodiscard]] std::vector<size_type> hyperedge_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_incident);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_incident);
     }
 
     [[nodiscard]] gl_attr_force_inline auto tail(const id_type hyperedge_id) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_tail);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_tail);
     }
 
     [[nodiscard]] size_type tail_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_tail);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_tail);
     }
 
     [[nodiscard]] std::vector<size_type> tail_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_tail);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_tail);
     }
 
     [[nodiscard]] gl_attr_force_inline auto head(const id_type hyperedge_id) const noexcept {
-        return this->_query<element_type::hyperedge>(hyperedge_id, bf_is_head);
+        return this->_query<hyperedge_t>(hyperedge_id, bf_is_head);
     }
 
     [[nodiscard]] size_type head_size(const id_type hyperedge_id) const noexcept {
-        return this->_count<element_type::hyperedge>(hyperedge_id, bf_is_head);
+        return this->_count<hyperedge_t>(hyperedge_id, bf_is_head);
     }
 
     [[nodiscard]] std::vector<size_type> head_size_map(const size_type n_hyperedges
     ) const noexcept {
-        return this->_count_map<element_type::hyperedge>(n_hyperedges, bf_is_head);
+        return this->_count_map<hyperedge_t>(n_hyperedges, bf_is_head);
     }
 
     // --- binding methods ---
@@ -427,9 +427,9 @@ private:
     using matrix_row_type = std::vector<bf_incidence>;
     using hypergraph_storage_type = std::vector<matrix_row_type>;
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _add(const size_type n) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // add major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // add major
             this->_matrix.resize(
                 this->_matrix.size() + n,
                 matrix_row_type(this->_matrix_row_size, bf_incidence::none)
@@ -442,9 +442,9 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     void _remove(const id_type id) noexcept {
-        if constexpr (Element == layout_tag::major_element) { // remove major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // remove major
             this->_matrix.erase(this->_matrix.begin() + to_diff(id));
         }
         else { // remove minor
@@ -458,11 +458,11 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline auto _query(
         const id_type id, std::predicate<bf_incidence> auto&& pred
     ) const noexcept {
-        if constexpr (Element == layout_tag::major_element) { // query major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // query major
             return std::views::iota(initial_id_v<id_type>, this->_matrix_row_size)
                  | std::views::filter([&row = this->_matrix[to_idx(id)], pred](id_type minor_id) {
                        return pred(row[to_idx(minor_id)]);
@@ -476,11 +476,11 @@ private:
         }
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] gl_attr_force_inline size_type
     _count(const id_type id, std::predicate<bf_incidence> auto&& pred) const noexcept {
         size_type count = 0uz;
-        if constexpr (Element == layout_tag::major_element) { // count major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count major
             for (const bf_incidence t : this->_matrix[to_idx(id)])
                 count += static_cast<size_type>(pred(t));
         }
@@ -492,13 +492,13 @@ private:
         return count;
     }
 
-    template <element_type Element>
+    template <traits::c_hypergraph_element_tag Element>
     [[nodiscard]] std::vector<size_type> _count_map(
         const size_type n_elements, std::predicate<bf_incidence> auto&& pred
     ) const noexcept {
         std::vector<size_type> size_map(n_elements, 0uz);
 
-        if constexpr (Element == layout_tag::major_element) { // count map major
+        if constexpr (std::same_as<Element, major_element_t<layout_tag>>) { // count map major
             const size_type limit = std::min(n_elements, this->_matrix.size());
             for (auto i = 0uz; i < limit; ++i)
                 for (const auto val : this->_matrix[i])

--- a/include/hgl/impl/layout_tags.hpp
+++ b/include/hgl/impl/layout_tags.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "hgl/hypergraph_elements.hpp"
 #include "hgl/traits.hpp"
 #include "hgl/types.hpp"
 
@@ -13,11 +14,9 @@ namespace hgl {
 
 namespace impl {
 
-enum class element_type : bool { vertex, hyperedge };
-
 struct vertex_major_t {
-    static constexpr element_type major_element = element_type::vertex;
-    static constexpr element_type minor_element = element_type::hyperedge;
+    using major_element = vertex_t;
+    using minor_element = hyperedge_t;
 
     template <std::regular T>
     [[nodiscard]] static constexpr T major(
@@ -42,8 +41,8 @@ struct vertex_major_t {
 };
 
 struct hyperedge_major_t {
-    static constexpr element_type major_element = element_type::hyperedge;
-    static constexpr element_type minor_element = element_type::vertex;
+    using major_element = hyperedge_t;
+    using minor_element = vertex_t;
 
     template <std::regular T>
     [[nodiscard]] static constexpr T major(
@@ -82,5 +81,11 @@ concept c_hypergraph_asymmetric_layout_tag =
     c_one_of<T, impl::vertex_major_t, impl::hyperedge_major_t>;
 
 } // namespace traits
+
+template <traits::c_hypergraph_asymmetric_layout_tag LT>
+using major_element_t = typename LT::major_element;
+
+template <traits::c_hypergraph_asymmetric_layout_tag LT>
+using minor_element_t = typename LT::minor_element;
 
 } // namespace hgl

--- a/tests/external/doctest.h
+++ b/tests/external/doctest.h
@@ -3453,20 +3453,20 @@ using ticks_t = timer_large_integer::type;
 
         T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
 
-        T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_add(arg, order);
+        T fetch_add(T arg, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_add(arg, n_vertices);
         }
 
-        T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_sub(arg, order);
+        T fetch_sub(T arg, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_sub(arg, n_vertices);
         }
 
         operator T() const DOCTEST_NOEXCEPT { return load(); }
 
-        T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+        T load(std::memory_order n_vertices = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
             auto result = T();
             for(auto const& c : m_atomics) {
-                result += c.atomic.load(order);
+                result += c.atomic.load(n_vertices);
             }
             return result;
         }
@@ -3476,10 +3476,10 @@ using ticks_t = timer_large_integer::type;
             return desired;
         }
 
-        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        void store(T desired, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
             // first value becomes desired", all others become 0.
             for(auto& c : m_atomics) {
-                c.atomic.store(desired, order);
+                c.atomic.store(desired, n_vertices);
                 desired = {};
             }
         }
@@ -6130,7 +6130,7 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "reporters to use (console is default)\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
               << Whitespace(sizePrefixDisplay*1) << "output filename\n";
-            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "n_vertices-by=<string>             "
               << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
             s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
@@ -6659,7 +6659,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 
     // clang-format off
     DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
-    DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
+    DOCTEST_PARSE_STR_OPTION("n_vertices-by", "ob", order_by, "file");
     DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
 
     DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);

--- a/tests/external/doctest.h
+++ b/tests/external/doctest.h
@@ -3453,20 +3453,20 @@ using ticks_t = timer_large_integer::type;
 
         T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
 
-        T fetch_add(T arg, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_add(arg, n_vertices);
+        T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_add(arg, order);
         }
 
-        T fetch_sub(T arg, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_sub(arg, n_vertices);
+        T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_sub(arg, order);
         }
 
         operator T() const DOCTEST_NOEXCEPT { return load(); }
 
-        T load(std::memory_order n_vertices = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+        T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
             auto result = T();
             for(auto const& c : m_atomics) {
-                result += c.atomic.load(n_vertices);
+                result += c.atomic.load(order);
             }
             return result;
         }
@@ -3476,10 +3476,10 @@ using ticks_t = timer_large_integer::type;
             return desired;
         }
 
-        void store(T desired, std::memory_order n_vertices = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
             // first value becomes desired", all others become 0.
             for(auto& c : m_atomics) {
-                c.atomic.store(desired, n_vertices);
+                c.atomic.store(desired, order);
                 desired = {};
             }
         }
@@ -6130,7 +6130,7 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "reporters to use (console is default)\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
               << Whitespace(sizePrefixDisplay*1) << "output filename\n";
-            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "n_vertices-by=<string>             "
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
               << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
             s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
@@ -6659,7 +6659,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 
     // clang-format off
     DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
-    DOCTEST_PARSE_STR_OPTION("n_vertices-by", "ob", order_by, "file");
+    DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
     DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
 
     DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);

--- a/tests/include/testing/hgl/io.hpp
+++ b/tests/include/testing/hgl/io.hpp
@@ -25,12 +25,12 @@ void verify_hypergraph_structure(const HypergraphType& actual, const HypergraphT
         else if constexpr (std::same_as<
                                typename HypergraphType::directional_tag,
                                hgl::bf_directed_t>) {
-            auto actual_tail = actual.tail_vertex_ids(id) | std::ranges::to<std::vector>();
-            auto expected_tail = expected.tail_vertex_ids(id) | std::ranges::to<std::vector>();
+            auto actual_tail = actual.tail_ids(id) | std::ranges::to<std::vector>();
+            auto expected_tail = expected.tail_ids(id) | std::ranges::to<std::vector>();
             CHECK(std::ranges::is_permutation(actual_tail, expected_tail));
 
-            auto actual_head = actual.head_vertex_ids(id) | std::ranges::to<std::vector>();
-            auto expected_head = expected.head_vertex_ids(id) | std::ranges::to<std::vector>();
+            auto actual_head = actual.head_ids(id) | std::ranges::to<std::vector>();
+            auto expected_head = expected.head_ids(id) | std::ranges::to<std::vector>();
             CHECK(std::ranges::is_permutation(actual_head, expected_head));
         }
     }

--- a/tests/include/testing/hgl/io.hpp
+++ b/tests/include/testing/hgl/io.hpp
@@ -10,8 +10,8 @@ namespace hgl_testing {
 
 template <hgl::traits::c_hypergraph HypergraphType>
 void verify_hypergraph_structure(const HypergraphType& actual, const HypergraphType& expected) {
-    REQUIRE_EQ(actual.order(), expected.order());
-    REQUIRE_EQ(actual.size(), expected.size());
+    REQUIRE_EQ(actual.n_vertices(), expected.n_vertices());
+    REQUIRE_EQ(actual.n_hyperedges(), expected.n_hyperedges());
 
     for (const auto& he_actual : actual.hyperedges()) {
         const auto id = he_actual.id();

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -257,7 +257,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(expected_previsit_order);
 
     /*
-    post visit order should be reverse of pre visit order
+    post visit n_vertices should be reverse of pre visit n_vertices
     because the algorithm will search the graph recursively and call
     post visit after return from the recursive call
     */
@@ -344,7 +344,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(expected_previsit_order);
 
     /*
-    post visit order should be reverse of pre visit order
+    post visit n_vertices should be reverse of pre visit n_vertices
     because the algorithm will search the graph recursively and call
     post visit after return from the recursive call
     */

--- a/tests/source/gl/test_alg_dfs.cpp
+++ b/tests/source/gl/test_alg_dfs.cpp
@@ -257,7 +257,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(expected_previsit_order);
 
     /*
-    post visit n_vertices should be reverse of pre visit n_vertices
+    post visit order should be reverse of pre visit order
     because the algorithm will search the graph recursively and call
     post visit after return from the recursive call
     */
@@ -344,7 +344,7 @@ TEST_CASE_TEMPLATE_DEFINE(
     CAPTURE(expected_previsit_order);
 
     /*
-    post visit n_vertices should be reverse of pre visit n_vertices
+    post visit order should be reverse of pre visit order
     because the algorithm will search the graph recursively and call
     post visit after return from the recursive call
     */

--- a/tests/source/gl/test_conversion.cpp
+++ b/tests/source/gl/test_conversion.cpp
@@ -44,7 +44,7 @@ struct test_conversion {
                           typename std::decay_t<decltype(graph)>::edge_properties_type,
                           property_type>)
             for (const auto& eid : graph.edge_ids())
-                graph.get_edge_properties(eid) = property_type("edge_" + std::to_string(eid));
+                graph.edge_properties(eid) = property_type("edge_" + std::to_string(eid));
     }
 
     void validate_graph(const gl::traits::c_graph auto& graph) {
@@ -67,7 +67,7 @@ struct test_conversion {
                           typename std::decay_t<decltype(graph)>::edge_properties_type,
                           property_type>)
             for (const auto& eid : graph.edge_ids())
-                CHECK_EQ(graph.get_edge_properties(eid), "edge_" + std::to_string(eid));
+                CHECK_EQ(graph.edge_properties(eid), "edge_" + std::to_string(eid));
     }
 
     gl::size_type test_order{5};

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -140,7 +140,7 @@ TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directi
     }
 
     SUBCASE("incident_vertices_r should return the pair of vertex IDS the edge was initialized "
-            "with but with switched order") {
+            "with but with switched n_vertices") {
         const auto& vertices = sut.incident_vertices_r();
         CHECK_EQ(vertices.first, fixture.v2);
         CHECK_EQ(vertices.second, fixture.v1);

--- a/tests/source/gl/test_edge_descriptor.cpp
+++ b/tests/source/gl/test_edge_descriptor.cpp
@@ -140,7 +140,7 @@ TEST_CASE_TEMPLATE_DEFINE("directional_tag-independent tests", EdgeType, directi
     }
 
     SUBCASE("incident_vertices_r should return the pair of vertex IDS the edge was initialized "
-            "with but with switched n_vertices") {
+            "with but with switched order") {
         const auto& vertices = sut.incident_vertices_r();
         CHECK_EQ(vertices.first, fixture.v2);
         CHECK_EQ(vertices.second, fixture.v1);

--- a/tests/source/gl/test_graph.cpp
+++ b/tests/source/gl/test_graph.cpp
@@ -1105,7 +1105,7 @@ TEST_CASE_TEMPLATE_DEFINE("common graph structure tests", TraitsType, common_gra
         }
 
         SUBCASE("hypergraph with different hyperedge properties are not equal") {
-            sut2.get_edge_properties(0uz) = "dummy";
+            sut2.edge_properties(0uz) = "dummy";
             CHECK_NE(sut1, sut2);
         }
     }
@@ -1316,12 +1316,11 @@ TEST_CASE_TEMPLATE_DEFINE("property getter tests", TraitsType, property_graph_tr
         CHECK_EQ(property, std::format("edge_{}", id));
         CHECK_EQ(emap[id], std::format("edge_{}", id));
         CHECK_EQ(
-            sut.get_edge_properties(static_cast<gl::default_id_type>(id)),
-            std::format("edge_{}", id)
+            sut.edge_properties(static_cast<gl::default_id_type>(id)), std::format("edge_{}", id)
         );
     }
 
-    CHECK_THROWS_AS(discard(sut.get_edge_properties(constants::out_of_rng_idx)), std::out_of_range);
+    CHECK_THROWS_AS(discard(sut.edge_properties(constants::out_of_rng_idx)), std::out_of_range);
 }
 
 TEST_CASE_TEMPLATE_INSTANTIATE(

--- a/tests/source/hgl/test_alg_backward_search.cpp
+++ b/tests/source/hgl/test_alg_backward_search.cpp
@@ -39,8 +39,8 @@ TEST_CASE_TEMPLATE_DEFINE(
        v1 ------->------ v4
     */
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
+    const auto n_vertices = 5uz;
+    hypergraph.add_vertices(n_vertices);
     const auto e0 = hypergraph.add_hyperedge({0u, 1u}, {2u}).id();
     const auto e1 = hypergraph.add_hyperedge({2u}, {3u, 4u}).id();
     const auto e2 = hypergraph.add_hyperedge({1u}, {4u}).id();
@@ -48,9 +48,9 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("single root v0 (immediate halt)") {
         root_vertices = {0u};
         expected_visit_order = {0u};
-        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map.resize(n_vertices, hgl::invalid_id);
         expected_pred_map[0uz] = 0u;
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges.resize(n_vertices, hgl::invalid_id);
         unreachable_vertices = {1u, 2u, 3u, 4u};
     }
 
@@ -74,8 +74,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::backward_bfs<hgl::algorithm::noret>(
         hypergraph,
@@ -178,8 +178,8 @@ TEST_CASE_TEMPLATE_DEFINE(
        v1 ------->------ v4
     */
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
+    const auto n_vertices = 5uz;
+    hypergraph.add_vertices(n_vertices);
     const auto e0 = hypergraph.add_hyperedge({0u, 1u}, {2u}).id();
     const auto e1 = hypergraph.add_hyperedge({2u}, {3u, 4u}).id();
     const auto e2 = hypergraph.add_hyperedge({1u}, {4u}).id();
@@ -187,9 +187,9 @@ TEST_CASE_TEMPLATE_DEFINE(
     SUBCASE("single root v0 (immediate halt)") {
         root_vertices = {0u};
         expected_visit_order = {0u};
-        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map.resize(n_vertices, hgl::invalid_id);
         expected_pred_map[0uz] = 0u;
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges.resize(n_vertices, hgl::invalid_id);
         unreachable_vertices = {1u, 2u, 3u, 4u};
     }
 
@@ -223,8 +223,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::backward_dfs<hgl::algorithm::noret>(
         hypergraph,

--- a/tests/source/hgl/test_alg_bfs.cpp
+++ b/tests/source/hgl/test_alg_bfs.cpp
@@ -112,8 +112,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::breadth_first_search<hgl::algorithm::noret>(
         hypergraph,
@@ -288,8 +288,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::breadth_first_search<hgl::algorithm::noret>(
         hypergraph,

--- a/tests/source/hgl/test_alg_dfs.cpp
+++ b/tests/source/hgl/test_alg_dfs.cpp
@@ -112,8 +112,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::depth_first_search<hgl::algorithm::noret>(
         hypergraph,
@@ -291,8 +291,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::depth_first_search<hgl::algorithm::noret>(
         hypergraph,

--- a/tests/source/hgl/test_alg_forward_search.cpp
+++ b/tests/source/hgl/test_alg_forward_search.cpp
@@ -39,8 +39,8 @@ TEST_CASE_TEMPLATE_DEFINE(
        v1 ------->------ v4
     */
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
+    const auto n_vertices = 5uz;
+    hypergraph.add_vertices(n_vertices);
     const auto e0 = hypergraph.add_hyperedge({0u, 1u}, {2u}).id();
     const auto e1 = hypergraph.add_hyperedge({2u}, {3u, 4u}).id();
     const auto e2 = hypergraph.add_hyperedge({1u}, {4u}).id();
@@ -52,11 +52,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         expected_visit_order = {4u, 1u};
 
-        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map.resize(n_vertices, hgl::invalid_id);
         expected_pred_map[4uz] = 4u; // Root
         expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
 
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges.resize(n_vertices, hgl::invalid_id);
         expected_in_hyperedges[1uz] = e2;
 
         unreachable_vertices = {0u, 2u, 3u};
@@ -107,8 +107,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::forward_bfs<hgl::algorithm::noret>(
         hypergraph,
@@ -211,8 +211,8 @@ TEST_CASE_TEMPLATE_DEFINE(
        v1 ------->------ v4
     */
 
-    const auto order = 5uz;
-    hypergraph.add_vertices(order);
+    const auto n_vertices = 5uz;
+    hypergraph.add_vertices(n_vertices);
     const auto e0 = hypergraph.add_hyperedge({0u, 1u}, {2u}).id();
     const auto e1 = hypergraph.add_hyperedge({2u}, {3u, 4u}).id();
     const auto e2 = hypergraph.add_hyperedge({1u}, {4u}).id();
@@ -222,11 +222,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         expected_visit_order = {4u, 1u};
 
-        expected_pred_map.resize(order, hgl::invalid_id);
+        expected_pred_map.resize(n_vertices, hgl::invalid_id);
         expected_pred_map[4uz] = 4u; // Root
         expected_pred_map[1uz] = 4u; // v1 reached backward from v4 via e2
 
-        expected_in_hyperedges.resize(order, hgl::invalid_id);
+        expected_in_hyperedges.resize(n_vertices, hgl::invalid_id);
         expected_in_hyperedges[1uz] = e2;
 
         unreachable_vertices = {0u, 2u, 3u};
@@ -275,8 +275,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     std::vector<id_type> previsit_order;
     std::vector<id_type> postvisit_order;
-    std::vector<id_type> noret_pred_map(hypergraph.order(), hgl::invalid_id);
-    std::vector<id_type> noret_in_hyperedges(hypergraph.order(), hgl::invalid_id);
+    std::vector<id_type> noret_pred_map(hypergraph.n_vertices(), hgl::invalid_id);
+    std::vector<id_type> noret_in_hyperedges(hypergraph.n_vertices(), hgl::invalid_id);
 
     hgl::algorithm::forward_dfs<hgl::algorithm::noret>(
         hypergraph,

--- a/tests/source/hgl/test_alg_forward_search.cpp
+++ b/tests/source/hgl/test_alg_forward_search.cpp
@@ -244,7 +244,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         // Pop v0 -> no incoming edges.
         expected_visit_order = {4u, 1u, 3u, 2u, 0u};
 
-        // Notice v2's pred is v3 now! (v3 was popped after v4, unlocking e1)
         expected_pred_map = {
             2u, // v0 reached backward from v2 via e0
             4u, // v1 reached backward from v4 via e2

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -49,13 +49,13 @@ struct test_hypergraph_conversion {
                           typename std::decay_t<decltype(h)>::vertex_properties_type,
                           property_type>)
             for (const auto& vid : h.vertex_ids())
-                h.get_vertex_properties(vid) = property_type("vertex_" + std::to_string(vid));
+                h.vertex_properties(vid) = property_type("vertex_" + std::to_string(vid));
 
         if constexpr (std::same_as<
                           typename std::decay_t<decltype(h)>::hyperedge_properties_type,
                           property_type>)
             for (const auto& eid : h.hyperedge_ids())
-                h.get_hyperedge_properties(eid) = property_type("hyperedge_" + std::to_string(eid));
+                h.hyperedge_properties(eid) = property_type("hyperedge_" + std::to_string(eid));
     }
 
     void validate_hypergraph(const hgl::traits::c_undirected_hypergraph auto& h) {
@@ -103,13 +103,13 @@ struct test_hypergraph_conversion {
                           typename std::decay_t<decltype(h)>::vertex_properties_type,
                           property_type>)
             for (const auto& vid : h.vertex_ids())
-                CHECK_EQ(h.get_vertex_properties(vid), "vertex_" + std::to_string(vid));
+                CHECK_EQ(h.vertex_properties(vid), "vertex_" + std::to_string(vid));
 
         if constexpr (std::same_as<
                           typename std::decay_t<decltype(h)>::hyperedge_properties_type,
                           property_type>)
             for (const auto& eid : h.hyperedge_ids())
-                CHECK_EQ(h.get_hyperedge_properties(eid), "hyperedge_" + std::to_string(eid));
+                CHECK_EQ(h.hyperedge_properties(eid), "hyperedge_" + std::to_string(eid));
     }
 };
 

--- a/tests/source/hgl/test_conversion.cpp
+++ b/tests/source/hgl/test_conversion.cpp
@@ -59,8 +59,8 @@ struct test_hypergraph_conversion {
     }
 
     void validate_hypergraph(const hgl::traits::c_undirected_hypergraph auto& h) {
-        REQUIRE_EQ(h.order(), 4uz);
-        REQUIRE_EQ(h.size(), 3uz);
+        REQUIRE_EQ(h.n_vertices(), 4uz);
+        REQUIRE_EQ(h.n_hyperedges(), 3uz);
         CHECK(h.are_incident(0u, 0u));
         CHECK(h.are_incident(1u, 0u));
         CHECK(h.are_incident(2u, 0u));
@@ -78,8 +78,8 @@ struct test_hypergraph_conversion {
     }
 
     void validate_hypergraph(const hgl::traits::c_bf_directed_hypergraph auto& h) {
-        REQUIRE_EQ(h.order(), 4uz);
-        REQUIRE_EQ(h.size(), 2uz);
+        REQUIRE_EQ(h.n_vertices(), 4uz);
+        REQUIRE_EQ(h.n_hyperedges(), 2uz);
 
         CHECK(h.is_tail(0u, 0u));
         CHECK(h.is_tail(1u, 0u));
@@ -318,7 +318,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto clique = hgl::projection<TargetGraph>(sut);
-                    CHECK_EQ(clique.n_vertices(), sut.order());
+                    CHECK_EQ(clique.n_vertices(), sut.n_vertices());
                     CHECK_EQ(clique.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(clique.has_edge(u, v));
@@ -359,7 +359,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto incidence = hgl::incidence_graph<TargetGraph>(sut);
-                    CHECK_EQ(incidence.n_vertices(), sut.order() + sut.size());
+                    CHECK_EQ(incidence.n_vertices(), sut.n_vertices() + sut.n_hyperedges());
                     CHECK_EQ(incidence.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(incidence.has_edge(u, v));
@@ -446,7 +446,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto proj = hgl::projection<TargetGraph>(sut);
-                    CHECK_EQ(proj.n_vertices(), sut.order());
+                    CHECK_EQ(proj.n_vertices(), sut.n_vertices());
                     CHECK_EQ(proj.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(proj.has_edge(u, v));
@@ -489,7 +489,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             [&]<typename TargetGraph>(std::type_identity<TargetGraph>, const char* target_name) {
                 SUBCASE(target_name) {
                     const auto incidence = hgl::incidence_graph<TargetGraph>(sut);
-                    CHECK_EQ(incidence.n_vertices(), sut.order() + sut.size());
+                    CHECK_EQ(incidence.n_vertices(), sut.n_vertices() + sut.n_hyperedges());
                     CHECK_EQ(incidence.n_edges(), expected_edges.size());
                     for (const auto& [u, v] : expected_edges)
                         CHECK(incidence.has_edge(u, v));

--- a/tests/source/hgl/test_flat_incidence_list.cpp
+++ b/tests/source/hgl/test_flat_incidence_list.cpp
@@ -852,8 +852,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_flat_incidence_list,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -864,8 +864,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -900,7 +900,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(head_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(tail_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -919,7 +919,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(tail_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(head_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1334,8 +1334,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_flat_incidence_list,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1348,8 +1348,8 @@ TEST_CASE_FIXTURE(
     CHECK(
         std::ranges::is_permutation(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view)
     );
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -1384,7 +1384,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(head_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(tail_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto hyperedges = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto hyperedges = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(hyperedges), 1uz);
     CHECK(std::ranges::contains(hyperedges, constants::id1));
@@ -1403,7 +1403,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(tail_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(head_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto hyperedges = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto hyperedges = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(hyperedges), 1uz);
     CHECK(std::ranges::contains(hyperedges, constants::id1));

--- a/tests/source/hgl/test_flat_incidence_matrix.cpp
+++ b/tests/source/hgl/test_flat_incidence_matrix.cpp
@@ -944,8 +944,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_flat_incidence_matrix,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -956,8 +956,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -990,7 +990,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1007,7 +1007,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1399,8 +1399,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_flat_incidence_matrix,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1411,8 +1411,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -1445,7 +1445,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1462,7 +1462,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -78,7 +78,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
 
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::out_of_rng_vid)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
@@ -92,14 +92,14 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::out_of_rng_vid)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
         );
 
         REQUIRE(rng::equal(sut.hyperedges() | vw::transform(get_id), constants::hyperedge_ids_view)
         );
         REQUIRE(rng::equal(sut.hyperedge_ids(), constants::hyperedge_ids_view));
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge(constants::out_of_rng_eid)), std::out_of_range
+            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
         );
     }
 
@@ -168,17 +168,17 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_FALSE(sut.has_vertex(constants::out_of_rng_vid));
     }
 
-    SUBCASE("get_vertex should throw if the given id is invalid") {
+    SUBCASE("vertex should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::out_of_rng_vid)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
-    SUBCASE("get_vertex should return a vertex with the given id") {
+    SUBCASE("vertex should return a vertex with the given id") {
         sut_type sut;
         const auto added_vertex = sut.add_vertex();
-        CHECK_EQ(sut.get_vertex(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
     }
 
     SUBCASE("remove_vertex(vertex) should do nothing if the given vertex is invalid") {
@@ -196,7 +196,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
     }
 
@@ -215,7 +215,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
+            static_cast<void>(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
     }
 
@@ -237,8 +237,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         constexpr auto n_vertices = constants::n_vertices + 1uz;
 
         sut_type sut{n_vertices};
-        const auto v1 = sut.get_vertex(constants::id1);
-        const auto v3 = sut.get_vertex(constants::id3);
+        const auto v1 = sut.vertex(constants::id1);
+        const auto v3 = sut.vertex(constants::id3);
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
@@ -268,8 +268,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
 
-            auto vertices =
-                v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
+            auto vertices = v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge(vertices);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
@@ -285,10 +284,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
 
-            auto h_vertices =
-                h_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
-            auto t_vertices =
-                t_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
+            auto h_vertices = h_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
+            auto t_vertices = t_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge(t_vertices, h_vertices);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
@@ -306,8 +303,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
 
-            auto he2 =
-                sut.add_hyperedge({sut.get_vertex(0u), sut.get_vertex(1u), sut.get_vertex(2u)});
+            auto he2 = sut.add_hyperedge({sut.vertex(0u), sut.vertex(1u), sut.vertex(2u)});
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
         }
@@ -324,7 +320,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
 
             auto he2 = sut.add_hyperedge(
-                {sut.get_vertex(0u), sut.get_vertex(1u)}, {sut.get_vertex(2u), sut.get_vertex(3u)}
+                {sut.vertex(0u), sut.vertex(1u)}, {sut.vertex(2u), sut.vertex(3u)}
             );
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
@@ -358,8 +354,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
-            auto vertices =
-                v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
+            auto vertices = v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge_with(vertices, constants::p_false);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
@@ -380,10 +375,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
-            auto t_vertices =
-                t_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
-            auto h_vertices =
-                h_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
+            auto t_vertices = t_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
+            auto h_vertices = h_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge_with(t_vertices, h_vertices, constants::p_false);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
@@ -407,7 +400,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto he2 = sut.add_hyperedge_with(
-                {sut.get_vertex(0u), sut.get_vertex(1u), sut.get_vertex(3u)}, constants::p_false
+                {sut.vertex(0u), sut.vertex(1u), sut.vertex(3u)}, constants::p_false
             );
             CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
@@ -429,8 +422,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto he2 = sut.add_hyperedge_with(
-                {sut.get_vertex(0u), sut.get_vertex(1u)},
-                {sut.get_vertex(2u), sut.get_vertex(3u)},
+                {sut.vertex(0u), sut.vertex(1u)},
+                {sut.vertex(2u), sut.vertex(3u)},
                 constants::p_false
             );
             CHECK_EQ(sut.n_hyperedges(), 2uz);
@@ -481,17 +474,17 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_FALSE(sut.has_hyperedge(constants::out_of_rng_eid));
     }
 
-    SUBCASE("get_hyperedge should throw if the given id is invalid") {
+    SUBCASE("hyperedge should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge(constants::out_of_rng_eid)), std::out_of_range
+            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
         );
     }
 
-    SUBCASE("get_hyperedge should return a hyperedge with the given id") {
+    SUBCASE("hyperedge should return a hyperedge with the given id") {
         sut_type sut;
         const auto added_hyperedge = sut.add_hyperedge();
-        CHECK_EQ(sut.get_hyperedge(added_hyperedge.id()), added_hyperedge);
+        CHECK_EQ(sut.hyperedge(added_hyperedge.id()), added_hyperedge);
     }
 
     SUBCASE("remove_hyperedge(hyperedge) should do nothing if the given hyperedge is invalid") {
@@ -509,7 +502,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
+            static_cast<void>(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
     }
 
@@ -528,7 +521,7 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
+            static_cast<void>(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
     }
 
@@ -550,8 +543,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         constexpr auto n_hyperedges = constants::n_hyperedges + 1uz;
 
         sut_type sut{0uz, n_hyperedges};
-        const auto he1 = sut.get_hyperedge(constants::id1);
-        const auto he3 = sut.get_hyperedge(constants::id3);
+        const auto he1 = sut.hyperedge(constants::id1);
+        const auto he3 = sut.hyperedge(constants::id3);
         sut.remove_hyperedges_from(std::vector<hyperedge_type>{he1, he3, he1});
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
@@ -708,8 +701,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.incident_vertex_ids(0u), he1_v_ids));
 
             auto he2_vertices =
-                he1_v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
-            sut.bind(he2_vertices, sut.get_hyperedge(1u));
+                he1_v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
+            sut.bind(he2_vertices, sut.hyperedge(1u));
             CHECK(rng::equal(sut.incident_vertex_ids(1u), he1_v_ids));
 
             std::vector<hgl::default_id_type> v3_he_ids{2u, 3u};
@@ -717,8 +710,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.incident_hyperedge_ids(2u), v3_he_ids));
 
             auto v4_hyperedges =
-                v3_he_ids | vw::transform([&](const auto id) { return sut.get_hyperedge(id); });
-            sut.bind(sut.get_vertex(3u), v4_hyperedges);
+                v3_he_ids | vw::transform([&](const auto id) { return sut.hyperedge(id); });
+            sut.bind(sut.vertex(3u), v4_hyperedges);
             CHECK(rng::equal(sut.incident_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -732,14 +725,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut.bind(he1_v_ids, 0u);
             CHECK(rng::equal(sut.incident_vertex_ids(0u), he1_v_ids));
 
-            sut.bind({sut.get_vertex(0u), sut.get_vertex(1u)}, sut.get_hyperedge(1u));
+            sut.bind({sut.vertex(0u), sut.vertex(1u)}, sut.hyperedge(1u));
             CHECK(rng::equal(sut.incident_vertex_ids(1u), he1_v_ids));
 
             std::initializer_list<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind(2u, v3_he_ids);
             CHECK(rng::equal(sut.incident_hyperedge_ids(2u), v3_he_ids));
 
-            sut.bind(sut.get_vertex(3u), {sut.get_hyperedge(2u), sut.get_hyperedge(3u)});
+            sut.bind(sut.vertex(3u), {sut.hyperedge(2u), sut.hyperedge(3u)});
             CHECK(rng::equal(sut.incident_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -753,8 +746,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.tail_vertex_ids(0u), he1_v_ids));
 
             auto he2_vertices =
-                he1_v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
-            sut.bind_tail(he2_vertices, sut.get_hyperedge(1u));
+                he1_v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
+            sut.bind_tail(he2_vertices, sut.hyperedge(1u));
             CHECK(rng::equal(sut.tail_vertex_ids(1u), he1_v_ids));
 
             std::vector<hgl::default_id_type> v3_he_ids{2u, 3u};
@@ -762,8 +755,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.out_hyperedge_ids(2u), v3_he_ids));
 
             auto v4_hyperedges =
-                v3_he_ids | vw::transform([&](const auto id) { return sut.get_hyperedge(id); });
-            sut.bind_tail(sut.get_vertex(3u), v4_hyperedges);
+                v3_he_ids | vw::transform([&](const auto id) { return sut.hyperedge(id); });
+            sut.bind_tail(sut.vertex(3u), v4_hyperedges);
             CHECK(rng::equal(sut.out_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -777,14 +770,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut.bind_tail(he1_v_ids, 0u);
             CHECK(rng::equal(sut.tail_vertex_ids(0u), he1_v_ids));
 
-            sut.bind_tail({sut.get_vertex(0u), sut.get_vertex(1u)}, sut.get_hyperedge(1u));
+            sut.bind_tail({sut.vertex(0u), sut.vertex(1u)}, sut.hyperedge(1u));
             CHECK(rng::equal(sut.tail_vertex_ids(1u), he1_v_ids));
 
             std::initializer_list<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_tail(2u, v3_he_ids);
             CHECK(rng::equal(sut.out_hyperedge_ids(2u), v3_he_ids));
 
-            sut.bind_tail(sut.get_vertex(3u), {sut.get_hyperedge(2u), sut.get_hyperedge(3u)});
+            sut.bind_tail(sut.vertex(3u), {sut.hyperedge(2u), sut.hyperedge(3u)});
             CHECK(rng::equal(sut.out_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -798,8 +791,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.head_vertex_ids(0u), he1_v_ids));
 
             auto he2_vertices =
-                he1_v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
-            sut.bind_head(he2_vertices, sut.get_hyperedge(1u));
+                he1_v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
+            sut.bind_head(he2_vertices, sut.hyperedge(1u));
             CHECK(rng::equal(sut.head_vertex_ids(1u), he1_v_ids));
 
             std::vector<hgl::default_id_type> v3_he_ids{2u, 3u};
@@ -807,8 +800,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(rng::equal(sut.in_hyperedge_ids(2u), v3_he_ids));
 
             auto v4_hyperedges =
-                v3_he_ids | vw::transform([&](const auto id) { return sut.get_hyperedge(id); });
-            sut.bind_head(sut.get_vertex(3u), v4_hyperedges);
+                v3_he_ids | vw::transform([&](const auto id) { return sut.hyperedge(id); });
+            sut.bind_head(sut.vertex(3u), v4_hyperedges);
             CHECK(rng::equal(sut.in_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -822,14 +815,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             sut.bind_head(he1_v_ids, 0u);
             CHECK(rng::equal(sut.head_vertex_ids(0u), he1_v_ids));
 
-            sut.bind_head({sut.get_vertex(0u), sut.get_vertex(1u)}, sut.get_hyperedge(1u));
+            sut.bind_head({sut.vertex(0u), sut.vertex(1u)}, sut.hyperedge(1u));
             CHECK(rng::equal(sut.head_vertex_ids(1u), he1_v_ids));
 
             std::initializer_list<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_head(2u, v3_he_ids);
             CHECK(rng::equal(sut.in_hyperedge_ids(2u), v3_he_ids));
 
-            sut.bind_head(sut.get_vertex(3u), {sut.get_hyperedge(2u), sut.get_hyperedge(3u)});
+            sut.bind_head(sut.vertex(3u), {sut.hyperedge(2u), sut.hyperedge(3u)});
             CHECK(rng::equal(sut.in_hyperedge_ids(3u), v3_he_ids));
         }
     }
@@ -1211,12 +1204,12 @@ TEST_CASE_TEMPLATE_DEFINE(
         }
 
         SUBCASE("hypergraphs with different vertex properties are not equal") {
-            sut2.get_vertex_properties(0uz) = "dummy";
+            sut2.vertex_properties(0uz) = "dummy";
             CHECK_NE(sut1, sut2);
         }
 
         SUBCASE("hypergraphs with different hyperedge properties are not equal") {
-            sut2.get_hyperedge_properties(0uz) = "dummy";
+            sut2.hyperedge_properties(0uz) = "dummy";
             CHECK_NE(sut1, sut2);
         }
     }
@@ -1313,11 +1306,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto [id, property] : vw::zip(sut.vertex_ids(), vmap)) {
             CHECK_EQ(property, std::format("vertex_{}", id));
             CHECK_EQ(vmap[id], std::format("vertex_{}", id));
-            CHECK_EQ(sut.get_vertex_properties(id), std::format("vertex_{}", id));
+            CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex_properties(constants::out_of_rng_vid)),
-            std::out_of_range
+            static_cast<void>(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
@@ -1327,10 +1319,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto [id, property] : vw::zip(sut.hyperedge_ids(), emap)) {
             CHECK_EQ(property, std::format("hyperedge_{}", id));
             CHECK_EQ(emap[id], std::format("hyperedge_{}", id));
-            CHECK_EQ(sut.get_hyperedge_properties(id), std::format("hyperedge_{}", id));
+            CHECK_EQ(sut.hyperedge_properties(id), std::format("hyperedge_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge_properties(constants::out_of_rng_eid)),
+            static_cast<void>(sut.hyperedge_properties(constants::out_of_rng_eid)),
             std::out_of_range
         );
     }
@@ -1347,7 +1339,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             std::vector<hyperedge_properties_type*> expected_properties{};
             for (const auto hyperedge_id : sut.hyperedge_ids()) {
                 sut.bind(vertex_id, hyperedge_id);
-                expected_properties.push_back(&sut.get_hyperedge_properties(hyperedge_id));
+                expected_properties.push_back(&sut.hyperedge_properties(hyperedge_id));
 
                 CHECK(std::ranges::equal(
                     sut.incident_hyperedges(vertex_id),
@@ -1365,8 +1357,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(std::ranges::equal(
                 sut.incident_hyperedges(vertex_id),
                 std::vector<hyperedge_properties_type*>{
-                    &sut.get_hyperedge_properties(constants::id2),
-                    &sut.get_hyperedge_properties(constants::id4)
+                    &sut.hyperedge_properties(constants::id2),
+                    &sut.hyperedge_properties(constants::id4)
                 },
                 std::equal_to{},
                 get_property_addr
@@ -1382,7 +1374,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             std::vector<vertex_properties_type*> expected_properties{};
             for (const auto vertex_id : sut.vertex_ids()) {
                 sut.bind(vertex_id, hyperedge_id);
-                expected_properties.push_back(&sut.get_vertex_properties(vertex_id));
+                expected_properties.push_back(&sut.vertex_properties(vertex_id));
 
                 CHECK(std::ranges::equal(
                     sut.incident_vertices(hyperedge_id),
@@ -1400,8 +1392,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(std::ranges::equal(
                 sut.incident_vertices(hyperedge_id),
                 std::vector<vertex_properties_type*>{
-                    &sut.get_vertex_properties(constants::id1),
-                    &sut.get_vertex_properties(constants::id3)
+                    &sut.vertex_properties(constants::id1), &sut.vertex_properties(constants::id3)
                 },
                 std::equal_to{},
                 get_property_addr
@@ -1485,11 +1476,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto [id, property] : vw::zip(sut.vertex_ids(), vmap)) {
             CHECK_EQ(property, std::format("vertex_{}", id));
             CHECK_EQ(vmap[id], std::format("vertex_{}", id));
-            CHECK_EQ(sut.get_vertex_properties(id), std::format("vertex_{}", id));
+            CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_vertex_properties(constants::out_of_rng_vid)),
-            std::out_of_range
+            static_cast<void>(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
@@ -1499,10 +1489,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto [id, property] : vw::zip(sut.hyperedge_ids(), emap)) {
             CHECK_EQ(property, std::format("hyperedge_{}", id));
             CHECK_EQ(emap[id], std::format("hyperedge_{}", id));
-            CHECK_EQ(sut.get_hyperedge_properties(id), std::format("hyperedge_{}", id));
+            CHECK_EQ(sut.hyperedge_properties(id), std::format("hyperedge_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.get_hyperedge_properties(constants::out_of_rng_eid)),
+            static_cast<void>(sut.hyperedge_properties(constants::out_of_rng_eid)),
             std::out_of_range
         );
     }
@@ -1521,13 +1511,13 @@ TEST_CASE_TEMPLATE_DEFINE(
             for (const auto eid : sut.hyperedge_ids()) {
                 if (eid % 2 == 0) {
                     sut.bind_head(vertex_id, eid);
-                    expected_in_properties.push_back(&sut.get_hyperedge_properties(eid));
+                    expected_in_properties.push_back(&sut.hyperedge_properties(eid));
                 }
                 else {
                     sut.bind_tail(vertex_id, eid);
-                    expected_out_properties.push_back(&sut.get_hyperedge_properties(eid));
+                    expected_out_properties.push_back(&sut.hyperedge_properties(eid));
                 }
-                expected_properties.push_back(&sut.get_hyperedge_properties(eid));
+                expected_properties.push_back(&sut.hyperedge_properties(eid));
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_hyperedges(vertex_id),
@@ -1559,8 +1549,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(std::ranges::is_permutation(
                 sut.incident_hyperedges(vertex_id),
                 std::vector<hyperedge_properties_type*>{
-                    &sut.get_hyperedge_properties(constants::id2),
-                    &sut.get_hyperedge_properties(constants::id4)
+                    &sut.hyperedge_properties(constants::id2),
+                    &sut.hyperedge_properties(constants::id4)
                 },
                 std::equal_to{},
                 get_property_addr
@@ -1568,16 +1558,14 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             CHECK(std::ranges::equal(
                 sut.in_hyperedges(vertex_id),
-                std::vector<hyperedge_properties_type*>{&sut.get_hyperedge_properties(constants::id2
-                )},
+                std::vector<hyperedge_properties_type*>{&sut.hyperedge_properties(constants::id2)},
                 std::equal_to{},
                 get_property_addr
             ));
 
             CHECK(std::ranges::equal(
                 sut.out_hyperedges(vertex_id),
-                std::vector<hyperedge_properties_type*>{&sut.get_hyperedge_properties(constants::id4
-                )},
+                std::vector<hyperedge_properties_type*>{&sut.hyperedge_properties(constants::id4)},
                 std::equal_to{},
                 get_property_addr
             ));
@@ -1594,13 +1582,13 @@ TEST_CASE_TEMPLATE_DEFINE(
             for (const auto vid : sut.vertex_ids()) {
                 if (vid % 2 == 0) {
                     sut.bind_head(vid, hyperedge_id);
-                    expected_head_properties.push_back(&sut.get_vertex_properties(vid));
+                    expected_head_properties.push_back(&sut.vertex_properties(vid));
                 }
                 else {
                     sut.bind_tail(vid, hyperedge_id);
-                    expected_tail_properties.push_back(&sut.get_vertex_properties(vid));
+                    expected_tail_properties.push_back(&sut.vertex_properties(vid));
                 }
-                expected_properties.push_back(&sut.get_vertex_properties(vid));
+                expected_properties.push_back(&sut.vertex_properties(vid));
 
                 CHECK(std::ranges::is_permutation(
                     sut.incident_vertices(hyperedge_id),
@@ -1632,8 +1620,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK(std::ranges::is_permutation(
                 sut.incident_vertices(hyperedge_id),
                 std::vector<vertex_properties_type*>{
-                    &sut.get_vertex_properties(constants::id1),
-                    &sut.get_vertex_properties(constants::id3)
+                    &sut.vertex_properties(constants::id1), &sut.vertex_properties(constants::id3)
                 },
                 std::equal_to{},
                 get_property_addr
@@ -1641,14 +1628,14 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             CHECK(std::ranges::equal(
                 sut.head_vertices(hyperedge_id),
-                std::vector<vertex_properties_type*>{&sut.get_vertex_properties(constants::id1)},
+                std::vector<vertex_properties_type*>{&sut.vertex_properties(constants::id1)},
                 std::equal_to{},
                 get_property_addr
             ));
 
             CHECK(std::ranges::equal(
                 sut.tail_vertices(hyperedge_id),
-                std::vector<vertex_properties_type*>{&sut.get_vertex_properties(constants::id3)},
+                std::vector<vertex_properties_type*>{&sut.vertex_properties(constants::id3)},
                 std::equal_to{},
                 get_property_addr
             ));

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -1,4 +1,5 @@
 #include "doctest.h"
+#include "hgl/hypergraph_elements.hpp"
 #include "testing/common/functional.hpp"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
@@ -223,26 +224,30 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_FALSE(sut.has_vertex(constants::out_of_rng_vid));
     }
 
-    SUBCASE("vertex should throw if the given id is invalid") {
+    SUBCASE("vertex/at should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices};
         CHECK_THROWS_AS(discard(sut.vertex(constants::out_of_rng_vid)), std::out_of_range);
+        CHECK_THROWS_AS(discard(sut.at(hgl::vertex, constants::out_of_rng_vid)), std::out_of_range);
     }
 
-    SUBCASE("vertex should return a vertex with the given id") {
+    SUBCASE("vertex/at should return a vertex with the given id") {
         sut_type sut;
         const auto added_vertex = sut.add_vertex();
         CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut.at(hgl::vertex, added_vertex.id()), added_vertex);
     }
 
-    SUBCASE("vertex_uncheckekd should not throw if the given id is invalid (UB)") {
+    SUBCASE("vertex_uncheckekd/operator[] should not throw if the given id is invalid (UB)") {
         sut_type sut{constants::n_vertices};
         CHECK_NOTHROW(discard(sut.vertex_unchecked(constants::out_of_rng_vid)));
+        CHECK_NOTHROW(discard(sut[hgl::vertex, constants::out_of_rng_vid]));
     }
 
-    SUBCASE("vertex_uncheckekd should return a vertex with the given id") {
+    SUBCASE("vertex_uncheckekd/operator[] should return a vertex with the given id") {
         sut_type sut;
         const auto added_vertex = sut.add_vertex();
         CHECK_EQ(sut.vertex_unchecked(added_vertex.id()), added_vertex);
+        CHECK_EQ(sut[hgl::vertex, added_vertex.id()], added_vertex);
     }
 
     // --- hyperedge modifers ---
@@ -536,26 +541,32 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_FALSE(sut.has_hyperedge(constants::out_of_rng_eid));
     }
 
-    SUBCASE("hyperedge should throw if the given id is invalid") {
+    SUBCASE("hyperedge/at should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
         CHECK_THROWS_AS(discard(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range);
+        CHECK_THROWS_AS(
+            discard(sut.at(hgl::hyperedge, constants::out_of_rng_eid)), std::out_of_range
+        );
     }
 
-    SUBCASE("hyperedge should return a hyperedge with the given id") {
+    SUBCASE("hyperedge/at should return a hyperedge with the given id") {
         sut_type sut;
         const auto added_hyperedge = sut.add_hyperedge();
         CHECK_EQ(sut.hyperedge(added_hyperedge.id()), added_hyperedge);
+        CHECK_EQ(sut.at(hgl::hyperedge, added_hyperedge.id()), added_hyperedge);
     }
 
-    SUBCASE("hyperedge_unchecked should not throw if the given id is invalid (UB)") {
+    SUBCASE("hyperedge_unchecked/operator[] should not throw if the given id is invalid (UB)") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
         CHECK_NOTHROW(discard(sut.hyperedge_unchecked(constants::out_of_rng_eid)));
+        CHECK_NOTHROW(discard(sut[hgl::hyperedge, constants::out_of_rng_eid]));
     }
 
-    SUBCASE("hyperedge_unchecked should return a hyperedge with the given id") {
+    SUBCASE("hyperedge_unchecked/operator[] should return a hyperedge with the given id") {
         sut_type sut;
         const auto added_hyperedge = sut.add_hyperedge();
         CHECK_EQ(sut.hyperedge_unchecked(added_hyperedge.id()), added_hyperedge);
+        CHECK_EQ(sut[hgl::hyperedge, added_hyperedge.id()], added_hyperedge);
     }
 
     // --- incidence method tests ---

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -63,16 +63,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("a hypergraph should be initialized with no vertices and no hyperedges by default") {
         sut_type sut{};
-        CHECK_EQ(sut.order(), 0uz);
-        CHECK_EQ(sut.size(), 0uz);
+        CHECK_EQ(sut.n_vertices(), 0uz);
+        CHECK_EQ(sut.n_hyperedges(), 0uz);
     }
 
     SUBCASE("a hypergraph constructed with n_vertices parameter should contain n_vertices vertices "
             "and no hyperedges") {
         sut_type sut{constants::n_vertices};
 
-        REQUIRE_EQ(sut.order(), constants::n_vertices);
-        REQUIRE_EQ(sut.size(), 0uz);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
+        REQUIRE_EQ(sut.n_hyperedges(), 0uz);
 
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
@@ -86,8 +86,8 @@ TEST_CASE_TEMPLATE_DEFINE(
             "n_vertices vertices and n_hyperedges hyperedges") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
-        REQUIRE_EQ(sut.order(), constants::n_vertices);
-        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
+        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
 
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
@@ -111,11 +111,11 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto v_id = 0u; v_id < constants::n_vertices; v_id++) {
             const auto vertex = sut.add_vertex();
             CHECK_EQ(vertex.id(), v_id);
-            CHECK_EQ(sut.order(), v_id + 1uz);
+            CHECK_EQ(sut.n_vertices(), v_id + 1uz);
             CHECK_EQ(sut.degree(v_id), 0uz);
         }
 
-        CHECK_EQ(sut.order(), constants::n_vertices);
+        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
     }
 
     SUBCASE("add_vertex_with should initialize a new vertex with the input properties structure") {
@@ -123,7 +123,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto vertex = sut.add_vertex_with(constants::p_true);
-        REQUIRE_EQ(sut.order(), 1uz);
+        REQUIRE_EQ(sut.n_vertices(), 1uz);
 
         CHECK_EQ(vertex.id(), constants::id1);
         CHECK_EQ(vertex.properties(), constants::p_true);
@@ -134,8 +134,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{};
         sut.add_vertices(constants::n_vertices);
 
-        CHECK_EQ(sut.order(), constants::n_vertices);
-        CHECK_EQ(sut.size(), 0uz);
+        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
+        CHECK_EQ(sut.n_hyperedges(), 0uz);
     }
 
     SUBCASE("add_vertices_with should add new vertices to the hypergraph with the given properties"
@@ -150,8 +150,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut.add_vertices_with(properties_list);
 
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
-        CHECK_EQ(sut.size(), 0uz);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
+        CHECK_EQ(sut.n_hyperedges(), 0uz);
 
         CHECK(rng::equal(sut.vertices(), properties_list, rng::equal_to{}, [](const auto vertex) {
             return vertex.properties();
@@ -183,10 +183,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_vertex(vertex) should do nothing if the given vertex is invalid") {
         sut_type sut{constants::n_vertices};
-        REQUIRE_EQ(sut.order(), constants::n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
 
         CHECK_NOTHROW(sut.remove_vertex(vertex_type{constants::out_of_rng_vid}));
-        CHECK_EQ(sut.order(), constants::n_vertices);
+        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
     }
 
     SUBCASE("remove_vertex(vertex) should remove the given vertex and align ids of remaining "
@@ -194,7 +194,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{constants::n_vertices};
         sut.remove_vertex(constants::id1);
 
-        REQUIRE_EQ(sut.order(), constants::n_vertices - 1uz);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
@@ -202,10 +202,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_vertex(id) should do nothing if the given id is invalid") {
         sut_type sut{constants::n_vertices};
-        REQUIRE_EQ(sut.order(), constants::n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices);
 
         CHECK_NOTHROW(sut.remove_vertex(constants::out_of_rng_vid));
-        CHECK_EQ(sut.order(), constants::n_vertices);
+        CHECK_EQ(sut.n_vertices(), constants::n_vertices);
     }
 
     SUBCASE("remove_vertex(id) should remove the given vertex and align ids of remaining vertices"
@@ -213,7 +213,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{constants::n_vertices};
         sut.remove_vertex(constants::id1);
 
-        REQUIRE_EQ(sut.order(), constants::n_vertices - 1uz);
+        REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_vertex(constants::n_vertices - 1uz)), std::out_of_range
         );
@@ -229,7 +229,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
     }
 
     SUBCASE("remove_vertices_from(vertices) should properly remove elements at given indices "
@@ -242,7 +242,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_vertices_from(std::vector<vertex_type>{v1, v3, v1});
 
         constexpr auto expected_n_vertices = n_vertices - 2uz;
-        REQUIRE_EQ(sut.order(), expected_n_vertices);
+        REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
     }
 
     // --- hyperedge method tests ---
@@ -253,10 +253,10 @@ TEST_CASE_TEMPLATE_DEFINE(
         for (auto e_id = 0u; e_id < constants::n_hyperedges; e_id++) {
             const auto hyperedge = sut.add_hyperedge();
             CHECK_EQ(hyperedge.id(), e_id);
-            CHECK_EQ(sut.size(), e_id + 1uz);
+            CHECK_EQ(sut.n_hyperedges(), e_id + 1uz);
         }
 
-        CHECK_EQ(sut.size(), constants::n_hyperedges);
+        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
     }
 
     SUBCASE("add_hyperedge(<vertices>) should create a hyperedge and bind the given vertices") {
@@ -265,13 +265,13 @@ TEST_CASE_TEMPLATE_DEFINE(
             const std::vector<hgl::default_id_type> v_ids{0u, 1u, 2u};
 
             auto he1 = sut.add_hyperedge(v_ids);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
 
             auto vertices =
                 v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
             auto he2 = sut.add_hyperedge(vertices);
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
         }
 
@@ -281,7 +281,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const std::vector<hgl::default_id_type> h_ids{1u, 2u};
 
             auto he1 = sut.add_hyperedge(t_ids, h_ids);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
 
@@ -290,7 +290,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             auto t_vertices =
                 t_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
             auto he2 = sut.add_hyperedge(t_vertices, h_vertices);
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
         }
@@ -303,12 +303,12 @@ TEST_CASE_TEMPLATE_DEFINE(
             const std::vector<hgl::default_id_type> v_ids{0u, 1u, 2u};
 
             auto he1 = sut.add_hyperedge(v_ids);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
 
             auto he2 =
                 sut.add_hyperedge({sut.get_vertex(0u), sut.get_vertex(1u), sut.get_vertex(2u)});
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
         }
 
@@ -319,14 +319,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             std::initializer_list<hgl::default_id_type> h_ids = {2u, 3u};
 
             auto he1 = sut.add_hyperedge(t_ids, h_ids);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
 
             auto he2 = sut.add_hyperedge(
                 {sut.get_vertex(0u), sut.get_vertex(1u)}, {sut.get_vertex(2u), sut.get_vertex(3u)}
             );
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
         }
@@ -338,7 +338,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         hgl::hypergraph<properties_traits_type> sut;
 
         const auto hyperedge = sut.add_hyperedge_with(constants::p_true);
-        REQUIRE_EQ(sut.size(), 1uz);
+        REQUIRE_EQ(sut.n_hyperedges(), 1uz);
 
         CHECK_EQ(hyperedge.id(), constants::id1);
         CHECK_EQ(hyperedge.properties(), constants::p_true);
@@ -354,14 +354,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             const std::vector<hgl::default_id_type> v_ids{0u, 1u, 3u};
 
             auto he1 = sut.add_hyperedge_with(v_ids, constants::p_true);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto vertices =
                 v_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
             auto he2 = sut.add_hyperedge_with(vertices, constants::p_false);
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
         }
@@ -375,7 +375,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             const std::vector<hgl::default_id_type> h_ids{2u, 3u};
 
             auto he1 = sut.add_hyperedge_with(t_ids, h_ids, constants::p_true);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
@@ -385,7 +385,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             auto h_vertices =
                 h_ids | vw::transform([&](const auto id) { return sut.get_vertex(id); });
             auto he2 = sut.add_hyperedge_with(t_vertices, h_vertices, constants::p_false);
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
@@ -402,14 +402,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             std::initializer_list<hgl::default_id_type> v_ids{0u, 1u, 3u};
 
             auto he1 = sut.add_hyperedge_with(v_ids, constants::p_true);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he1), v_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto he2 = sut.add_hyperedge_with(
                 {sut.get_vertex(0u), sut.get_vertex(1u), sut.get_vertex(3u)}, constants::p_false
             );
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.incident_vertex_ids(he2), v_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
         }
@@ -423,7 +423,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             std::initializer_list<hgl::default_id_type> h_ids{2u, 3u};
 
             auto he1 = sut.add_hyperedge_with(t_ids, h_ids, constants::p_true);
-            CHECK_EQ(sut.size(), 1uz);
+            CHECK_EQ(sut.n_hyperedges(), 1uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
@@ -433,7 +433,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 {sut.get_vertex(2u), sut.get_vertex(3u)},
                 constants::p_false
             );
-            CHECK_EQ(sut.size(), 2uz);
+            CHECK_EQ(sut.n_hyperedges(), 2uz);
             CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
             CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
@@ -444,8 +444,8 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{};
         sut.add_hyperedges(constants::n_hyperedges);
 
-        CHECK_EQ(sut.order(), 0uz);
-        CHECK_EQ(sut.size(), constants::n_hyperedges);
+        CHECK_EQ(sut.n_vertices(), 0uz);
+        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
     }
 
     SUBCASE("add_hyperedges_with should add new hyperedges to the hypergraph with the given "
@@ -460,8 +460,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut.add_hyperedges_with(properties_list);
 
-        REQUIRE_EQ(sut.order(), 0uz);
-        CHECK_EQ(sut.size(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.n_vertices(), 0uz);
+        CHECK_EQ(sut.n_hyperedges(), expected_n_hyperedges);
 
         CHECK(rng::equal(
             sut.hyperedges(),
@@ -496,10 +496,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_hyperedge(hyperedge) should do nothing if the given hyperedge is invalid") {
         sut_type sut{0uz, constants::n_hyperedges};
-        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
 
         CHECK_NOTHROW(sut.remove_hyperedge(hyperedge_type{constants::out_of_rng_eid}));
-        CHECK_EQ(sut.size(), constants::n_hyperedges);
+        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
     }
 
     SUBCASE("remove_hyperedge(hyperedge) should remove the given hyperedge and align ids of "
@@ -507,7 +507,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{0uz, constants::n_hyperedges};
         sut.remove_hyperedge(constants::id1);
 
-        REQUIRE_EQ(sut.size(), constants::n_hyperedges - 1uz);
+        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
@@ -515,10 +515,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("remove_hyperedge(id) should do nothing if the given id is invalid") {
         sut_type sut{0uz, constants::n_hyperedges};
-        REQUIRE_EQ(sut.size(), constants::n_hyperedges);
+        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
 
         CHECK_NOTHROW(sut.remove_hyperedge(constants::out_of_rng_eid));
-        CHECK_EQ(sut.size(), constants::n_hyperedges);
+        CHECK_EQ(sut.n_hyperedges(), constants::n_hyperedges);
     }
 
     SUBCASE("remove_hyperedge(id) should remove the given hyperedge and align ids of remaining "
@@ -526,7 +526,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut_type sut{0uz, constants::n_hyperedges};
         sut.remove_hyperedge(constants::id1);
 
-        REQUIRE_EQ(sut.size(), constants::n_hyperedges - 1uz);
+        REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
         CHECK_THROWS_AS(
             static_cast<void>(sut.get_hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
         );
@@ -542,7 +542,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
-        REQUIRE_EQ(sut.size(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.n_hyperedges(), expected_n_hyperedges);
     }
 
     SUBCASE("remove_hyperedges_from(hyperedges) should properly remove elements at given indices "
@@ -555,7 +555,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_hyperedges_from(std::vector<hyperedge_type>{he1, he3, he1});
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
-        REQUIRE_EQ(sut.size(), expected_n_hyperedges);
+        REQUIRE_EQ(sut.n_hyperedges(), expected_n_hyperedges);
     }
 
     // --- incidence method tests ---

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -59,8 +59,6 @@ TEST_CASE_TEMPLATE_DEFINE(
     using vertex_type = typename sut_type::vertex_type;
     using hyperedge_type = typename sut_type::hyperedge_type;
 
-    // --- general tests ---
-
     SUBCASE("a hypergraph should be initialized with no vertices and no hyperedges by default") {
         sut_type sut{};
         CHECK_EQ(sut.n_vertices(), 0uz);
@@ -103,7 +101,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         );
     }
 
-    // --- vertex method tests ---
+    // --- vertex modifiers ---
 
     SUBCASE("add_vertex should return a vertex_descriptor with an incremented id") {
         sut_type sut;
@@ -156,29 +154,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK(rng::equal(sut.vertices(), properties_list, rng::equal_to{}, [](const auto vertex) {
             return vertex.properties();
         }));
-    }
-
-    SUBCASE("has_vertex(id) should return true when a vertex with the given id is present in "
-            "the graph") {
-        sut_type sut{constants::n_vertices};
-
-        CHECK(rng::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
-            return sut.has_vertex(vertex_id);
-        }));
-        CHECK_FALSE(sut.has_vertex(constants::out_of_rng_vid));
-    }
-
-    SUBCASE("vertex should throw if the given id is invalid") {
-        sut_type sut{constants::n_vertices};
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
-        );
-    }
-
-    SUBCASE("vertex should return a vertex with the given id") {
-        sut_type sut;
-        const auto added_vertex = sut.add_vertex();
-        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
     }
 
     SUBCASE("remove_vertex(vertex) should do nothing if the given vertex is invalid") {
@@ -245,7 +220,32 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE_EQ(sut.n_vertices(), expected_n_vertices);
     }
 
-    // --- hyperedge method tests ---
+    // --- vertex getters ---
+
+    SUBCASE("has_vertex(id) should return true when a vertex with the given id is present in "
+            "the graph") {
+        sut_type sut{constants::n_vertices};
+
+        CHECK(rng::all_of(constants::vertex_ids_view, [&sut](const auto vertex_id) {
+            return sut.has_vertex(vertex_id);
+        }));
+        CHECK_FALSE(sut.has_vertex(constants::out_of_rng_vid));
+    }
+
+    SUBCASE("vertex should throw if the given id is invalid") {
+        sut_type sut{constants::n_vertices};
+        CHECK_THROWS_AS(
+            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
+        );
+    }
+
+    SUBCASE("vertex should return a vertex with the given id") {
+        sut_type sut;
+        const auto added_vertex = sut.add_vertex();
+        CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
+    }
+
+    // --- hyperedge modifers ---
 
     SUBCASE("add_hyperedge should return a hyperedge_descriptor with an incremented id") {
         sut_type sut;
@@ -464,29 +464,6 @@ TEST_CASE_TEMPLATE_DEFINE(
         ));
     }
 
-    SUBCASE("has_hyperedge(id) should return true when a hyperedge with the given id is present in "
-            "the graph") {
-        sut_type sut{constants::n_vertices, constants::n_hyperedges};
-
-        CHECK(rng::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
-            return sut.has_hyperedge(hyperedge_id);
-        }));
-        CHECK_FALSE(sut.has_hyperedge(constants::out_of_rng_eid));
-    }
-
-    SUBCASE("hyperedge should throw if the given id is invalid") {
-        sut_type sut{constants::n_vertices, constants::n_hyperedges};
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
-        );
-    }
-
-    SUBCASE("hyperedge should return a hyperedge with the given id") {
-        sut_type sut;
-        const auto added_hyperedge = sut.add_hyperedge();
-        CHECK_EQ(sut.hyperedge(added_hyperedge.id()), added_hyperedge);
-    }
-
     SUBCASE("remove_hyperedge(hyperedge) should do nothing if the given hyperedge is invalid") {
         sut_type sut{0uz, constants::n_hyperedges};
         REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges);
@@ -549,6 +526,31 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         constexpr auto expected_n_hyperedges = n_hyperedges - 2uz;
         REQUIRE_EQ(sut.n_hyperedges(), expected_n_hyperedges);
+    }
+
+    // --- hyperedge getters ---
+
+    SUBCASE("has_hyperedge(id) should return true when a hyperedge with the given id is present in "
+            "the graph") {
+        sut_type sut{constants::n_vertices, constants::n_hyperedges};
+
+        CHECK(rng::all_of(constants::hyperedge_ids_view, [&sut](const auto hyperedge_id) {
+            return sut.has_hyperedge(hyperedge_id);
+        }));
+        CHECK_FALSE(sut.has_hyperedge(constants::out_of_rng_eid));
+    }
+
+    SUBCASE("hyperedge should throw if the given id is invalid") {
+        sut_type sut{constants::n_vertices, constants::n_hyperedges};
+        CHECK_THROWS_AS(
+            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
+        );
+    }
+
+    SUBCASE("hyperedge should return a hyperedge with the given id") {
+        sut_type sut;
+        const auto added_hyperedge = sut.add_hyperedge();
+        CHECK_EQ(sut.hyperedge(added_hyperedge.id()), added_hyperedge);
     }
 
     // --- incidence method tests ---

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -281,15 +281,15 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             auto he1 = sut.add_hyperedge(t_ids, h_ids);
             CHECK_EQ(sut.n_hyperedges(), 1uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he1), t_ids));
+            CHECK(rng::equal(sut.head_ids(he1), h_ids));
 
             auto h_vertices = h_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto t_vertices = t_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge(t_vertices, h_vertices);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he2), t_ids));
+            CHECK(rng::equal(sut.head_ids(he2), h_ids));
         }
     }
 
@@ -316,15 +316,15 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             auto he1 = sut.add_hyperedge(t_ids, h_ids);
             CHECK_EQ(sut.n_hyperedges(), 1uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he1), t_ids));
+            CHECK(rng::equal(sut.head_ids(he1), h_ids));
 
             auto he2 = sut.add_hyperedge(
                 {sut.vertex(0u), sut.vertex(1u)}, {sut.vertex(2u), sut.vertex(3u)}
             );
             CHECK_EQ(sut.n_hyperedges(), 2uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he2), t_ids));
+            CHECK(rng::equal(sut.head_ids(he2), h_ids));
         }
     }
 
@@ -371,16 +371,16 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             auto he1 = sut.add_hyperedge_with(t_ids, h_ids, constants::p_true);
             CHECK_EQ(sut.n_hyperedges(), 1uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he1), t_ids));
+            CHECK(rng::equal(sut.head_ids(he1), h_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto t_vertices = t_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto h_vertices = h_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             auto he2 = sut.add_hyperedge_with(t_vertices, h_vertices, constants::p_false);
             CHECK_EQ(sut.n_hyperedges(), 2uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he2), t_ids));
+            CHECK(rng::equal(sut.head_ids(he2), h_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
         }
     }
@@ -417,8 +417,8 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             auto he1 = sut.add_hyperedge_with(t_ids, h_ids, constants::p_true);
             CHECK_EQ(sut.n_hyperedges(), 1uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he1), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he1), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he1), t_ids));
+            CHECK(rng::equal(sut.head_ids(he1), h_ids));
             CHECK_EQ(he1.properties(), constants::p_true);
 
             auto he2 = sut.add_hyperedge_with(
@@ -427,8 +427,8 @@ TEST_CASE_TEMPLATE_DEFINE(
                 constants::p_false
             );
             CHECK_EQ(sut.n_hyperedges(), 2uz);
-            CHECK(rng::equal(sut.tail_vertex_ids(he2), t_ids));
-            CHECK(rng::equal(sut.head_vertex_ids(he2), h_ids));
+            CHECK(rng::equal(sut.tail_ids(he2), t_ids));
+            CHECK(rng::equal(sut.head_ids(he2), h_ids));
             CHECK_EQ(he2.properties(), constants::p_false);
         }
     }
@@ -741,12 +741,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             std::vector<hgl::default_id_type> he1_v_ids{0u, 1u};
             sut.bind_tail(he1_v_ids, 0u);
-            CHECK(rng::equal(sut.tail_vertex_ids(0u), he1_v_ids));
+            CHECK(rng::equal(sut.tail_ids(0u), he1_v_ids));
 
             auto he2_vertices =
                 he1_v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             sut.bind_tail(he2_vertices, sut.hyperedge(1u));
-            CHECK(rng::equal(sut.tail_vertex_ids(1u), he1_v_ids));
+            CHECK(rng::equal(sut.tail_ids(1u), he1_v_ids));
 
             std::vector<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_tail(2u, v3_he_ids);
@@ -766,10 +766,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             std::initializer_list<hgl::default_id_type> he1_v_ids{0u, 1u};
             sut.bind_tail(he1_v_ids, 0u);
-            CHECK(rng::equal(sut.tail_vertex_ids(0u), he1_v_ids));
+            CHECK(rng::equal(sut.tail_ids(0u), he1_v_ids));
 
             sut.bind_tail({sut.vertex(0u), sut.vertex(1u)}, sut.hyperedge(1u));
-            CHECK(rng::equal(sut.tail_vertex_ids(1u), he1_v_ids));
+            CHECK(rng::equal(sut.tail_ids(1u), he1_v_ids));
 
             std::initializer_list<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_tail(2u, v3_he_ids);
@@ -786,12 +786,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             std::vector<hgl::default_id_type> he1_v_ids{0u, 1u};
             sut.bind_head(he1_v_ids, 0u);
-            CHECK(rng::equal(sut.head_vertex_ids(0u), he1_v_ids));
+            CHECK(rng::equal(sut.head_ids(0u), he1_v_ids));
 
             auto he2_vertices =
                 he1_v_ids | vw::transform([&](const auto id) { return sut.vertex(id); });
             sut.bind_head(he2_vertices, sut.hyperedge(1u));
-            CHECK(rng::equal(sut.head_vertex_ids(1u), he1_v_ids));
+            CHECK(rng::equal(sut.head_ids(1u), he1_v_ids));
 
             std::vector<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_head(2u, v3_he_ids);
@@ -811,10 +811,10 @@ TEST_CASE_TEMPLATE_DEFINE(
 
             std::initializer_list<hgl::default_id_type> he1_v_ids{0u, 1u};
             sut.bind_head(he1_v_ids, 0u);
-            CHECK(rng::equal(sut.head_vertex_ids(0u), he1_v_ids));
+            CHECK(rng::equal(sut.head_ids(0u), he1_v_ids));
 
             sut.bind_head({sut.vertex(0u), sut.vertex(1u)}, sut.hyperedge(1u));
-            CHECK(rng::equal(sut.head_vertex_ids(1u), he1_v_ids));
+            CHECK(rng::equal(sut.head_ids(1u), he1_v_ids));
 
             std::initializer_list<hgl::default_id_type> v3_he_ids{2u, 3u};
             sut.bind_head(2u, v3_he_ids);
@@ -1029,18 +1029,12 @@ TEST_CASE_TEMPLATE_DEFINE(
                     CHECK_EQ(sut.hyperedge_size(hyperedge_id), expected_vertices.size());
 
                     CHECK(std::ranges::equal(
-                        sut.head_vertices(hyperedge_id),
-                        expected_head_vertices,
-                        std::equal_to{},
-                        get_id
+                        sut.head(hyperedge_id), expected_head_vertices, std::equal_to{}, get_id
                     ));
                     CHECK_EQ(sut.head_size(hyperedge_id), expected_head_vertices.size());
 
                     CHECK(std::ranges::equal(
-                        sut.tail_vertices(hyperedge_id),
-                        expected_tail_vertices,
-                        std::equal_to{},
-                        get_id
+                        sut.tail(hyperedge_id), expected_tail_vertices, std::equal_to{}, get_id
                     ));
                     CHECK_EQ(sut.tail_size(hyperedge_id), expected_tail_vertices.size());
                 }
@@ -1074,7 +1068,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 CHECK_EQ(sut.hyperedge_size(hyperedge_id), 2uz);
 
                 CHECK(std::ranges::equal(
-                    sut.head_vertices(hyperedge_id),
+                    sut.head(hyperedge_id),
                     std::vector<hgl::default_id_type>{constants::id1},
                     std::equal_to{},
                     get_id
@@ -1082,7 +1076,7 @@ TEST_CASE_TEMPLATE_DEFINE(
                 CHECK_EQ(sut.head_size(hyperedge_id), 1uz);
 
                 CHECK(std::ranges::equal(
-                    sut.tail_vertices(hyperedge_id),
+                    sut.tail(hyperedge_id),
                     std::vector<hgl::default_id_type>{constants::id3},
                     std::equal_to{},
                     get_id
@@ -1594,14 +1588,14 @@ TEST_CASE_TEMPLATE_DEFINE(
                 ));
 
                 CHECK(std::ranges::equal(
-                    sut.head_vertices(hyperedge_id),
+                    sut.head(hyperedge_id),
                     expected_head_properties,
                     std::equal_to{},
                     get_property_addr
                 ));
 
                 CHECK(std::ranges::equal(
-                    sut.tail_vertices(hyperedge_id),
+                    sut.tail(hyperedge_id),
                     expected_tail_properties,
                     std::equal_to{},
                     get_property_addr
@@ -1623,14 +1617,14 @@ TEST_CASE_TEMPLATE_DEFINE(
             ));
 
             CHECK(std::ranges::equal(
-                sut.head_vertices(hyperedge_id),
+                sut.head(hyperedge_id),
                 std::vector<vertex_properties_type*>{&sut.vertex_properties(constants::id1)},
                 std::equal_to{},
                 get_property_addr
             ));
 
             CHECK(std::ranges::equal(
-                sut.tail_vertices(hyperedge_id),
+                sut.tail(hyperedge_id),
                 std::vector<vertex_properties_type*>{&sut.vertex_properties(constants::id3)},
                 std::equal_to{},
                 get_property_addr

--- a/tests/source/hgl/test_hypergraph.cpp
+++ b/tests/source/hgl/test_hypergraph.cpp
@@ -1,4 +1,5 @@
 #include "doctest.h"
+#include "testing/common/functional.hpp"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
 
@@ -75,9 +76,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
 
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.vertex(constants::out_of_rng_vid)), std::out_of_range);
     }
 
     SUBCASE("a hypergraph constructed with n_vertices and n_hyperedges parameters should contain "
@@ -89,16 +88,12 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         REQUIRE(rng::equal(sut.vertices() | vw::transform(get_id), constants::vertex_ids_view));
         REQUIRE(rng::equal(sut.vertex_ids(), constants::vertex_ids_view));
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.vertex(constants::out_of_rng_vid)), std::out_of_range);
 
         REQUIRE(rng::equal(sut.hyperedges() | vw::transform(get_id), constants::hyperedge_ids_view)
         );
         REQUIRE(rng::equal(sut.hyperedge_ids(), constants::hyperedge_ids_view));
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range);
     }
 
     // --- vertex modifiers ---
@@ -170,9 +165,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_vertex(constants::id1);
 
         REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range);
     }
 
     SUBCASE("remove_vertex(id) should do nothing if the given id is invalid") {
@@ -189,9 +182,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_vertex(constants::id1);
 
         REQUIRE_EQ(sut.n_vertices(), constants::n_vertices - 1uz);
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.vertex(constants::n_vertices - 1uz)), std::out_of_range);
     }
 
     SUBCASE("remove_vertices_from(ids) should properly remove elements at given indices (ignoring "
@@ -234,15 +225,24 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("vertex should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices};
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex(constants::out_of_rng_vid)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.vertex(constants::out_of_rng_vid)), std::out_of_range);
     }
 
     SUBCASE("vertex should return a vertex with the given id") {
         sut_type sut;
         const auto added_vertex = sut.add_vertex();
         CHECK_EQ(sut.vertex(added_vertex.id()), added_vertex);
+    }
+
+    SUBCASE("vertex_uncheckekd should not throw if the given id is invalid (UB)") {
+        sut_type sut{constants::n_vertices};
+        CHECK_NOTHROW(discard(sut.vertex_unchecked(constants::out_of_rng_vid)));
+    }
+
+    SUBCASE("vertex_uncheckekd should return a vertex with the given id") {
+        sut_type sut;
+        const auto added_vertex = sut.add_vertex();
+        CHECK_EQ(sut.vertex_unchecked(added_vertex.id()), added_vertex);
     }
 
     // --- hyperedge modifers ---
@@ -478,9 +478,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_hyperedge(constants::id1);
 
         REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range);
     }
 
     SUBCASE("remove_hyperedge(id) should do nothing if the given id is invalid") {
@@ -497,9 +495,7 @@ TEST_CASE_TEMPLATE_DEFINE(
         sut.remove_hyperedge(constants::id1);
 
         REQUIRE_EQ(sut.n_hyperedges(), constants::n_hyperedges - 1uz);
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.hyperedge(constants::n_hyperedges - 1uz)), std::out_of_range);
     }
 
     SUBCASE("remove_hyperedges_from(ids) should properly remove elements at given indices "
@@ -542,15 +538,24 @@ TEST_CASE_TEMPLATE_DEFINE(
 
     SUBCASE("hyperedge should throw if the given id is invalid") {
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
-        CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range
-        );
+        CHECK_THROWS_AS(discard(sut.hyperedge(constants::out_of_rng_eid)), std::out_of_range);
     }
 
     SUBCASE("hyperedge should return a hyperedge with the given id") {
         sut_type sut;
         const auto added_hyperedge = sut.add_hyperedge();
         CHECK_EQ(sut.hyperedge(added_hyperedge.id()), added_hyperedge);
+    }
+
+    SUBCASE("hyperedge_unchecked should not throw if the given id is invalid (UB)") {
+        sut_type sut{constants::n_vertices, constants::n_hyperedges};
+        CHECK_NOTHROW(discard(sut.hyperedge_unchecked(constants::out_of_rng_eid)));
+    }
+
+    SUBCASE("hyperedge_unchecked should return a hyperedge with the given id") {
+        sut_type sut;
+        const auto added_hyperedge = sut.add_hyperedge();
+        CHECK_EQ(sut.hyperedge_unchecked(added_hyperedge.id()), added_hyperedge);
     }
 
     // --- incidence method tests ---
@@ -600,46 +605,37 @@ TEST_CASE_TEMPLATE_DEFINE(
         CHECK_THROWS_AS(sut.unbind(constants::out_of_rng_vid, constants::id1), std::out_of_range);
 
         CHECK_THROWS_AS(
-            static_cast<void>(sut.are_incident(constants::out_of_rng_vid, constants::out_of_rng_eid)
-            ),
+            discard(sut.are_incident(constants::out_of_rng_vid, constants::out_of_rng_eid)),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            static_cast<void>(sut.are_incident(constants::id1, constants::out_of_rng_eid)),
-            std::out_of_range
+            discard(sut.are_incident(constants::id1, constants::out_of_rng_eid)), std::out_of_range
         );
         CHECK_THROWS_AS(
-            static_cast<void>(sut.are_incident(constants::out_of_rng_vid, constants::id1)),
-            std::out_of_range
+            discard(sut.are_incident(constants::out_of_rng_vid, constants::id1)), std::out_of_range
         );
 
         if constexpr (std::same_as<directional_tag, hgl::bf_directed_t>) {
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_tail(constants::out_of_rng_vid, constants::out_of_rng_eid)
-                ),
+                discard(sut.is_tail(constants::out_of_rng_vid, constants::out_of_rng_eid)),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_tail(constants::id1, constants::out_of_rng_eid)),
-                std::out_of_range
+                discard(sut.is_tail(constants::id1, constants::out_of_rng_eid)), std::out_of_range
             );
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_tail(constants::out_of_rng_vid, constants::id1)),
-                std::out_of_range
+                discard(sut.is_tail(constants::out_of_rng_vid, constants::id1)), std::out_of_range
             );
 
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_head(constants::out_of_rng_vid, constants::out_of_rng_eid)
-                ),
+                discard(sut.is_head(constants::out_of_rng_vid, constants::out_of_rng_eid)),
                 std::out_of_range
             );
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_head(constants::id1, constants::out_of_rng_eid)),
-                std::out_of_range
+                discard(sut.is_head(constants::id1, constants::out_of_rng_eid)), std::out_of_range
             );
             CHECK_THROWS_AS(
-                static_cast<void>(sut.is_head(constants::out_of_rng_vid, constants::id1)),
-                std::out_of_range
+                discard(sut.is_head(constants::out_of_rng_vid, constants::id1)), std::out_of_range
             );
         }
 
@@ -834,11 +830,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.incident_hyperedges(vertex_type{constants::out_of_rng_vid})),
+            discard(sut.incident_hyperedges(vertex_type{constants::out_of_rng_vid})),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            static_cast<void>(sut.degree(vertex_type{constants::out_of_rng_vid})), std::out_of_range
+            discard(sut.degree(vertex_type{constants::out_of_rng_vid})), std::out_of_range
         );
 
         GL_SUPPRESS_WARNING_END;
@@ -966,11 +962,11 @@ TEST_CASE_TEMPLATE_DEFINE(
 
         sut_type sut{constants::n_vertices, constants::n_hyperedges};
         CHECK_THROWS_AS(
-            static_cast<void>(sut.incident_vertices(hyperedge_type{constants::out_of_rng_eid})),
+            discard(sut.incident_vertices(hyperedge_type{constants::out_of_rng_eid})),
             std::out_of_range
         );
         CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge_size(hyperedge_type{constants::out_of_rng_eid})),
+            discard(sut.hyperedge_size(hyperedge_type{constants::out_of_rng_eid})),
             std::out_of_range
         );
 
@@ -1311,7 +1307,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
+            discard(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
@@ -1324,8 +1320,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.hyperedge_properties(id), std::format("hyperedge_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge_properties(constants::out_of_rng_eid)),
-            std::out_of_range
+            discard(sut.hyperedge_properties(constants::out_of_rng_eid)), std::out_of_range
         );
     }
 
@@ -1481,7 +1476,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.vertex_properties(id), std::format("vertex_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
+            discard(sut.vertex_properties(constants::out_of_rng_vid)), std::out_of_range
         );
     }
 
@@ -1494,8 +1489,7 @@ TEST_CASE_TEMPLATE_DEFINE(
             CHECK_EQ(sut.hyperedge_properties(id), std::format("hyperedge_{}", id));
         }
         CHECK_THROWS_AS(
-            static_cast<void>(sut.hyperedge_properties(constants::out_of_rng_eid)),
-            std::out_of_range
+            discard(sut.hyperedge_properties(constants::out_of_rng_eid)), std::out_of_range
         );
     }
 

--- a/tests/source/hgl/test_hypergraph_elements.cpp
+++ b/tests/source/hgl/test_hypergraph_elements.cpp
@@ -1,4 +1,5 @@
 #include "doctest.h"
+#include "testing/common/functional.hpp"
 #include "testing/hgl/constants.hpp"
 #include "testing/hgl/types.hpp"
 
@@ -49,14 +50,40 @@ TEST_CASE_FIXTURE(test_hyperedge_descriptor, "properties should be properly init
     CHECK_EQ(&sut.properties(), &property);
 }
 
-TEST_CASE("accessing properties should throw for an invalid hyperedge") {
+TEST_CASE_FIXTURE(
+    test_hyperedge_descriptor, "operator* should return a reference to the properties"
+) {
+    boolean_property property{constants::p_true};
+    const hgl::hyperedge_descriptor<boolean_property> sut{id1, property};
+    CHECK_EQ(&(*sut), &property);
+}
+
+TEST_CASE_FIXTURE(
+    test_hyperedge_descriptor, "operator-> should return a pointer to the properties"
+) {
+    boolean_property property{constants::p_true};
+    const hgl::hyperedge_descriptor<boolean_property> sut{id1, property};
+    CHECK_EQ(sut.operator->(), &property);
+    CHECK_EQ(sut->value, property.value);
+}
+
+TEST_CASE_FIXTURE(
+    test_hyperedge_descriptor, "accessing properties should throw for an invalid hyperedge"
+) {
     using sut_type = hgl::hyperedge_descriptor<boolean_property>;
     boolean_property property{constants::p_true};
 
-    CHECK_THROWS_AS(static_cast<void>(sut_type::invalid().properties()), std::logic_error);
-    CHECK_THROWS_AS(
-        static_cast<void>(sut_type{hgl::invalid_id, property}.properties()), std::logic_error
-    );
+    // .properties()
+    CHECK_THROWS_AS(discard(sut_type::invalid().properties()), std::logic_error);
+    CHECK_THROWS_AS(discard(sut_type{hgl::invalid_id, property}.properties()), std::logic_error);
+
+    // operator*
+    CHECK_THROWS_AS(discard(*sut_type::invalid()), std::logic_error);
+    CHECK_THROWS_AS(discard(*sut_type{hgl::invalid_id, property}), std::logic_error);
+
+    // operator->
+    CHECK_THROWS_AS(discard(sut_type::invalid().operator->()), std::logic_error);
+    CHECK_THROWS_AS(discard(sut_type{hgl::invalid_id, property}.operator->()), std::logic_error);
 }
 
 TEST_SUITE_END(); // test_hypergraph_elements

--- a/tests/source/hgl/test_incidence_list.cpp
+++ b/tests/source/hgl/test_incidence_list.cpp
@@ -837,8 +837,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_list,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -849,8 +849,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -885,7 +885,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(head_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(tail_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -904,7 +904,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(tail_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(head_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1317,8 +1317,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_list,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1331,8 +1331,8 @@ TEST_CASE_FIXTURE(
     CHECK(
         std::ranges::is_permutation(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view)
     );
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -1367,7 +1367,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(head_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(tail_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto hyperedges = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto hyperedges = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(hyperedges), 1uz);
     CHECK(std::ranges::contains(hyperedges, constants::id1));
@@ -1386,7 +1386,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(tail_storage(sut)[constants::id1].size(), 0uz);
     CHECK_EQ(head_storage(sut)[constants::id1].front(), constants::id1);
 
-    const auto hyperedges = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto hyperedges = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(hyperedges), 1uz);
     CHECK(std::ranges::contains(hyperedges, constants::id1));

--- a/tests/source/hgl/test_incidence_matrix.cpp
+++ b/tests/source/hgl/test_incidence_matrix.cpp
@@ -937,8 +937,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_vertex_major_incidence_matrix,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -949,8 +949,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -983,7 +983,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1000,7 +1000,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1391,8 +1391,8 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_bf_directed_hyperedge_major_incidence_matrix,
     "incident_vertices should return a view of the hyperedge's incident vertex ids, "
-    "tail_vertices should return a view of the hyperedge's tail vertex ids: T(e), "
-    "head_vertices should return a view of the hyperedge's head vertex ids: H(e)"
+    "tail should return a view of the hyperedge's tail vertex ids: T(e), "
+    "head should return a view of the hyperedge's head vertex ids: H(e)"
 ) {
     sut_type sut{constants::n_vertices, constants::n_hyperedges};
 
@@ -1403,8 +1403,8 @@ TEST_CASE_FIXTURE(
         altbind_to_hyperedge(sut, hyperedge_id, constants::n_vertices);
 
     CHECK(std::ranges::equal(sut.incident_vertices(hyperedge_id), constants::vertex_ids_view));
-    CHECK(std::ranges::equal(sut.tail_vertices(hyperedge_id), tail_bound_vertices));
-    CHECK(std::ranges::equal(sut.head_vertices(hyperedge_id), head_bound_vertices));
+    CHECK(std::ranges::equal(sut.tail(hyperedge_id), tail_bound_vertices));
+    CHECK(std::ranges::equal(sut.head(hyperedge_id), head_bound_vertices));
 }
 
 TEST_CASE_FIXTURE(
@@ -1437,7 +1437,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::backward);
 
-    const auto vertices = sut.tail_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.tail(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.tail_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));
@@ -1454,7 +1454,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_EQ(matrix(sut)[constants::id1][constants::id1], incidence_type::forward);
 
-    const auto vertices = sut.head_vertices(constants::id1) | std::ranges::to<std::vector>();
+    const auto vertices = sut.head(constants::id1) | std::ranges::to<std::vector>();
     CHECK_EQ(sut.head_size(constants::id1), 1uz);
     CHECK_EQ(std::ranges::size(vertices), 1uz);
     CHECK(std::ranges::contains(vertices, constants::id1));


### PR DESCRIPTION
- Added generic hypergraph class aliases:
  - Directional: undirected_hypergraph, bf_directed_hypergraph
  - Implementation: list_hypergraph, flat_list_hypergraph, matrix_hypergraph, flat_matrix_hypergraph
- Renamed the order and size methods of the hypergraph class to n_vertices and n_hyperedges (Least Astonishment)
- Renamed the tail/head collection getters:
  - Descriptor collections: tail_vertices, head_vertices to tail, head
  - ID collections: tail_vertex_ids, head_vertex_ids to tail_ids, head_ids
- Removed the get_ prefixes from hypergraph class getter methods
- Added new vertex_unchecked and hyperedge_unchecked methods
- Defined the vertex_t and hyperedge_t element tag types
- Implemented convenience element accessors in the hypergraph class: at(<tag>, id) and operator[](<tag>, id)
- Extended hyperedge descriptor class with operator* and operator-> property accessors