### PR TITLE
YT-CPPHGL-32: Refactor element properties storage

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Execute the smoke test
         run: |
-          ./build_bench/benchmarks/gl_benchmarks \
+          ./build_bench/benchmarks/cpp-gl-bench \
             --benchmark_repetitions=1 --benchmark_display_aggregates_only=true \
             --bip-v 100

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(gl_benchmarks LANGUAGES CXX)
+project(cpp-gl-bench LANGUAGES CXX)
 
 include(FetchContent)
 
@@ -30,13 +30,13 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cpp-argon)
 
 # Define the benchmarks target
-add_executable(gl_benchmarks
+add_executable(cpp-gl-bench
     source/main.cpp
     source/runner.cpp
     suites/is_bipartite.cpp
 )
 
-target_compile_options(gl_benchmarks PRIVATE
+target_compile_options(cpp-gl-bench PRIVATE
     -Werror
     -Wall
     -Wextra
@@ -50,8 +50,8 @@ target_compile_options(gl_benchmarks PRIVATE
     -O${BENCH_OPT_MODE}
 )
 
-target_include_directories(gl_benchmarks PRIVATE include)
-target_link_libraries(gl_benchmarks PRIVATE
+target_include_directories(cpp-gl-bench PRIVATE include)
+target_link_libraries(cpp-gl-bench PRIVATE
     benchmark::benchmark
     cpp-argon
     cpp-gl
@@ -59,12 +59,12 @@ target_link_libraries(gl_benchmarks PRIVATE
 
 if(BENCH_GL_DEFS)
     separate_arguments(BENCH_GL_DEFS_LIST NATIVE_COMMAND "${BENCH_GL_DEFS}")
-    target_compile_definitions(gl_benchmarks PRIVATE ${BENCH_GL_DEFS_LIST})
+    target_compile_definitions(cpp-gl-bench PRIVATE ${BENCH_GL_DEFS_LIST})
 endif()
 
 # Include Boost Graph Library
 if(BENCH_INCLUDE_BGL)
     find_package(Boost CONFIG REQUIRED)
-    target_link_libraries(gl_benchmarks PRIVATE Boost::headers)
-    target_compile_definitions(gl_benchmarks PRIVATE GL_BENCH_INCLUDE_BGL)
+    target_link_libraries(cpp-gl-bench PRIVATE Boost::headers)
+    target_compile_definitions(cpp-gl-bench PRIVATE GL_BENCH_INCLUDE_BGL)
 endif()

--- a/benchmarks/source/runner.cpp
+++ b/benchmarks/source/runner.cpp
@@ -10,7 +10,7 @@ namespace vw = std::views;
 
 namespace gl_bench {
 
-runner::runner() : _parser("gl_benchmarks") {
+runner::runner() : _parser("cpp-gl-bench") {
     auto& glob_args = this->_parser.add_group("Global Benchmark Options");
     this->_glob_args = &glob_args;
 

--- a/include/gl/types/properties.hpp
+++ b/include/gl/types/properties.hpp
@@ -10,12 +10,12 @@
 #include <any>
 #include <iomanip>
 #include <unordered_map>
-#include <variant>
 
 namespace gl {
 
-using empty_properties = std::monostate;
-using empty_properties_map = std::monostate;
+struct empty_properties {};
+
+struct empty_properties_map {};
 
 struct name_property {
     using value_type = std::string;

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -166,12 +166,11 @@ public:
         this->_n_vertices += n;
 
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            this->_vertex_properties.append_range(properties_rng);
-        // this->_vertex_properties.insert(
-        //     this->_vertex_properties.end(),
-        //     std::ranges::begin(properties_rng),
-        //     std::ranges::end(properties_rng)
-        // );
+            this->_vertex_properties.insert(
+                this->_vertex_properties.end(),
+                std::ranges::begin(properties_rng),
+                std::ranges::end(properties_rng)
+            );
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) {
@@ -453,12 +452,11 @@ public:
         this->_n_hyperedges += n;
 
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
-            this->_hyperedge_properties.append_range(properties_rng);
-        // this->_hyperedge_properties.insert(
-        //     this->_hyperedge_properties.end(),
-        //     std::ranges::begin(properties_rng),
-        //     std::ranges::end(properties_rng)
-        // );
+            this->_hyperedge_properties.insert(
+                this->_hyperedge_properties.end(),
+                std::ranges::begin(properties_rng),
+                std::ranges::end(properties_rng)
+            );
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) {

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <initializer_list>
-#include <memory>
 #include <set>
 #include <type_traits>
 #include <vector>
@@ -91,31 +90,24 @@ public:
     using vertex_properties_map_type = std::conditional_t<
         traits::c_empty_properties<vertex_properties_type>,
         empty_properties_map,
-        std::vector<std::unique_ptr<vertex_properties_type>>>;
+        std::vector<vertex_properties_type>>;
 
     using hyperedge_type = typename traits_type::hyperedge_type;
     using hyperedge_properties_type = typename traits_type::hyperedge_properties_type;
     using hyperedge_properties_map_type = std::conditional_t<
         traits::c_empty_properties<hyperedge_properties_type>,
         empty_properties_map,
-        std::vector<std::unique_ptr<hyperedge_properties_type>>>;
+        std::vector<hyperedge_properties_type>>;
 
     hypergraph& operator=(const hypergraph&) = delete;
 
     explicit hypergraph(const size_type n_vertices = 0uz, const size_type n_hyperedges = 0uz)
     : _n_vertices(n_vertices), _n_hyperedges(n_hyperedges), _impl(n_vertices, n_hyperedges) {
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
-            this->_vertex_properties.reserve(n_vertices);
-            for (const auto _ : this->vertex_ids())
-                this->_vertex_properties.push_back(std::make_unique<vertex_properties_type>());
-        }
+        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
+            this->_vertex_properties.resize(n_vertices);
 
-        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
-            this->_hyperedge_properties.reserve(n_hyperedges);
-            for (const auto _ : this->hyperedge_ids())
-                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
-                );
-        }
+        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
+            this->_hyperedge_properties.resize(n_hyperedges);
     }
 
     hypergraph(hypergraph&&) noexcept = default;
@@ -140,10 +132,7 @@ public:
         const auto new_vertex_id = static_cast<id_type>(this->_n_vertices++);
 
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            return vertex_type{
-                new_vertex_id,
-                *this->_vertex_properties.emplace_back(std::make_unique<vertex_properties_type>())
-            };
+            return vertex_type{new_vertex_id, this->_vertex_properties.emplace_back()};
         else
             return vertex_type{new_vertex_id};
     }
@@ -154,9 +143,7 @@ public:
         this->_impl.add_vertices(1uz);
         return vertex_type{
             static_cast<id_type>(this->_n_vertices++),
-            *this->_vertex_properties.emplace_back(
-                std::make_unique<vertex_properties_type>(std::move(properties))
-            )
+            this->_vertex_properties.emplace_back(std::move(properties))
         };
     }
 
@@ -164,12 +151,8 @@ public:
         this->_impl.add_vertices(n);
         this->_n_vertices += n;
 
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
-            const auto old_size = this->_vertex_properties.size();
-            this->_vertex_properties.reserve(this->_n_vertices);
-            for (size_type i = old_size; i < this->_n_vertices; ++i)
-                this->_vertex_properties.push_back(std::make_unique<vertex_properties_type>());
-        }
+        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
+            this->_vertex_properties.resize(this->_n_vertices);
     }
 
     void add_vertices_with(
@@ -182,13 +165,13 @@ public:
         this->_impl.add_vertices(n);
         this->_n_vertices += n;
 
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
-            for (auto& properties : properties_rng) {
-                this->_vertex_properties.emplace_back(
-                    std::make_unique<vertex_properties_type>(properties)
-                );
-            }
-        }
+        if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
+            this->_vertex_properties.append_range(properties_rng);
+        // this->_vertex_properties.insert(
+        //     this->_vertex_properties.end(),
+        //     std::ranges::begin(properties_rng),
+        //     std::ranges::end(properties_rng)
+        // );
     }
 
     gl_attr_force_inline void remove_vertex(const id_type vertex_id) {
@@ -242,7 +225,7 @@ public:
 
     [[nodiscard]] gl_attr_force_inline vertex_type vertex_unchecked(const id_type vertex_id) const {
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            return vertex_type{vertex_id, *this->_vertex_properties[vertex_id]};
+            return vertex_type{vertex_id, this->_vertex_properties[vertex_id]};
         else
             return vertex_type{vertex_id};
     }
@@ -266,13 +249,13 @@ public:
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
         this->_verify_vertex_id(vertex_id);
-        return *this->_vertex_properties[vertex_id];
+        return this->_vertex_properties[vertex_id];
     }
 
     [[nodiscard]] gl_attr_force_inline auto vertex_properties_map() const noexcept
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
-        return util::deref_view(this->_vertex_properties);
+        return std::views::all(this->_vertex_properties);
     }
 
     // --- hyperedge modifiers ---
@@ -282,12 +265,7 @@ public:
         const auto new_hyperedge_id = static_cast<id_type>(this->_n_hyperedges++);
 
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
-            return hyperedge_type{
-                new_hyperedge_id,
-                *this->_hyperedge_properties.emplace_back(
-                    std::make_unique<hyperedge_properties_type>()
-                )
-            };
+            return hyperedge_type{new_hyperedge_id, this->_hyperedge_properties.emplace_back()};
         else
             return hyperedge_type{new_hyperedge_id};
     }
@@ -298,9 +276,7 @@ public:
         this->_impl.add_hyperedges(1uz);
         return hyperedge_type{
             static_cast<id_type>(this->_n_hyperedges++),
-            *this->_hyperedge_properties.emplace_back(
-                std::make_unique<hyperedge_properties_type>(std::move(properties))
-            )
+            this->_hyperedge_properties.emplace_back(std::move(properties))
         };
     }
 
