### PR TITLE
Graph/Hypergraph output format cleanup

### DIFF
--- a/docs/gl/io.md
+++ b/docs/gl/io.md
@@ -158,8 +158,7 @@ type: directed, |V| = 5, |E| = 12
 
 ## Graph Specification Format (GSF)
 
-<!-- TODO: reword -->
-For disk storage and network transmission, CPP-GL defines the **Graph Specification Format (GSF)**. This format is triggered by the [**gl::io::spec_fmt**](../cpp-gl/group__GL-IO.md#variable-spec_fmt) manipulator and is designed to be easily parseable.
+For storage purposes, CPP-GL defines the **Graph Specification Format (GSF)**. This format is triggered by the [**gl::io::spec_fmt**](../cpp-gl/group__GL-IO.md#variable-spec_fmt) manipulator and is designed to be easily parseable.
 
 ### Format Structure
 

--- a/docs/hgl/io.md
+++ b/docs/hgl/io.md
@@ -166,7 +166,7 @@ hyperedges:
 
 ## Hypergraph Specification Format (HGSF)
 
-For disk storage and network transmission, HGL utilizes the **Hypergraph Specification Format (HGSF)**. This is a lightweight, flat text format triggered by the `hgl::io::spec_fmt` manipulator.
+For storage purposes, HGL utilizes the **Hypergraph Specification Format (HGSF)**. This is a lightweight, flat text format triggered by the `hgl::io::spec_fmt` manipulator.
 
 ### Format Structure
 

--- a/include/gl/graph.hpp
+++ b/include/gl/graph.hpp
@@ -1382,19 +1382,25 @@ private:
 
     std::ostream& _verbose_write(std::ostream& os) const {
         os << "type: " << fmt_traits::type << ", |V| = " << this->_n_vertices
-           << ", |E| = " << this->_n_edges << '\n';
+           << ", |E| = " << this->_n_edges;
+
         for (auto vertex : this->vertices()) {
-            os << "- " << vertex << "\n  " << fmt_traits::out_edges << ":\n";
+            os << "\n- " << vertex << "\n  " << fmt_traits::out_edges << ":";
             for (const auto& edge : this->out_edges(vertex.id()))
-                os << "\t- " << edge << '\n';
+                os << "\n\t- " << edge;
         }
         return os;
     }
 
     std::ostream& _concise_write(this auto&& self, std::ostream& os) {
         using enum io::detail::option_bit;
+        bool first = true;
 
         for (auto src : self.vertices()) {
+            if (not first)
+                os << '\n';
+            first = false;
+
             auto tgts = std::views::transform(
                 self.out_edges(src.id()),
                 [src_id = src.id(),
@@ -1402,7 +1408,7 @@ private:
                     return concise_target_formatter{edge, src_id, with_props};
                 }
             );
-            os << src << " : " << io::range_formatter(tgts) << '\n';
+            os << src << " : " << io::range_formatter(tgts);
         }
 
         return os;
@@ -1417,12 +1423,12 @@ private:
         // print graph metadata
         os << traits::c_directed_edge<edge_type> << ' ' << this->_n_vertices << ' '
            << this->_n_edges << ' ' << static_cast<int>(with_v_props) << ' '
-           << static_cast<int>(with_e_props) << '\n';
+           << static_cast<int>(with_e_props);
 
         if constexpr (traits::c_writable<vertex_properties_type>)
             if (with_v_props)
                 for (auto vertex : this->vertices())
-                    os << vertex.properties() << '\n';
+                    os << '\n' << vertex.properties();
 
         if constexpr (traits::c_writable<edge_properties_type>) {
             if (with_e_props) {
@@ -1431,8 +1437,9 @@ private:
                         if constexpr (std::same_as<directional_tag, undirected_t>)
                             if (edge.other(vertex_id) > vertex_id)
                                 continue; // deduplicate edges
-                        os << edge.source() << ' ' << edge.target() << ' ' << edge.properties()
-                           << '\n';
+
+                        os << '\n'
+                           << edge.source() << ' ' << edge.target() << ' ' << edge.properties();
                     }
                 };
 
@@ -1448,7 +1455,8 @@ private:
                 if constexpr (std::same_as<directional_tag, undirected_t>)
                     if (edge.other(vertex_id) > vertex_id)
                         continue; // deduplicate edges
-                os << edge.source() << ' ' << edge.target() << '\n';
+
+                os << '\n' << edge.source() << ' ' << edge.target();
             }
         };
 

--- a/include/hgl/hypergraph.hpp
+++ b/include/hgl/hypergraph.hpp
@@ -2251,30 +2251,29 @@ private:
         using fmt_traits = io::detail::hypergraph_fmt_traits<directional_tag>;
 
         os << "type: " << fmt_traits::type << ", |V| = " << this->_n_vertices
-           << ", |E| = " << this->_n_hyperedges << '\n';
+           << ", |E| = " << this->_n_hyperedges;
 
-        os << "vertices: ";
+        os << "\nvertices: ";
         if constexpr (traits::c_writable<vertex_properties_type>) {
             if (io::is_option_set(os, with_vertex_properties)) {
-                os << '\n';
                 for (const auto& vertex : this->vertices())
-                    os << "  - " << vertex << '\n';
+                    os << "\n  - " << vertex;
             }
             else {
-                os << io::implicit_range(this->_n_vertices) << '\n';
+                os << io::implicit_range(this->_n_vertices);
             }
         }
         else {
-            os << io::implicit_range(this->_n_vertices) << '\n';
+            os << io::implicit_range(this->_n_vertices);
         }
 
         if (this->_n_hyperedges == 0uz) {
-            os << "hyperedges: {}";
+            os << "\nhyperedges: {}";
         }
         else {
-            os << "hyperedges:\n";
+            os << "\nhyperedges:";
             for (const auto& edge : this->hyperedges())
-                os << "  - " << this->fmt(edge) << '\n';
+                os << "\n  - " << this->fmt(edge);
         }
 
         return os;
@@ -2286,23 +2285,23 @@ private:
         os << "V = ";
         if constexpr (traits::c_writable<vertex_properties_type>) {
             if (io::is_option_set(os, with_vertex_properties))
-                os << io::multiline_set_formatter(this->vertices()) << '\n';
+                os << io::multiline_set_formatter(this->vertices());
             else
-                os << io::implicit_range(this->_n_vertices) << '\n';
+                os << io::implicit_range(this->_n_vertices);
         }
         else {
-            os << io::implicit_range(this->_n_vertices) << '\n';
+            os << io::implicit_range(this->_n_vertices);
         }
 
         if (this->_n_hyperedges == 0uz) {
-            os << "E = {}\n";
+            os << "\nE = {}";
         }
         else {
             auto hyperedges = std::views::transform(this->hyperedges(), [this](auto hyperedge) {
                 return this->fmt(hyperedge);
             });
 
-            os << "E = " << io::multiline_set_formatter(hyperedges) << '\n';
+            os << "\nE = " << io::multiline_set_formatter(hyperedges);
         }
 
         return os;
@@ -2317,17 +2316,17 @@ private:
 
         // print hypergraph metadata
         os << fmt_traits::discriminator << ' ' << this->_n_vertices << ' ' << this->_n_hyperedges
-           << ' ' << static_cast<int>(with_v_props) << ' ' << static_cast<int>(with_he_props)
-           << '\n';
+           << ' ' << static_cast<int>(with_v_props) << ' ' << static_cast<int>(with_he_props);
 
         if constexpr (traits::c_writable<vertex_properties_type>)
             if (with_v_props)
                 for (const auto& vertex : this->vertices())
-                    os << vertex.properties() << '\n';
+                    os << '\n' << vertex.properties();
 
         for (const auto& hyperedge : this->hyperedges()) {
-            const auto he_id = hyperedge.id();
+            os << '\n';
 
+            const auto he_id = hyperedge.id();
             if constexpr (std::same_as<directional_tag, undirected_t>) {
                 os << this->hyperedge_size(he_id);
                 for (const auto v : this->incident_vertex_ids(he_id))
@@ -2345,8 +2344,6 @@ private:
                 if (with_he_props)
                     os << ' ' << hyperedge.properties();
             }
-
-            os << '\n';
         }
 
         return os;

--- a/include/hgl/hypergraph_elements.hpp
+++ b/include/hgl/hypergraph_elements.hpp
@@ -32,7 +32,7 @@ namespace hgl {
 ///
 /// ### Example Usage
 /// ```cpp
-/// std::cout << gl::io::verbose << gl::io::with_vertex_properties; // (1)!
+/// std::cout << hgl::io::verbose << hgl::io::with_vertex_properties; // (1)!
 ///
 /// for (const auto& vertex : hypergraph.vertices()) {
 ///     const auto deg = hypergraph.degree(vertex); // (2)!
@@ -79,7 +79,7 @@ using vertex_descriptor = gl::vertex_descriptor<Properties, IdType>;
 ///
 /// ### Example Usage
 /// ```cpp
-/// std::cout << gl::io::verbose << gl::io::with_hyperedge_properties; // (1)!
+/// std::cout << hgl::io::verbose << gl::io::with_hyperedge_properties; // (1)!
 ///
 /// for (const auto& hyperedge : hypergraph.hyperedges()) {
 ///     const auto size = hypergraph.hyperedge_size(hyperedge); // (2)!


### PR DESCRIPTION
Removed trailing new line characters in graph/hypergraph stream output