@@ -462,13 +438,8 @@ public:
         this->_impl.add_hyperedges(n);
         this->_n_hyperedges += n;
 
-        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
-            const auto old_size = this->_hyperedge_properties.size();
-            this->_hyperedge_properties.reserve(this->_n_hyperedges);
-            for (auto i = old_size; i < this->_n_hyperedges; ++i)
-                this->_hyperedge_properties.push_back(std::make_unique<hyperedge_properties_type>()
-                );
-        }
+        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
+            this->_hyperedge_properties.resize(this->_n_hyperedges);
     }
 
     void add_hyperedges_with(
@@ -481,13 +452,13 @@ public:
         this->_impl.add_hyperedges(n);
         this->_n_hyperedges += n;
 
-        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
-            for (auto& properties : properties_rng) {
-                this->_hyperedge_properties.emplace_back(
-                    std::make_unique<hyperedge_properties_type>(properties)
-                );
-            }
-        }
+        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
+            this->_hyperedge_properties.append_range(properties_rng);
+        // this->_hyperedge_properties.insert(
+        //     this->_hyperedge_properties.end(),
+        //     std::ranges::begin(properties_rng),
+        //     std::ranges::end(properties_rng)
+        // );
     }
 
     gl_attr_force_inline void remove_hyperedge(const id_type hyperedge_id) {
@@ -544,7 +515,7 @@ public:
     [[nodiscard]] gl_attr_force_inline hyperedge_type hyperedge_unchecked(const id_type hyperedge_id
     ) const {
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
-            return hyperedge_type{hyperedge_id, *this->_hyperedge_properties[hyperedge_id]};
+            return hyperedge_type{hyperedge_id, this->_hyperedge_properties[hyperedge_id]};
         else
             return hyperedge_type{hyperedge_id};
     }
@@ -568,13 +539,13 @@ public:
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
         this->_verify_hyperedge_id(id);
-        return *this->_hyperedge_properties[id];
+        return this->_hyperedge_properties[id];
     }
 
     [[nodiscard]] gl_attr_force_inline auto hyperedge_properties_map() const noexcept
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
-        return util::deref_view(this->_hyperedge_properties);
+        return std::views::all(this->_hyperedge_properties);
     }
 
     // --- incidence modifiers ---
@@ -1150,21 +1121,15 @@ public:
     // --- comparison ---
 
     [[nodiscard]] friend bool operator==(const hypergraph& lhs, const hypergraph& rhs) noexcept {
-        constexpr auto val_eq = [](const auto& ptr_a, const auto& ptr_b) {
-            return *ptr_a == *ptr_b;
-        };
-
         if (lhs._n_vertices != rhs._n_vertices or lhs._n_hyperedges != rhs._n_hyperedges)
             return false;
 
         if constexpr (traits::c_non_empty_properties<vertex_properties_type>)
-            if (not std::ranges::equal(lhs._vertex_properties, rhs._vertex_properties, val_eq))
+            if (lhs._vertex_properties != rhs._vertex_properties)
                 return false;
 
         if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>)
-            if (not std::ranges::equal(
-                    lhs._hyperedge_properties, rhs._hyperedge_properties, val_eq
-                ))
+            if (lhs._hyperedge_properties != rhs._hyperedge_properties)
                 return false;
 
         return lhs._impl == rhs._impl;
@@ -1261,25 +1226,11 @@ public:
 
 private:
     hypergraph(const hypergraph& other)
-    : _n_vertices{other._n_vertices}, _n_hyperedges{other._n_hyperedges}, _impl{other._impl} {
-        // Deep copy vertex properties
-        if constexpr (traits::c_non_empty_properties<vertex_properties_type>) {
-            this->_vertex_properties.reserve(other._vertex_properties.size());
-            for (const auto& property : other._vertex_properties)
-                this->_vertex_properties.push_back(
-                    std::make_unique<vertex_properties_type>(*property)
-                );
-        }
-
-        // Deep copy hyperedge properties
-        if constexpr (traits::c_non_empty_properties<hyperedge_properties_type>) {
-            this->_hyperedge_properties.reserve(other._hyperedge_properties.size());
-            for (const auto& property : other._hyperedge_properties)
-                this->_hyperedge_properties.push_back(
-                    std::make_unique<hyperedge_properties_type>(*property)
-                );
-        }
-    }
+    : _n_vertices{other._n_vertices},
+      _n_hyperedges{other._n_hyperedges},
+      _impl{other._impl},
+      _vertex_properties{other._vertex_properties},
+      _hyperedge_properties{other._hyperedge_properties} {}
 
     // --- vertex methods ---
 
@@ -1308,7 +1259,7 @@ private:
     requires(traits::c_non_empty_properties<vertex_properties_type>)
     {
         return [&pmap = this->_vertex_properties](const id_type id) {
-            return vertex_type{id, *pmap[to_idx(id)]};
+            return vertex_type{id, pmap[to_idx(id)]};
         };
     }
 
@@ -1339,7 +1290,7 @@ private:
     requires(traits::c_non_empty_properties<hyperedge_properties_type>)
     {
         return [&pmap = this->_hyperedge_properties](const id_type id) {
-            return hyperedge_type{id, *pmap[to_idx(id)]};
+            return hyperedge_type{id, pmap[to_idx(id)]};
         };
     }
 
@@ -1571,8 +1522,11 @@ private:
 
     implementation_type _impl{};
 
-    [[no_unique_address]] vertex_properties_map_type _vertex_properties{};
-    [[no_unique_address]] hyperedge_properties_map_type _hyperedge_properties{};
+    /// @todo Replace mutability with proper const-correct getter overloads to ensure thread safety guarantees associated with the const qualifier
+    [[no_unique_address]] mutable vertex_properties_map_type _vertex_properties{};
+
+    /// @todo Replace mutability with proper const-correct getter overloads to ensure thread safety guarantees associated with the const qualifier
+    [[no_unique_address]] mutable hyperedge_properties_map_type _hyperedge_properties{};
 };
 
 // --- general hypergraph utility ---

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -94,6 +94,7 @@ using bf_directed_hypergraph_traits =
 
 namespace traits {
 
+
 template <typename TraitsType>
 concept c_list_hypergraph_traits =
     c_instantiation_of<TraitsType, hypergraph_traits>

--- a/include/hgl/hypergraph_traits.hpp
+++ b/include/hgl/hypergraph_traits.hpp
@@ -94,7 +94,6 @@ using bf_directed_hypergraph_traits =
 
 namespace traits {
 
-
 template <typename TraitsType>
 concept c_list_hypergraph_traits =
     c_instantiation_of<TraitsType, hypergraph_traits>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,9 @@ set(INCLUDE_DIRS "include" "external")
 set(EXECUTABLE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Test target generation
-function(add_test_target TARGET_NAME SOURCE_DIRS DATA_DIR TESTING_DEF)
+function(add_test_target BASE_NAME SOURCE_DIRS DATA_DIR TESTING_DEF)
+    set(TARGET_NAME "cpp-gl-tests-${BASE_NAME}")
+
     set(TARGET_SOURCES "")
     foreach(SOURCE_DIR ${SOURCE_DIRS})
         file(GLOB_RECURSE CURRENT_SOURCES "${SOURCE_DIR}/*.cpp")
@@ -17,6 +19,7 @@ function(add_test_target TARGET_NAME SOURCE_DIRS DATA_DIR TESTING_DEF)
     add_executable(${TARGET_NAME} ${TARGET_SOURCES})
 
     set_target_properties(${TARGET_NAME} PROPERTIES
+        OUTPUT_NAME "${BASE_NAME}"
         RUNTIME_OUTPUT_DIRECTORY "${EXECUTABLE_DIR}"
         CXX_STANDARD ${CMAKE_CXX_STANDARD}
         CXX_STANDARD_REQUIRED YES


### PR DESCRIPTION
- Replaced the std::vector<std::unique_ptr<T>> containers with std::vector<T> for hypergraph element property storage
- Aligned the names of CMake testing and benchmark targets